### PR TITLE
Use 30k range not 3k range for UIDs on Linux and 30k for a GID on all

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -87,7 +87,7 @@ pub struct CommonSettings {
         feature = "cli",
         clap(
             long,
-            default_value_t = 3000,
+            default_value_t = 30_000,
             env = "NIX_INSTALLER_NIX_BUILD_GROUP_ID",
             global = true
         )
@@ -117,7 +117,7 @@ pub struct CommonSettings {
     #[cfg_attr(all(target_os = "macos", feature = "cli"), clap(default_value_t = 300))]
     #[cfg_attr(
         all(target_os = "linux", feature = "cli"),
-        clap(default_value_t = 3000)
+        clap(default_value_t = 30_000)
     )]
     pub(crate) nix_build_user_id_base: usize,
 


### PR DESCRIPTION
##### Description

Fixes #220 

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
