### PR TITLE
Rename daemon-user-count and make an alias

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   modify-profile:
     description: Modify the user profile to automatically load nix
     required: false
-  daemon-user-count:
+  nix-build-user-count:
     description: Number of build users to create
     required: false
   nix-build-group-name:
@@ -86,8 +86,8 @@ runs:
         fi
 
         if [ -n "${{ inputs.daemon-user-count }}" ]; then
-          export NIX_INSTALLER_DAEMON_USER_COUNT=${{ inputs.daemon-user-count }}
-          echo "Set NIX_INSTALLER_DAEMON_USER_COUNT=$NIX_INSTALLER_DAEMON_USER_COUNT"
+          export NIX_INSTALLER_NIX_BUILD_USER_COUNT=${{ inputs.nix-build-user-count }}
+          echo "Set NIX_INSTALLER_NIX_BUILD_USER_COUNT=$NIX_INSTALLER_NIX_BUILD_USER_COUNT"
         fi
 
         if [ -n "${{ inputs.nix-build-group-name }}" ]; then

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -10,7 +10,7 @@ use tracing::{span, Instrument, Span};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct CreateUsersAndGroups {
-    daemon_user_count: usize,
+    nix_build_user_count: usize,
     nix_build_group_name: String,
     nix_build_group_id: usize,
     nix_build_user_prefix: String,
@@ -28,7 +28,7 @@ impl CreateUsersAndGroups {
             settings.nix_build_group_id,
         );
         // TODO(@hoverbear): CHeck if they exist, error if so
-        let create_users = (0..settings.daemon_user_count)
+        let create_users = (0..settings.nix_build_user_count)
             .map(|count| {
                 CreateUser::plan(
                     format!("{}{count}", settings.nix_build_user_prefix),
@@ -39,7 +39,7 @@ impl CreateUsersAndGroups {
             })
             .collect();
         Ok(Self {
-            daemon_user_count: settings.daemon_user_count,
+            nix_build_user_count: settings.nix_build_user_count,
             nix_build_group_name: settings.nix_build_group_name,
             nix_build_group_id: settings.nix_build_group_id,
             nix_build_user_prefix: settings.nix_build_user_prefix,
@@ -58,7 +58,7 @@ impl Action for CreateUsersAndGroups {
         format!(
             "Create build users (UID {}-{}) and group (GID {})",
             self.nix_build_user_id_base,
-            self.nix_build_user_id_base + self.daemon_user_count,
+            self.nix_build_user_id_base + self.nix_build_user_count,
             self.nix_build_group_id
         )
     }
@@ -67,7 +67,7 @@ impl Action for CreateUsersAndGroups {
         span!(
             tracing::Level::DEBUG,
             "create_users_and_group",
-            daemon_user_count = self.daemon_user_count,
+            nix_build_user_count = self.nix_build_user_count,
             nix_build_group_name = self.nix_build_group_name,
             nix_build_group_id = self.nix_build_group_id,
             nix_build_user_prefix = self.nix_build_user_prefix,
@@ -77,7 +77,7 @@ impl Action for CreateUsersAndGroups {
 
     fn execute_description(&self) -> Vec<ActionDescription> {
         let Self {
-            daemon_user_count: _,
+            nix_build_user_count: _,
             nix_build_group_name: _,
             nix_build_group_id: _,
             nix_build_user_prefix: _,
@@ -109,7 +109,7 @@ impl Action for CreateUsersAndGroups {
         let Self {
             create_users,
             create_group,
-            daemon_user_count: _,
+            nix_build_user_count: _,
             nix_build_group_name: _,
             nix_build_group_id: _,
             nix_build_user_prefix: _,
@@ -167,7 +167,7 @@ impl Action for CreateUsersAndGroups {
 
     fn revert_description(&self) -> Vec<ActionDescription> {
         let Self {
-            daemon_user_count: _,
+            nix_build_user_count: _,
             nix_build_group_name: _,
             nix_build_group_id: _,
             nix_build_user_prefix: _,
@@ -201,7 +201,7 @@ impl Action for CreateUsersAndGroups {
         let Self {
             create_users,
             create_group,
-            daemon_user_count: _,
+            nix_build_user_count: _,
             nix_build_group_name: _,
             nix_build_group_id: _,
             nix_build_user_prefix: _,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -64,11 +64,12 @@ pub struct CommonSettings {
         clap(
             long,
             default_value = "32",
-            env = "NIX_INSTALLER_DAEMON_USER_COUNT",
+            alias = "daemon-user-count",
+            env = "NIX_INSTALLER_NIX_BUILD_USER_COUNT",
             global = true
         )
     )]
-    pub(crate) daemon_user_count: usize,
+    pub(crate) nix_build_user_count: usize,
 
     /// The Nix build group name
     #[cfg_attr(
@@ -209,7 +210,7 @@ impl CommonSettings {
         };
 
         Ok(Self {
-            daemon_user_count: 32,
+            nix_build_user_count: 32,
             channels: vec![ChannelValue(
                 "nixpkgs".into(),
                 reqwest::Url::parse("https://nixos.org/channels/nixpkgs-unstable")
@@ -231,7 +232,7 @@ impl CommonSettings {
         let Self {
             channels,
             modify_profile,
-            daemon_user_count,
+            nix_build_user_count: nix_user_count,
             nix_build_group_name,
             nix_build_group_id,
             nix_build_user_prefix,
@@ -256,8 +257,8 @@ impl CommonSettings {
             serde_json::to_value(modify_profile)?,
         );
         map.insert(
-            "daemon_user_count".into(),
-            serde_json::to_value(daemon_user_count)?,
+            "nix_user_count".into(),
+            serde_json::to_value(nix_user_count)?,
         );
         map.insert(
             "nix_build_group_name".into(),
@@ -289,8 +290,8 @@ impl CommonSettings {
 // Builder Pattern
 impl CommonSettings {
     /// Number of build users to create
-    pub fn daemon_user_count(&mut self, count: usize) -> &mut Self {
-        self.daemon_user_count = count;
+    pub fn nix_user_count(&mut self, count: usize) -> &mut Self {
+        self.nix_build_user_count = count;
         self
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -232,7 +232,7 @@ impl CommonSettings {
         let Self {
             channels,
             modify_profile,
-            nix_build_user_count: nix_user_count,
+            nix_build_user_count,
             nix_build_group_name,
             nix_build_group_id,
             nix_build_user_prefix,
@@ -257,8 +257,8 @@ impl CommonSettings {
             serde_json::to_value(modify_profile)?,
         );
         map.insert(
-            "nix_user_count".into(),
-            serde_json::to_value(nix_user_count)?,
+            "nix_build_user_count".into(),
+            serde_json::to_value(nix_build_user_count)?,
         );
         map.insert(
             "nix_build_group_name".into(),
@@ -290,7 +290,7 @@ impl CommonSettings {
 // Builder Pattern
 impl CommonSettings {
     /// Number of build users to create
-    pub fn nix_user_count(&mut self, count: usize) -> &mut Self {
+    pub fn nix_build_user_count(&mut self, count: usize) -> &mut Self {
         self.nix_build_user_count = count;
         self
     }

--- a/tests/fixtures/darwin/darwin-multi.json
+++ b/tests/fixtures/darwin/darwin-multi.json
@@ -92,7 +92,7 @@
                 },
                 "create_users_and_group": {
                     "action": {
-                        "daemon_user_count": 32,
+                        "nix_build_user_count": 32,
                         "nix_build_group_name": "nixbld",
                         "nix_build_group_id": 3000,
                         "nix_build_user_prefix": "_nixbld",
@@ -665,7 +665,7 @@
                 ]
             ],
             "modify_profile": true,
-            "daemon_user_count": 32,
+            "nix_build_user_count": 32,
             "nix_build_group_name": "nixbld",
             "nix_build_group_id": 3000,
             "nix_build_user_prefix": "_nixbld",

--- a/tests/fixtures/linux/linux-multi.json
+++ b/tests/fixtures/linux/linux-multi.json
@@ -24,7 +24,7 @@
                 },
                 "create_users_and_group": {
                     "action": {
-                        "daemon_user_count": 32,
+                        "nix_build_user_count": 32,
                         "nix_build_group_name": "nixbld",
                         "nix_build_group_id": 3000,
                         "nix_build_user_prefix": "nixbld",
@@ -607,7 +607,7 @@
                 ]
             ],
             "modify_profile": true,
-            "daemon_user_count": 32,
+            "nix_build_user_count": 32,
             "nix_build_group_name": "nixbld",
             "nix_build_group_id": 3000,
             "nix_build_user_prefix": "nixbld",

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -67,7 +67,7 @@
                 },
                 "create_users_and_group": {
                     "action": {
-                        "daemon_user_count": 32,
+                        "nix_build_user_count": 32,
                         "nix_build_group_name": "nixbld",
                         "nix_build_group_id": 3000,
                         "nix_build_user_prefix": "nixbld",
@@ -651,7 +651,7 @@
                 ]
             ],
             "modify_profile": true,
-            "daemon_user_count": 32,
+            "nix_build_user_count": 32,
             "nix_build_group_name": "nixbld",
             "nix_build_group_id": 3000,
             "nix_build_user_prefix": "nixbld",


### PR DESCRIPTION
We discussed that this may make the UX more consistent.

Now:

```
❯ cargo run -- install --help | rg nix-
   Compiling nix-installer v0.0.0-unreleased (/home/ana/git/determinatesystems/harmonic)
    Finished dev [unoptimized + debuginfo] target(s) in 9.23s
     Running `target/debug/nix-installer install --help`
To pass custom options, select a planner, for example `nix-installer install linux-multi --help`
Usage: nix-installer install [OPTIONS] [PLAN]
       nix-installer install <COMMAND>
      --nix-build-user-count <NIX_BUILD_USER_COUNT>
      --nix-build-group-name <NIX_BUILD_GROUP_NAME>
      --nix-build-group-id <NIX_BUILD_GROUP_ID>
      --nix-build-user-prefix <NIX_BUILD_USER_PREFIX>
      --nix-build-user-id-base <NIX_BUILD_USER_ID_BASE>
      --nix-package-url <NIX_PACKAGE_URL>
          [default: https://releases.nixos.org/nix/nix-2.12.0/nix-2.12.0-x86_64-linux.tar.xz]
          If `nix-installer` should forcibly recreate files it finds existing

```