### PR TITLE
It's the Determinate Nix Installer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nix-installer"
-description = "A `nix` installer"
+description = "The Determinate Nix Installer"
 version = "0.2.1-unreleased"
 edition = "2021"
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Determinate Nix Installer
+# The Determinate Nix Installer
 
 [![Crates.io](https://img.shields.io/crates/v/nix-installer)](https://crates.io/crates/nix-installer)
 [![Docs.rs](https://img.shields.io/docsrs/nix-installer)](https://docs.rs/nix-installer/latest/nix_installer/)
 
-`nix-installer` is an opinionated, **experimental** Nix installer.
+The Determinate `nix-installer` is an opinionated, **experimental** Nix installer.
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nix Installer
+# Determinate Nix Installer
 
 [![Crates.io](https://img.shields.io/crates/v/nix-installer)](https://crates.io/crates/nix-installer)
 [![Docs.rs](https://img.shields.io/docsrs/nix-installer)](https://docs.rs/nix-installer/latest/nix_installer/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/nix-installer)](https://crates.io/crates/nix-installer)
 [![Docs.rs](https://img.shields.io/docsrs/nix-installer)](https://docs.rs/nix-installer/latest/nix_installer/)
 
-The Determinate `nix-installer` is an opinionated, **experimental** Nix installer.
+`nix-installer` is an opinionated, **experimental** Nix installer.
 
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A Nix Installer";
+  description = "The Determinate Nix Installer";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-/*! A [Nix](https://github.com/NixOS/nix) installer and uninstaller.
+/*! The Determinate [Nix](https://github.com/NixOS/nix) Installer
 
 `nix-installer` breaks down into three main concepts:
 


### PR DESCRIPTION
##### Description

Refine the casual written name of the installer to ensure it is not easily mistaken for the official install scripts. This is the Determinate Nix Installer, not the official Nix installer (yet! -- it'd be really cool to see that happen).

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
