### PR TITLE
BUGFIX: CreateDirectory now properly prunes when it should

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futures"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,7 +901,7 @@ dependencies = [
  "nix",
  "owo-colors",
  "plist",
- "rand",
+ "rand 0.8.5",
  "reqwest",
  "semver",
  "serde",
@@ -903,6 +909,7 @@ dependencies = [
  "serde_with",
  "tar",
  "target-lexicon",
+ "tempdir",
  "term",
  "thiserror",
  "tokio",
@@ -1100,13 +1107,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1116,8 +1136,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1126,6 +1161,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1171,6 +1215,15 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -1486,6 +1539,16 @@ name = "target-lexicon"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
 
 [[package]]
 name = "term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 
 [features]
 default = ["cli"]
-cli = [ "eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error", "atty" ]
+cli = ["eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error", "atty"]
 
 [[bin]]
 name = "nix-installer"
@@ -55,6 +55,7 @@ term = { version = "0.7.0", default-features = false }
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }
+tempdir = "0.3.7"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -188,58 +188,63 @@ impl Action for CreateDirectory {
     }
 }
 
-#[tokio::test]
-async fn creates_and_deletes_empty_directory() -> eyre::Result<()> {
-    let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
-    let test_dir = temp_dir.path().join("creates_and_deletes_empty_directory");
-    let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, false).await?;
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    action.try_execute().await?;
+    #[tokio::test]
+    async fn creates_and_deletes_empty_directory() -> eyre::Result<()> {
+        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let test_dir = temp_dir.path().join("creates_and_deletes_empty_directory");
+        let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, false).await?;
 
-    action.try_revert().await?;
+        action.try_execute().await?;
 
-    assert!(!test_dir.exists(), "Folder should have been deleted");
+        action.try_revert().await?;
 
-    Ok(())
-}
+        assert!(!test_dir.exists(), "Folder should have been deleted");
 
-#[tokio::test]
-async fn creates_and_deletes_populated_directory_if_prune_true() -> eyre::Result<()> {
-    let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
-    let test_dir = temp_dir
-        .path()
-        .join("creates_and_deletes_populated_directory_if_prune_true");
-    let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, true).await?;
+        Ok(())
+    }
 
-    action.try_execute().await?;
+    #[tokio::test]
+    async fn creates_and_deletes_populated_directory_if_prune_true() -> eyre::Result<()> {
+        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let test_dir = temp_dir
+            .path()
+            .join("creates_and_deletes_populated_directory_if_prune_true");
+        let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, true).await?;
 
-    let stub_file = test_dir.as_path().join("stub");
-    tokio::fs::write(stub_file, "More content").await?;
+        action.try_execute().await?;
 
-    action.try_revert().await?;
+        let stub_file = test_dir.as_path().join("stub");
+        tokio::fs::write(stub_file, "More content").await?;
 
-    assert!(!test_dir.exists(), "Folder should have been deleted");
+        action.try_revert().await?;
 
-    Ok(())
-}
+        assert!(!test_dir.exists(), "Folder should have been deleted");
 
-#[tokio::test]
-async fn creates_and_leaves_populated_directory_if_prune_false() -> eyre::Result<()> {
-    let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
-    let test_dir = temp_dir
-        .path()
-        .join("creates_and_leaves_populated_directory_if_prune_false");
-    let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, false).await?;
+        Ok(())
+    }
 
-    action.try_execute().await?;
+    #[tokio::test]
+    async fn creates_and_leaves_populated_directory_if_prune_false() -> eyre::Result<()> {
+        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let test_dir = temp_dir
+            .path()
+            .join("creates_and_leaves_populated_directory_if_prune_false");
+        let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, false).await?;
 
-    let stub_file = test_dir.as_path().join("stub");
-    tokio::fs::write(&stub_file, "More content").await?;
+        action.try_execute().await?;
 
-    action.try_revert().await?;
+        let stub_file = test_dir.as_path().join("stub");
+        tokio::fs::write(&stub_file, "More content").await?;
 
-    assert!(test_dir.exists(), "Folder should not have been deleted");
-    assert!(stub_file.exists(), "Folder should not have been deleted");
+        action.try_revert().await?;
 
-    Ok(())
+        assert!(test_dir.exists(), "Folder should not have been deleted");
+        assert!(stub_file.exists(), "Folder should not have been deleted");
+
+        Ok(())
+    }
 }

--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -173,7 +173,8 @@ impl Action for CreateDirectory {
             .read_dir()
             .map_err(|e| ActionError::Read(path.clone(), e))?
             .next()
-            .is_some();
+            .is_none();
+
         match (is_empty, force_prune_on_revert) {
             (true, _) | (false, true) => remove_dir_all(path.clone())
                 .await
@@ -185,4 +186,60 @@ impl Action for CreateDirectory {
 
         Ok(())
     }
+}
+
+#[tokio::test]
+async fn creates_and_deletes_empty_directory() -> eyre::Result<()> {
+    let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+    let test_dir = temp_dir.path().join("creates_and_deletes_empty_directory");
+    let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, false).await?;
+
+    action.try_execute().await?;
+
+    action.try_revert().await?;
+
+    assert!(!test_dir.exists(), "Folder should have been deleted");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn creates_and_deletes_populated_directory_if_prune_true() -> eyre::Result<()> {
+    let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+    let test_dir = temp_dir
+        .path()
+        .join("creates_and_deletes_populated_directory_if_prune_true");
+    let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, true).await?;
+
+    action.try_execute().await?;
+
+    let stub_file = test_dir.as_path().join("stub");
+    tokio::fs::write(stub_file, "More content").await?;
+
+    action.try_revert().await?;
+
+    assert!(!test_dir.exists(), "Folder should have been deleted");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn creates_and_leaves_populated_directory_if_prune_false() -> eyre::Result<()> {
+    let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+    let test_dir = temp_dir
+        .path()
+        .join("creates_and_leaves_populated_directory_if_prune_false");
+    let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, false).await?;
+
+    action.try_execute().await?;
+
+    let stub_file = test_dir.as_path().join("stub");
+    tokio::fs::write(&stub_file, "More content").await?;
+
+    action.try_revert().await?;
+
+    assert!(test_dir.exists(), "Folder should not have been deleted");
+    assert!(stub_file.exists(), "Folder should not have been deleted");
+
+    Ok(())
 }


### PR DESCRIPTION
There were certain cases where we would not prune a directory, but should have.