### PR TITLE
BUGFIX(?): Resolve a steam deck system unit ordering bug after update

### DIFF
--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -114,6 +114,8 @@ impl Planner for SteamDeck {
             PropagatesStopTo=nix-daemon.service\n\
             PropagatesStopTo=nix.mount\n\
             DefaultDependencies=no\n\
+            After=grub-recordfail.service\n\
+            After=steamos-finish-oobe-migration.service\n\
             \n\
             [Service]\n\
             Type=oneshot\n\


### PR DESCRIPTION
After updating my Deck last night I noticed that it wasn't suspending fully and checked the systemd units. Two units failed: `steamos-finish-oobe-migration.service` and `grub-recordfail.service`

Output from `steamos-finish-oobe-migration.service`:

```
Dec 25 22:32:52 steamdeck systemd[1]: Starting Finish migration from OOBE build...
Dec 25 22:32:52 steamdeck root[2569]: '/home/doorstop' does not exist or is not a folder, nothing to migrate
Dec 25 22:32:52 steamdeck systemd[1]: steamos-finish-oobe-migration.service: Main process exited, code=exited, status=1/FAILURE
Dec 25 22:32:52 steamdeck systemd[1]: steamos-finish-oobe-migration.service: Failed with result 'exit-code'.
Dec 25 22:32:52 steamdeck systemd[1]: Failed to start Finish migration from OOBE build.
```

And `steamos-finish-oobe-migration.service`:

```
Dec 25 22:36:25 steamdeck systemd[1]: Started Record successful boot for GRUB.
Dec 25 22:36:25 steamdeck systemd[1]: grub-recordfail.service: Deactivated successfully.
Dec 26 06:38:10 steamdeck systemd[1]: Started Record successful boot for GRUB.
Dec 26 06:38:10 steamdeck grub-editenv[2258]: /usr/bin/grub-editenv: error: cannot open `/boot/grub/grubenv': Read-only file system.
Dec 26 06:38:10 steamdeck systemd[1]: grub-recordfail.service: Main process exited, code=exited, status=1/FAILURE
Dec 26 06:38:10 steamdeck systemd[1]: grub-recordfail.service: Failed with result 'exit-code'.
```

I am not entirely sure why these failed, but adding a strict ordering of the Nix related units `After=` these ones seems to cleanly resolve the issue.

As a side note: I'm not entirely clear that this is a successful update, my `grub-recordfail.service` fails with readonly errors even after uninstalling Nix and the related units entirely.


```
(deck@steamdeck ~)$ sudo systemctl status grub-recordfail.service 
× grub-recordfail.service - Record successful boot for GRUB
     Loaded: loaded (/usr/lib/systemd/system/grub-recordfail.service; enabled; preset: disabled)
     Active: failed (Result: exit-code) since Mon 2022-12-26 06:49:43 PST; 33s ago
   Duration: 15ms
   Main PID: 2213 (code=exited, status=1/FAILURE)
        CPU: 3ms

Dec 26 06:49:43 steamdeck systemd[1]: Started Record successful boot for GRUB.
Dec 26 06:49:43 steamdeck grub-editenv[2213]: /usr/bin/grub-editenv: error: cannot open `/boot/grub/grubenv': Read-only file system.
Dec 26 06:49:43 steamdeck systemd[1]: grub-recordfail.service: Main process exited, code=exited, status=1/FAILURE
Dec 26 06:49:43 steamdeck systemd[1]: grub-recordfail.service: Failed with result 'exit-code'.
```

This patch makes sure that we order our Nix units after these services run, so we can't be colliding with them anymore, just in case.