### PR TITLE
Trim irrelevant mac warning

### DIFF
--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -106,6 +106,8 @@ impl Action for SetupDefaultProfile {
             load_db_command.process_group(0);
             load_db_command.arg("--load-db");
             load_db_command.stdin(std::process::Stdio::piped());
+            load_db_command.stdout(std::process::Stdio::piped());
+            load_db_command.stderr(std::process::Stdio::piped());
             load_db_command.env(
                 "HOME",
                 dirs::home_dir().ok_or_else(|| {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/130903/212414794-767f4e07-2f03-457a-9c5d-772b4daef4df.png)

Silence this warning that isn't important to users.