### PR TITLE
Verify the apfs volume doesn't already exist before trying to create it

### DIFF
--- a/src/action/darwin/create_apfs_volume.rs
+++ b/src/action/darwin/create_apfs_volume.rs
@@ -5,6 +5,7 @@ use tracing::{span, Span};
 
 use crate::action::{ActionError, StatefulAction};
 use crate::execute_command;
+use serde::Deserialize;
 
 use crate::action::{Action, ActionDescription};
 
@@ -22,16 +23,19 @@ impl CreateApfsVolume {
         name: String,
         case_sensitive: bool,
     ) -> Result<StatefulAction<Self>, ActionError> {
-        let output = execute_command(Command::new("/usr/sbin/diskutil").args(["apfs", "list"]))
-            .await
-            .map_err(ActionError::Command)?;
+        let output =
+            execute_command(Command::new("/usr/sbin/diskutil").args(["apfs", "list", "-plist"]))
+                .await
+                .map_err(ActionError::Command)?;
 
-        let output_string = String::from_utf8(output.stdout)?;
-        for line in output_string.lines() {
-            if line.contains("Name:") && line.contains(&name) {
-                return Err(ActionError::Custom(Box::new(
-                    CreateApfsVolumeError::ExistingVolume(name),
-                )));
+        let parsed: DiskUtilApfsListOutput = plist::from_bytes(&output.stdout)?;
+        for container in parsed.containers {
+            for volume in container.volumes {
+                if volume.name == name {
+                    return Err(ActionError::Custom(Box::new(
+                        CreateApfsVolumeError::ExistingVolume(name),
+                    )));
+                }
             }
         }
 
@@ -136,4 +140,22 @@ impl Action for CreateApfsVolume {
 pub enum CreateApfsVolumeError {
     #[error("Existing volume called `{0}` found in `diskutil apfs list`, delete it with `diskutil apfs deleteVolume \"{0}\"`")]
     ExistingVolume(String),
+}
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct DiskUtilApfsListOutput {
+    containers: Vec<DiskUtilApfsContainer>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct DiskUtilApfsContainer {
+    volumes: Vec<DiskUtilApfsListVolume>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct DiskUtilApfsListVolume {
+    name: String,
 }

--- a/src/action/darwin/enable_ownership.rs
+++ b/src/action/darwin/enable_ownership.rs
@@ -97,4 +97,7 @@ impl Action for EnableOwnership {
 pub enum EnableOwnershipError {
     #[error("Failed to execute command")]
     Command(#[source] std::io::Error),
+    /// A MacOS (Darwin) plist related error
+    #[error(transparent)]
+    Plist(#[from] plist::Error),
 }

--- a/src/action/darwin/enable_ownership.rs
+++ b/src/action/darwin/enable_ownership.rs
@@ -62,7 +62,7 @@ impl Action for EnableOwnership {
             .await
             .map_err(ActionError::Command)?
             .stdout;
-            let the_plist: DiskUtilOutput = plist::from_reader(Cursor::new(buf)).unwrap();
+            let the_plist: DiskUtilOutput = plist::from_reader(Cursor::new(buf))?;
 
             the_plist.global_permissions_enabled
         };
@@ -97,7 +97,4 @@ impl Action for EnableOwnership {
 pub enum EnableOwnershipError {
     #[error("Failed to execute command")]
     Command(#[source] std::io::Error),
-    /// A MacOS (Darwin) plist related error
-    #[error(transparent)]
-    Plist(#[from] plist::Error),
 }

--- a/src/action/darwin/mod.rs
+++ b/src/action/darwin/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod kickstart_launchctl_service;
 pub(crate) mod unmount_apfs_volume;
 
 pub use bootstrap_apfs_volume::{BootstrapApfsVolume, BootstrapVolumeError};
-pub use create_apfs_volume::{CreateApfsVolume, CreateVolumeError};
+pub use create_apfs_volume::{CreateApfsVolume, CreateApfsVolumeError};
 pub use create_nix_volume::{CreateNixVolume, NIX_VOLUME_MOUNTD_DEST};
 pub use create_synthetic_objects::{CreateSyntheticObjects, CreateSyntheticObjectsError};
 pub use enable_ownership::{EnableOwnership, EnableOwnershipError};

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -327,6 +327,9 @@ pub enum ActionError {
         #[from]
         std::string::FromUtf8Error,
     ),
+    /// A MacOS (Darwin) plist related error
+    #[error(transparent)]
+    Plist(#[from] plist::Error),
 }
 
 impl HasExpectedErrors for ActionError {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -114,6 +114,7 @@ pub struct CommonSettings {
         feature = "cli",
         clap(long, env = "NIX_INSTALLER_NIX_BUILD_USER_ID_BASE", global = true)
     )]
+    // Service users on Mac should be between 200-400
     #[cfg_attr(all(target_os = "macos", feature = "cli"), clap(default_value_t = 300))]
     #[cfg_attr(
         all(target_os = "linux", feature = "cli"),


### PR DESCRIPTION
##### Description

During the plan phase, determine if a Mac APFS volume exists, and error if so with some remedy.

I think @9999years bumped into this in https://github.com/DeterminateSystems/nix-installer/issues/213#issuecomment-1407298341.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
