### PR TITLE
release: only run one release action at a time

### DIFF
--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   release:
+    concurrency: release
     runs-on: ubuntu-latest
     permissions:
       id-token: write # In order to request a JWT for AWS auth

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   release:
+    concurrency: release
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     if: github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-installer' && contains(github.event.pull_request.labels.*.name, 'upload to s3')
     runs-on: ubuntu-latest

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    concurrency: release
     runs-on: ubuntu-latest
     permissions:
       contents: write # In order to upload artifacts to GitHub releases


### PR DESCRIPTION
https://docs.github.com/en/actions/using-jobs/using-concurrency

##### Description

I noticed that it's possible to have the `tags` and `branches` release actions run at the same time. I want to prevent any potential for having multiple release actions running affecting each other.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
