### PR TITLE
Add a friendly top comment about `nix-installer.sh`

### DIFF
--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -5,8 +5,8 @@
 # https://github.com/DeterminateSystems/nix-installer/releases then pick the version and platform
 # most appropriate for your deployment target.
 #
-# This is just a little script selects and downloads the right `nix-installer`. It just does
-# platform detection, downloads the installer and runs it.
+# This is just a little script selects and downloads the right `nix-installer`. It does
+# platform detection, downloads the installer, and runs it; that's it.
 #
 # It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local`
 # extension. Note: Most shells limit `local` to 1 var per line, contra bash.

--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
 # shellcheck shell=dash
 
-# This script is based off https://github.com/rust-lang/rustup/blob/8f6b53628ad996ad86f9c6225fa500cddf860905/rustup-init.sh
-
-# This is just a little script that can be downloaded from the internet to
-# install `nix-installer`. It just does platform detection, downloads the installer
-# and runs it.
-
+# If you need an offline install, or you'd prefer to run the binary directly, head to 
+# https://github.com/DeterminateSystems/nix-installer/releases then pick the version and platform
+# most appropriate for your deployment target.
+#
+# This is just a little script selects and downloads the right `nix-installer`. It just does
+# platform detection, downloads the installer and runs it.
+#
 # It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local`
 # extension. Note: Most shells limit `local` to 1 var per line, contra bash.
+
+# This script is based off https://github.com/rust-lang/rustup/blob/8f6b53628ad996ad86f9c6225fa500cddf860905/rustup-init.sh
 
 if [ "$KSH_VERSION" = 'Version JM 93t+ 2010-03-05' ]; then
     # The version of ksh93 that ships with many illumos systems does not

--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -5,7 +5,7 @@
 # https://github.com/DeterminateSystems/nix-installer/releases then pick the version and platform
 # most appropriate for your deployment target.
 #
-# This is just a little script selects and downloads the right `nix-installer`. It does
+# This is just a little script that selects and downloads the right `nix-installer`. It does
 # platform detection, downloads the installer, and runs it; that's it.
 #
 # It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local`


### PR DESCRIPTION
##### Description

Some folks were a bit curious what the `nix-installer.sh` did, so we reworded the start to make it more friendly and explain quite directly what it does, as well as offering users a way to avoid using the script entirely.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
