### PR TITLE
Make systemd unit start detect already running unit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.2.0"
+version = "0.2.1-unreleased"
 dependencies = [
  "async-trait",
  "atty",

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -18,7 +18,6 @@ impl StartSystemdUnit {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(unit: impl AsRef<str>) -> Result<StatefulAction<Self>, ActionError> {
         let unit = unit.as_ref();
-        // If `systemctl is-active $UNIT` has exit status 3, it doesn't exist
         let output = Command::new("systemctl")
             .arg("is-active")
             .arg(unit)
@@ -27,7 +26,7 @@ impl StartSystemdUnit {
             .map_err(ActionError::Command)?;
 
         let state = if output.status.success() {
-            tracing::debug!("Starting systemd unit `{}` already complete", unit,);
+            tracing::debug!("Starting systemd unit `{}` already complete", unit);
             ActionState::Skipped
         } else {
             ActionState::Uncompleted

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -27,10 +27,7 @@ impl StartSystemdUnit {
             .map_err(ActionError::Command)?;
 
         let state = if output.status.success() {
-            tracing::debug!(
-                "Starting systemd unit `{}` already complete, skipping",
-                unit,
-            );
+            tracing::debug!("Starting systemd unit `{}` already complete", unit,);
             ActionState::Skipped
         } else {
             ActionState::Uncompleted


### PR DESCRIPTION
##### Description

During the plan phase, see if the unit is running, if it is, skip doing anything. Part of #35

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
