### PR TITLE
Fix ubuntu 16.04 support

### DIFF
--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -17,6 +17,7 @@ let
   images = {
 
     # End of standard support https://wiki.ubuntu.com/Releases
+    # No systemd
     /*
       "ubuntu-v14_04" = {
       image = import <nix/fetchurl.nix> {
@@ -66,6 +67,7 @@ let
       hash = "sha256-QwzbvRoRRGqUCQptM7X/InRWFSP2sqwRt2HaaO6zBGM=";
       };
       rootDisk = "box.img";
+      postBoot = disableSELinux;
       system = "x86_64-linux";
       };
     */

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -29,7 +29,7 @@ let
     */
 
     # End of standard support https://wiki.ubuntu.com/Releases
-    /* "ubuntu-v16_04" = {
+    "ubuntu-v16_04" = {
       image = import <nix/fetchurl.nix> {
       url = "https://app.vagrantup.com/generic/boxes/ubuntu1604/versions/4.1.12/providers/libvirt.box";
       hash = "sha256-lO4oYQR2tCh5auxAYe6bPOgEqOgv3Y3GC1QM1tEEEU8=";
@@ -37,7 +37,6 @@ let
       rootDisk = "box.img";
       system = "x86_64-linux";
       };
-    */
 
     "ubuntu-v22_04" = {
       image = import <nix/fetchurl.nix> {

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -31,12 +31,12 @@ let
     # End of standard support https://wiki.ubuntu.com/Releases
     "ubuntu-v16_04" = {
       image = import <nix/fetchurl.nix> {
-      url = "https://app.vagrantup.com/generic/boxes/ubuntu1604/versions/4.1.12/providers/libvirt.box";
-      hash = "sha256-lO4oYQR2tCh5auxAYe6bPOgEqOgv3Y3GC1QM1tEEEU8=";
+        url = "https://app.vagrantup.com/generic/boxes/ubuntu1604/versions/4.1.12/providers/libvirt.box";
+        hash = "sha256-lO4oYQR2tCh5auxAYe6bPOgEqOgv3Y3GC1QM1tEEEU8=";
       };
       rootDisk = "box.img";
       system = "x86_64-linux";
-      };
+    };
 
     "ubuntu-v22_04" = {
       image = import <nix/fetchurl.nix> {

--- a/src/action/base/mod.rs
+++ b/src/action/base/mod.rs
@@ -1,13 +1,13 @@
 //! Base [`Action`](crate::action::Action)s that themselves have no other actions as dependencies
 
-mod create_directory;
-mod create_file;
-mod create_group;
-mod create_or_append_file;
-mod create_user;
-mod fetch_and_unpack_nix;
-mod move_unpacked_nix;
-mod setup_default_profile;
+pub(crate) mod create_directory;
+pub(crate) mod create_file;
+pub(crate) mod create_group;
+pub(crate) mod create_or_append_file;
+pub(crate) mod create_user;
+pub(crate) mod fetch_and_unpack_nix;
+pub(crate) mod move_unpacked_nix;
+pub(crate) mod setup_default_profile;
 
 pub use create_directory::CreateDirectory;
 pub use create_file::CreateFile;

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -1,8 +1,10 @@
 use crate::{
     action::{
         base::SetupDefaultProfile,
-        common::{ConfigureShellProfile, PlaceChannelConfiguration, PlaceNixConfiguration},
-        linux::ConfigureNixDaemonService,
+        common::{
+            ConfigureNixDaemonService, ConfigureShellProfile, PlaceChannelConfiguration,
+            PlaceNixConfiguration,
+        },
         Action, ActionDescription, ActionError, StatefulAction,
     },
     channel_value::ChannelValue,

--- a/src/action/common/configure_nix_daemon_service.rs
+++ b/src/action/common/configure_nix_daemon_service.rs
@@ -10,11 +10,11 @@ use crate::execute_command;
 
 use crate::action::{Action, ActionDescription};
 
-pub const SERVICE_SRC: &str = "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service";
-pub const SOCKET_SRC: &str = "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket";
-pub const TMPFILES_SRC: &str = "/nix/var/nix/profiles/default/lib/tmpfiles.d/nix-daemon.conf";
-pub const TMPFILES_DEST: &str = "/etc/tmpfiles.d/nix-daemon.conf";
-pub const DARWIN_NIX_DAEMON_DEST: &str = "/Library/LaunchDaemons/org.nixos.nix-daemon.plist";
+const SERVICE_SRC: &str = "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service";
+const SOCKET_SRC: &str = "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket";
+const TMPFILES_SRC: &str = "/nix/var/nix/profiles/default/lib/tmpfiles.d/nix-daemon.conf";
+const TMPFILES_DEST: &str = "/etc/tmpfiles.d/nix-daemon.conf";
+const DARWIN_NIX_DAEMON_DEST: &str = "/Library/LaunchDaemons/org.nixos.nix-daemon.plist";
 
 /**
 Run systemd utilities to configure the Nix daemon
@@ -147,6 +147,16 @@ impl Action for ConfigureNixDaemonService {
                         .process_group(0)
                         .arg("daemon-reload")
                         .stdin(std::process::Stdio::null()),
+                )
+                .await
+                .map_err(ActionError::Command)?;
+
+                execute_command(
+                    Command::new("systemctl")
+                        .process_group(0)
+                        .arg("enable")
+                        .arg("--now")
+                        .arg(SOCKET_SRC),
                 )
                 .await
                 .map_err(ActionError::Command)?;

--- a/src/action/common/configure_nix_daemon_service.rs
+++ b/src/action/common/configure_nix_daemon_service.rs
@@ -10,11 +10,11 @@ use crate::execute_command;
 
 use crate::action::{Action, ActionDescription};
 
-const SERVICE_SRC: &str = "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service";
-const SOCKET_SRC: &str = "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket";
-const TMPFILES_SRC: &str = "/nix/var/nix/profiles/default/lib/tmpfiles.d/nix-daemon.conf";
-const TMPFILES_DEST: &str = "/etc/tmpfiles.d/nix-daemon.conf";
-const DARWIN_NIX_DAEMON_DEST: &str = "/Library/LaunchDaemons/org.nixos.nix-daemon.plist";
+pub const SERVICE_SRC: &str = "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service";
+pub const SOCKET_SRC: &str = "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket";
+pub const TMPFILES_SRC: &str = "/nix/var/nix/profiles/default/lib/tmpfiles.d/nix-daemon.conf";
+pub const TMPFILES_DEST: &str = "/etc/tmpfiles.d/nix-daemon.conf";
+pub const DARWIN_NIX_DAEMON_DEST: &str = "/Library/LaunchDaemons/org.nixos.nix-daemon.plist";
 
 /**
 Run systemd utilities to configure the Nix daemon
@@ -147,16 +147,6 @@ impl Action for ConfigureNixDaemonService {
                         .process_group(0)
                         .arg("daemon-reload")
                         .stdin(std::process::Stdio::null()),
-                )
-                .await
-                .map_err(ActionError::Command)?;
-
-                execute_command(
-                    Command::new("systemctl")
-                        .process_group(0)
-                        .arg("enable")
-                        .arg("--now")
-                        .arg("nix-daemon.socket"),
                 )
                 .await
                 .map_err(ActionError::Command)?;

--- a/src/action/common/mod.rs
+++ b/src/action/common/mod.rs
@@ -1,14 +1,16 @@
 //! [`Action`](crate::action::Action)s which only call other base plugins
 
-mod configure_nix;
-mod configure_shell_profile;
-mod create_nix_tree;
-mod create_users_and_groups;
-mod place_channel_configuration;
-mod place_nix_configuration;
-mod provision_nix;
+pub(crate) mod configure_nix;
+pub(crate) mod configure_nix_daemon_service;
+pub(crate) mod configure_shell_profile;
+pub(crate) mod create_nix_tree;
+pub(crate) mod create_users_and_groups;
+pub(crate) mod place_channel_configuration;
+pub(crate) mod place_nix_configuration;
+pub(crate) mod provision_nix;
 
 pub use configure_nix::ConfigureNix;
+pub use configure_nix_daemon_service::{ConfigureNixDaemonService, ConfigureNixDaemonServiceError};
 pub use configure_shell_profile::ConfigureShellProfile;
 pub use create_nix_tree::CreateNixTree;
 pub use create_users_and_groups::CreateUsersAndGroups;

--- a/src/action/darwin/mod.rs
+++ b/src/action/darwin/mod.rs
@@ -1,14 +1,14 @@
 /*!  [`Action`](crate::action::Action)s for Darwin based systems
 */
 
-mod bootstrap_apfs_volume;
-mod create_apfs_volume;
-mod create_nix_volume;
-mod create_synthetic_objects;
-mod enable_ownership;
-mod encrypt_apfs_volume;
-mod kickstart_launchctl_service;
-mod unmount_apfs_volume;
+pub(crate) mod bootstrap_apfs_volume;
+pub(crate) mod create_apfs_volume;
+pub(crate) mod create_nix_volume;
+pub(crate) mod create_synthetic_objects;
+pub(crate) mod enable_ownership;
+pub(crate) mod encrypt_apfs_volume;
+pub(crate) mod kickstart_launchctl_service;
+pub(crate) mod unmount_apfs_volume;
 
 pub use bootstrap_apfs_volume::{BootstrapApfsVolume, BootstrapVolumeError};
 pub use create_apfs_volume::{CreateApfsVolume, CreateVolumeError};

--- a/src/action/linux/mod.rs
+++ b/src/action/linux/mod.rs
@@ -1,5 +1,3 @@
-mod configure_nix_daemon_service;
-mod start_systemd_unit;
+pub(crate) mod start_systemd_unit;
 
-pub use configure_nix_daemon_service::{ConfigureNixDaemonService, ConfigureNixDaemonServiceError};
 pub use start_systemd_unit::{StartSystemdUnit, StartSystemdUnitError};

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -32,8 +32,8 @@ action.try_revert().await.unwrap();
 ```
 
 A general guidance for what determines how fine-grained an [`Action`] should be is the unit of
-reversion. The [`ConfigureNixDaemonService`](linux::ConfigureNixDaemonService) action is a good
-example of this,it takes several steps, such as running `systemd-tmpfiles`, and calling
+reversion. The [`ConfigureNixDaemonService`](common::ConfigureNixDaemonService) action is a good
+example of this, it takes several steps, such as running `systemd-tmpfiles`, and calling
 `systemctl link` on some systemd units.
 
 Where possible, tasks which could break during execution should be broken up, as uninstalling/installing

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -110,7 +110,7 @@ pub fn ensure_root() -> eyre::Result<()> {
                 _ => false,
             };
             if preserve {
-                preserve_env_list.push(format!("{key}=\"{value}\""));
+                preserve_env_list.push(format!("{key}={value}"));
             }
         }
 

--- a/src/planner/linux/multi.rs
+++ b/src/planner/linux/multi.rs
@@ -2,7 +2,6 @@ use crate::{
     action::{
         base::CreateDirectory,
         common::{ConfigureNix, ProvisionNix},
-        linux::StartSystemdUnit,
         StatefulAction,
     },
     planner::{Planner, PlannerError},
@@ -78,12 +77,6 @@ impl Planner for LinuxMulti {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            StartSystemdUnit::plan(
-                crate::action::common::configure_nix_daemon_service::SOCKET_SRC.to_string(),
-            )
-            .await
-            .map_err(|v| PlannerError::Action(v.into()))?
-            .boxed(),
         ])
     }
 

--- a/src/planner/linux/multi.rs
+++ b/src/planner/linux/multi.rs
@@ -78,10 +78,12 @@ impl Planner for LinuxMulti {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            StartSystemdUnit::plan("nix-daemon.socket".to_string())
-                .await
-                .map_err(|v| PlannerError::Action(v.into()))?
-                .boxed(),
+            StartSystemdUnit::plan(
+                crate::action::common::configure_nix_daemon_service::SOCKET_SRC.to_string(),
+            )
+            .await
+            .map_err(|v| PlannerError::Action(v.into()))?
+            .boxed(),
         ])
     }
 

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -223,10 +223,12 @@ impl Planner for SteamDeck {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            StartSystemdUnit::plan("nix-daemon.socket".to_string())
-                .await
-                .map_err(PlannerError::Action)?
-                .boxed(),
+            StartSystemdUnit::plan(
+                crate::action::common::configure_nix_daemon_service::SOCKET_SRC.to_string(),
+            )
+            .await
+            .map_err(PlannerError::Action)?
+            .boxed(),
         ])
     }
 

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -223,12 +223,6 @@ impl Planner for SteamDeck {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            StartSystemdUnit::plan(
-                crate::action::common::configure_nix_daemon_service::SOCKET_SRC.to_string(),
-            )
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed(),
         ])
     }
 


### PR DESCRIPTION
Fixes #137  Ubuntu 16.04 support

This was having issues due to two problems:

* We were elevating via `sudo --preserve-env BOOP,SNOOTS nix-installer` when `ubuntu-16.04` didn't have a recent enough `sudo` version to support it. We moved to `sudo env BOOP=$BOOP SNOOT=$SNOOT nix-installer` instead.
* We were calling `systemctl enable --now nix-daemon.socket` which was experiencing a "Too many levels of symbolic links" error on Ubuntu 16.04, so we rolled back to the nix install script behavior of using a raw file path.

Test via 

```
nix build github:determinatesystems/nix-installer/fix-ubuntu-16.04#hydraJobs.vm-test.ubuntu-v16_04.x86_64-linux.install-default -L
```