### PR TITLE
upload_s3: sync already-existing dir to its destination

### DIFF
--- a/upload_s3.sh
+++ b/upload_s3.sh
@@ -34,4 +34,4 @@ for file in $(find "$GITHUB_SHA" -type f); do
 done
 
 aws s3 sync "$GITHUB_SHA"/ s3://"$AWS_BUCKET"/"$GITHUB_SHA"/ --acl public-read
-aws s3 sync "$GITHUB_SHA"/ s3://"$AWS_BUCKET"/"$DEST"/ --acl public-read
+aws s3 sync s3://"$AWS_BUCKET"/"$GITHUB_SHA"/ s3://"$AWS_BUCKET"/"$DEST"/ --acl public-read


### PR DESCRIPTION
Rather than uploading the same files to S3 twice, upload once and then sync the directory to its other destination.