### PR TITLE
Attempt to minimize steam deck display manager restart risk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.2.0"
+version = "0.2.1-unreleased"
 dependencies = [
  "async-trait",
  "atty",

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -12,14 +12,19 @@ Start a given systemd unit
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct StartSystemdUnit {
     unit: String,
+    enable: bool,
 }
 
 impl StartSystemdUnit {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn plan(unit: impl AsRef<str>) -> Result<StatefulAction<Self>, ActionError> {
+    pub async fn plan(
+        unit: impl AsRef<str>,
+        enable: bool,
+    ) -> Result<StatefulAction<Self>, ActionError> {
         Ok(StatefulAction {
             action: Self {
                 unit: unit.as_ref().to_string(),
+                enable,
             },
             state: ActionState::Uncompleted,
         })
@@ -47,19 +52,35 @@ impl Action for StartSystemdUnit {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
-        let Self { unit, .. } = self;
+        let Self { unit, enable } = self;
 
-        // TODO(@Hoverbear): Handle proxy vars
-        execute_command(
-            Command::new("systemctl")
-                .process_group(0)
-                .arg("enable")
-                .arg("--now")
-                .arg(format!("{unit}"))
-                .stdin(std::process::Stdio::null()),
-        )
-        .await
-        .map_err(|e| ActionError::Custom(Box::new(StartSystemdUnitError::Command(e))))?;
+        match enable {
+            true => {
+                // TODO(@Hoverbear): Handle proxy vars
+                execute_command(
+                    Command::new("systemctl")
+                        .process_group(0)
+                        .arg("enable")
+                        .arg("--now")
+                        .arg(format!("{unit}"))
+                        .stdin(std::process::Stdio::null()),
+                )
+                .await
+                .map_err(|e| ActionError::Custom(Box::new(StartSystemdUnitError::Command(e))))?;
+            },
+            false => {
+                // TODO(@Hoverbear): Handle proxy vars
+                execute_command(
+                    Command::new("systemctl")
+                        .process_group(0)
+                        .arg("start")
+                        .arg(format!("{unit}"))
+                        .stdin(std::process::Stdio::null()),
+                )
+                .await
+                .map_err(|e| ActionError::Custom(Box::new(StartSystemdUnitError::Command(e))))?;
+            },
+        }
 
         Ok(())
     }
@@ -73,17 +94,19 @@ impl Action for StartSystemdUnit {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        let Self { unit, .. } = self;
+        let Self { unit, enable } = self;
 
-        execute_command(
-            Command::new("systemctl")
-                .process_group(0)
-                .arg("disable")
-                .arg(format!("{unit}"))
-                .stdin(std::process::Stdio::null()),
-        )
-        .await
-        .map_err(|e| ActionError::Custom(Box::new(StartSystemdUnitError::Command(e))))?;
+        if *enable {
+            execute_command(
+                Command::new("systemctl")
+                    .process_group(0)
+                    .arg("disable")
+                    .arg(format!("{unit}"))
+                    .stdin(std::process::Stdio::null()),
+            )
+            .await
+            .map_err(|e| ActionError::Custom(Box::new(StartSystemdUnitError::Command(e))))?;
+        };
 
         // We do both to avoid an error doing `disable --now` if the user did stop it already somehow.
         execute_command(

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -189,7 +189,7 @@ impl Planner for SteamDeck {
             Type=oneshot\n\
             RemainAfterExit=yes\n\
             ExecStart=/usr/bin/systemctl daemon-reload\n\
-            ExecStart=/usr/bin/systemctl restart --no-block nix-daemon.service\n\
+            ExecStart=/usr/bin/systemctl start --no-block sockets.target timers.target multi-user.target\n\
             \n\
             [Install]\n\
             WantedBy=sysinit.target\n\

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -152,6 +152,7 @@ impl Planner for SteamDeck {
             Requires=nix-directory.service\n\
             ConditionPathIsDirectory=/nix\n\
             DefaultDependencies=no\n\
+            RequiredBy=nix-daemon.service\n\
             \n\
             [Mount]\n\
             What={persistence}\n\
@@ -188,7 +189,7 @@ impl Planner for SteamDeck {
             Type=oneshot\n\
             RemainAfterExit=yes\n\
             ExecStart=/usr/bin/systemctl daemon-reload\n\
-            ExecStart=/usr/bin/systemctl restart --no-block sockets.target timers.target multi-user.target\n\
+            ExecStart=/usr/bin/systemctl restart --no-block nix-daemon.service\n\
             \n\
             [Install]\n\
             WantedBy=sysinit.target\n\

--- a/src/planner/linux/steam_deck.rs
+++ b/src/planner/linux/steam_deck.rs
@@ -153,6 +153,7 @@ impl Planner for SteamDeck {
             ConditionPathIsDirectory=/nix\n\
             DefaultDependencies=no\n\
             RequiredBy=nix-daemon.service\n\
+            RequiredBy=nix-daemon.socket\n\
             \n\
             [Mount]\n\
             What={persistence}\n\
@@ -181,15 +182,13 @@ impl Planner for SteamDeck {
             After=nix.mount\n\
             Requires=nix-directory.service\n\
             Requires=nix.mount\n\
-            PropagatesStopTo=nix-directory.service\n\
-            PropagatesStopTo=nix.mount\n\
             DefaultDependencies=no\n\
             \n\
             [Service]\n\
             Type=oneshot\n\
             RemainAfterExit=yes\n\
             ExecStart=/usr/bin/systemctl daemon-reload\n\
-            ExecStart=/usr/bin/systemctl start --no-block sockets.target timers.target multi-user.target\n\
+            ExecStart=/usr/bin/systemctl restart --no-block nix-daemon.socket\n\
             \n\
             [Install]\n\
             WantedBy=sysinit.target\n\
@@ -214,7 +213,7 @@ impl Planner for SteamDeck {
             nix_directory_unit.boxed(),
             create_bind_mount_unit.boxed(),
             ensure_symlinked_units_resolve_unit.boxed(),
-            StartSystemdUnit::plan("ensure-symlinked-units-resolve.service".to_string())
+            StartSystemdUnit::plan("nix.mount".to_string(), false)
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
@@ -228,6 +227,10 @@ impl Planner for SteamDeck {
                 .boxed(),
             // Init is required for the steam-deck archetype to make the `/nix` mount
             ConfigureInitService::plan(InitSystem::Systemd, true)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
+            StartSystemdUnit::plan("ensure-symlinked-units-resolve.service".to_string(), true)
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -51,7 +51,8 @@
       {
         "action": {
           "action": "start_systemd_unit",
-          "unit": "ensure-symlinked-units-resolve.service"
+          "unit": "ensure-symlinked-units-resolve.service",
+          "enable": true
         },
         "state": "Uncompleted"
       },


### PR DESCRIPTION
##### Description

This attempts to address https://github.com/DeterminateSystems/nix-installer/issues/235 with the information at hand. My best suspicion is that this is the display manager restarting.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
