### PR TITLE
v0.1.0-unreleased

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.1.0"
+version = "0.1.0-unreleased"
 dependencies = [
  "async-trait",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix-installer"
 description = "A `nix` installer"
-version = "0.1.0"
+version = "0.1.0-unreleased"
 edition = "2021"
 resolver = "2"
 license = "LGPL-2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
           };
           sharedAttrs = {
             pname = "nix-installer";
-            version = "0.0.2";
+            version = "0.1.0-unreleased";
             src = builtins.path {
               name = "nix-installer-source";
               path = self;

--- a/tests/fixtures/darwin/darwin-multi.json
+++ b/tests/fixtures/darwin/darwin-multi.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.0-unreleased",
   "actions": [
     {
       "action": {

--- a/tests/fixtures/linux/linux-multi.json
+++ b/tests/fixtures/linux/linux-multi.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.0-unreleased",
   "actions": [
     {
       "action": {

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.0-unreleased",
   "actions": [
     {
       "action": {


### PR DESCRIPTION
##### Description

Normal version bump as per `CONTRIBUTING.md`

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
