### PR TITLE
Mac support note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 
 The `nix-installer` tool is ready to use in a number of environments:
 
-| Platform                     | Multi User         | `root` only | Maturity          |
-|------------------------------|:------------------:|:-----------:|:-----------------:|
-| Linux (x86_64 & aarch64)     | ✓ (via [systemd])  | ✓           | Stable            |
-| MacOS (x86_64 & aarch64)     | ✓                  |             | Stable (See note) |
-| Valve Steam Deck (SteamOS)   | ✓                  |             | Stable            |
-| WSL2 (x86_64 & aarch64)      | ✓ (via [systemd])  | ✓           | Stable            |
-| Podman Linux Containers      | ✓ (via [systemd])  | ✓           | Stable            |
-| Docker Containers            |                    | ✓           | Stable            |
-| Linux (i686)                 | ✓ (via [systemd])  | ✓           | Unstable          |
+| Platform                     | Multi User         | `root` only | Maturity                 |
+|------------------------------|:------------------:|:-----------:|:------------------------:|
+| Linux (x86_64 & aarch64)     | ✓ (via [systemd])  | ✓           | Stable                   |
+| MacOS (x86_64 & aarch64)     | ✓                  |             | Mostly Stable (See note) |
+| Valve Steam Deck (SteamOS)   | ✓                  |             | Stable                   |
+| WSL2 (x86_64 & aarch64)      | ✓ (via [systemd])  | ✓           | Stable                   |
+| Podman Linux Containers      | ✓ (via [systemd])  | ✓           | Stable                   |
+| Docker Containers            |                    | ✓           | Stable                   |
+| Linux (i686)                 | ✓ (via [systemd])  | ✓           | Unstable                 |
 
-> **MacOS note:** `nix-installer` currently does not support uninstalling users or groups on Macs. See [#33](https://github.com/DeterminateSystems/nix-installer/issues/33) for details or to track the issue.
+> **MacOS note:** `nix-installer` currently does not support uninstalling users or groups on Macs. See [#33](https://github.com/DeterminateSystems/nix-installer/issues/33) for details, to track the issue, or help out!
 
 ## Installation Differences
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 
 The `nix-installer` tool is ready to use in a number of environments:
 
-| Platform                     | Multi User         | `root` only | Maturity |
-|------------------------------|:------------------:|:-----------:|:--------:|
-| Linux (x86_64 & aarch64)     | ✓ (via [systemd])  | ✓           | Stable   |
-| MacOS (x86_64 & aarch64)     | ✓                  |             | Stable   |
-| Valve Steam Deck (SteamOS)   | ✓                  |             | Stable   |
-| WSL2 (x86_64 & aarch64)      | ✓ (via [systemd])  | ✓           | Stable   |
-| Podman Linux Containers      | ✓ (via [systemd])  | ✓           | Stable   |
-| Docker Containers            |                    | ✓           | Stable   |
-| Linux (i686)                 | ✓ (via [systemd])  | ✓           | Unstable |
+| Platform                     | Multi User         | `root` only | Maturity          |
+|------------------------------|:------------------:|:-----------:|:-----------------:|
+| Linux (x86_64 & aarch64)     | ✓ (via [systemd])  | ✓           | Stable            |
+| MacOS (x86_64 & aarch64)     | ✓                  |             | Stable (See note) |
+| Valve Steam Deck (SteamOS)   | ✓                  |             | Stable            |
+| WSL2 (x86_64 & aarch64)      | ✓ (via [systemd])  | ✓           | Stable            |
+| Podman Linux Containers      | ✓ (via [systemd])  | ✓           | Stable            |
+| Docker Containers            |                    | ✓           | Stable            |
+| Linux (i686)                 | ✓ (via [systemd])  | ✓           | Unstable          |
+
+> **MacOS note:** `nix-installer` currently does not support uninstalling users or groups on Macs. See [#33](https://github.com/DeterminateSystems/nix-installer/issues/33) for details or to track the issue.
 
 ## Installation Differences
 


### PR DESCRIPTION
##### Description

Add a note about how Mac support isn't *quite* there yet. Closes #250 .

We had one before, it seems to have been accidentally lost.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
