### PR TITLE
Revert "Release v0.0.2 (#198)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.0.2"
+version = "0.0.2-unreleased"
 dependencies = [
  "async-trait",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix-installer"
 description = "A `nix` installer"
-version = "0.0.2"
+version = "0.0.2-unreleased"
 edition = "2021"
 resolver = "2"
 license = "LGPL-2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
           };
           sharedAttrs = {
             pname = "nix-installer";
-            version = "0.0.2";
+            version = "0.0.2-unreleased";
             src = builtins.path {
               name = "nix-installer-source";
               path = self;

--- a/tests/fixtures/darwin/darwin-multi.json
+++ b/tests/fixtures/darwin/darwin-multi.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.2-unreleased",
   "actions": [
     {
       "action": {

--- a/tests/fixtures/linux/linux-multi.json
+++ b/tests/fixtures/linux/linux-multi.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.2-unreleased",
   "actions": [
     {
       "action": {

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.2",
+  "version": "0.0.2-unreleased",
   "actions": [
     {
       "action": {


### PR DESCRIPTION
This reverts commit a29ebd7ae8a175ecfea6ae044ace37a0a3556114.

We want to include #199 .

Since we didn't produce artifacts, create a Github release, or do `cargo publish` we do not consider this a full release. We are re-releasing v0.0.2, the binaries it produces should be identical to the ones produced by #198 anyways, since #199 only touches CI jobs.

I'll recreate #198 after #199 is merged.