### PR TITLE
Correct --no-modify-profile

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -48,12 +48,11 @@ pub struct CommonSettings {
     #[cfg_attr(
         feature = "cli",
         clap(
-            long,
             action(ArgAction::SetFalse),
             default_value = "true",
             global = true,
             env = "NIX_INSTALLER_NO_MODIFY_PROFILE",
-            name = "no-modify-profile"
+            long = "no-modify-profile"
         )
     )]
     pub(crate) modify_profile: bool,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -51,7 +51,7 @@ pub struct CommonSettings {
             action(ArgAction::SetFalse),
             default_value = "true",
             global = true,
-            env = "NIX_INSTALLER_NO_MODIFY_PROFILE",
+            env = "NIX_INSTALLER_MODIFY_PROFILE",
             long = "no-modify-profile"
         )
     )]


### PR DESCRIPTION
##### Description

The `modify-profile` setting should be controlled by a `--no-modify-profile` flag.

Also corrects the env to be what the action expects:

https://github.com/DeterminateSystems/nix-installer-action/blob/841d37ff4674fb785d60c871f24a417ac413b2c5/action.yml#L127-L130

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
