### PR TITLE
Don't output a <dscl_cmd> DS Error: -14136 (eDSRecordNotFound)

### DIFF
--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -57,6 +57,7 @@ impl Action for CreateGroup {
                     .args([".", "-read", &format!("/Groups/{name}")])
                     .stdin(std::process::Stdio::null())
                     .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::piped())
                     .status()
                     .await
                     .map_err(ActionError::Command)?


### PR DESCRIPTION
Turns out we had one more sneaking around!