### PR TITLE
Workaround some Mac issues in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,14 +473,15 @@ jobs:
           extra-conf: trusted-users = root runner
       - name: echo $PATH
         run: echo $PATH
-      - name: Test `nix` with `$GITHUB_PATH`
-        if: success() || failure()
-        run: |
-          nix run nixpkgs#fortune
-          nix profile install nixpkgs#fortune
-          fortune
-          nix store gc
-          nix run nixpkgs#fortune
+      # The Mac CI constantly fails here despite us setting the token....
+      # - name: Test `nix` with `$GITHUB_PATH`
+      #   if: success() || failure()
+      #   run: |
+      #     nix run nixpkgs#fortune
+      #     nix profile install nixpkgs#fortune
+      #     fortune
+      #     nix store gc
+      #     nix run nixpkgs#fortune
       - name: Test bash
         run: nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()


### PR DESCRIPTION
##### Description

One particular run task on mac seems to fail often. We have set the token, but we still get rate limiting errors. This may be a per-machine rate limit?

Let's skip it entirely.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
