### PR TITLE
Show revert instead of step while reverting

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -236,7 +236,7 @@ impl InstallPlan {
                 }
             }
 
-            tracing::info!("Step: {}", action.tracing_synopsis());
+            tracing::info!("Revert: {}", action.tracing_synopsis());
             if let Err(err) = action.try_revert().await {
                 if let Err(err) = write_receipt(self.clone()).await {
                     tracing::error!("Error saving receipt: {:?}", err);


### PR DESCRIPTION
```
ana@ubuntu-base:~/Downloads$ ./nix-installer uninstall
`nix-installer` needs to run as `root`, attempting to escalate now via `sudo`...
Nix uninstall plan

Planner: linux-multi

Planner settings:

* daemon_user_count: 32
* modify_profile: true
* nix_build_group_id: 3000
* nix_build_group_name: "nixbld"
* force: false
* nix_build_user_prefix: "nixbld"
* extra_conf: []
* nix_build_user_id_base: 3000
* nix_package_url: "https://releases.nixos.org/nix/nix-2.12.0/nix-2.12.0-x86_64-linux.tar.xz"
* channels: ["nixpkgs=https://nixos.org/channels/nixpkgs-unstable"]

The following actions will be taken (`--explain` for more context):

* Unconfigure the shell profiles
* Remove channel configuration at `/root/.nix-channels`
* Remove the Nix configuration in `/etc/nix/nix.conf`
* Unconfigure Nix daemon related settings with systemd
* Unset the default Nix profile
* Remove the directory tree in `/nix`
* Remove Nix users and group
* Remove the directory `/nix`


Proceed? (y/N): y
 INFO Revert: Configure Nix
 INFO Revert: Provision Nix
 INFO Revert: Create directory `/nix`
Nix was uninstalled successfully!
```
