### PR TITLE
Upload tags to S3 as well to avoid egress limits

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -26,13 +26,12 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_S3_UPLOAD_ROLE }}
           aws-region: us-east-2
-      - name: Publish Release (PR)
+      - name: Publish Release to S3 (Tag)
         env:
           AWS_BUCKET: ${{ secrets.AWS_S3_UPLOAD_BUCKET }}
         run: |
-          GIT_ISH="${{ github.event.pull_request.head.sha }}"
-          ./upload_s3.sh "$GITHUB_REF_NAME" "$GIT_ISH"
-      - name: Publish Release (Tag)
+          ./upload_s3.sh "$GITHUB_SHA" "$GIT_ISH"
+      - name: Publish Release to GitHub (Tag)
         uses: softprops/action-gh-release@v1
         with:
           fail_on_unmatched_files: true

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Fixup URL in nix-installer.sh
         run: |
           sed -i "s@https://install.determinate.systems/nix@https://install.determinate.systems/nix/tag/$GITHUB_REF_NAME@" nix-installer.sh
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_UPLOAD_ROLE }}
+          aws-region: us-east-2
+      - name: Publish Release (PR)
+        env:
+          AWS_BUCKET: ${{ secrets.AWS_S3_UPLOAD_BUCKET }}
+        run: |
+          GIT_ISH="${{ github.event.pull_request.head.sha }}"
+          ./upload_s3.sh "$GITHUB_REF_NAME" "$GIT_ISH"
       - name: Publish Release (Tag)
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           AWS_BUCKET: ${{ secrets.AWS_S3_UPLOAD_BUCKET }}
         run: |
-          ./upload_s3.sh "$GITHUB_SHA" "$GIT_ISH"
+          ./upload_s3.sh "$GITHUB_REF_NAME" "$GITHUB_SHA"
       - name: Publish Release to GitHub (Tag)
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Upload tags to the s3 bucket so we don't get Github Egress warnings on the release artifacts.