### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.2.1-unreleased"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix-installer"
 description = "The Determinate Nix Installer"
-version = "0.2.1-unreleased"
+version = "0.3.0"
 edition = "2021"
 resolver = "2"
 license = "LGPL-2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
           };
           sharedAttrs = {
             pname = "nix-installer";
-            version = "0.2.1-unreleased";
+            version = "0.3.0";
             src = builtins.path {
               name = "nix-installer-source";
               path = self;

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1-unreleased",
+  "version": "0.3.0",
   "actions": [
     {
       "action": {

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.1-unreleased",
+    "version": "0.3.0",
     "actions": [
       {
         "action": {

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1-unreleased",
+  "version": "0.3.0",
   "actions": [
     {
       "action": {

--- a/tests/windows/test-wsl.ps1
+++ b/tests/windows/test-wsl.ps1
@@ -56,7 +56,7 @@ $MaybeInitChoice = switch ($Systemd) {
     $true { "" }
     $false { "--init none" }
 }
-wsl --distribution $DistroName bash --login -c "/root/.cargo/bin/cargo run --quiet --manifest-path /nix-installer/Cargo.toml -- install linux-multi --no-confirm $MaybeInitChoice"
+wsl --distribution $DistroName bash --login -c "/root/.cargo/bin/cargo run --quiet --manifest-path /nix-installer/Cargo.toml -- install linux --no-confirm $MaybeInitChoice"
 if ($LastExitCode -ne 0) {
     exit $LastExitCode 
 }


### PR DESCRIPTION
##### Description

Cuts v0.3.0.

##### Checklist

- [x] Ran all Qemu tests
- [x] Ran all container tests
- [x] Ran WSL2 tests
- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
