### PR TITLE
Enable deleting users and groups on Mac

### DIFF
--- a/nix/tests/container-test/default/Dockerfile
+++ b/nix/tests/container-test/default/Dockerfile
@@ -6,3 +6,4 @@ RUN mv /binary-tarball/nix-*.tar.xz nix.tar.xz
 RUN /nix-installer/bin/nix-installer install linux --nix-package-url file:///nix.tar.xz --init none --extra-conf "sandbox = false" --channel --no-confirm -vvv
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 RUN nix-build --no-substitute -E 'derivation { name = "foo"; system = "x86_64-linux"; builder = "/bin/sh"; args = ["-c" "echo foobar > $out"]; }'
+RUN /nix/nix-installer uninstall --no-confirm

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -236,6 +236,9 @@ let
         echo "Testing Nix installation..."
         $ssh "set -eux; $checkScript"
 
+        echo "Testing Nix installation..."
+        $ssh "set -eux; /nix/nix-installer uninstall --no-confirm"
+
         echo "Done!"
         touch $out
       '';

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -85,7 +85,7 @@ impl AddUserToGroup {
                             return Ok(StatefulAction::completed(this));
                         },
                         Some(64) => {
-                            // Group not found
+                            // 64 is the exit code for "Group not found"
                             tracing::trace!(
                                 "Will add user `{}` to newly created group `{}`",
                                 this.name,
@@ -105,8 +105,7 @@ impl AddUserToGroup {
                                     } else {
                                         "".to_string()
                                     },
-                                    String::from_utf8(output.stderr)
-                                        .unwrap_or_else(|_e| String::from("<Non-UTF-8>"))
+                                    String::from_utf8_lossy(&output.stderr),
                                 ),
                             )));
                         },

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -63,7 +63,7 @@ impl AddUserToGroup {
                     patch: _,
                 }
                 | OperatingSystem::Darwin => {
-                    let mut command = Command::new("/usr/bin/dseditgroup");
+                    let mut command = Command::new("/usr/sbin/dseditgroup");
                     command.process_group(0);
                     command.args(["-o", "checkmember", "-m"]);
                     command.arg(&this.name);

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -77,11 +77,20 @@ impl AddUserToGroup {
                         Some(0) => {
                             // yes {user} is a member of {groupname}
                             // Since the user exists, and is already a member of the group, we have truly nothing to do here
-                            tracing::debug!("Creating user `{}` already complete", this.name);
+                            tracing::debug!(
+                                "Adding user `{}` to group `{}` already complete",
+                                this.name,
+                                this.groupname
+                            );
                             return Ok(StatefulAction::completed(this));
                         },
                         Some(64) => {
                             // Group not found
+                            tracing::trace!(
+                                "Will add user `{}` to newly created group `{}`",
+                                this.name,
+                                this.groupname
+                            );
                             // The group will be created by the installer
                             ()
                         },
@@ -90,7 +99,12 @@ impl AddUserToGroup {
                             return Err(ActionError::Command(std::io::Error::new(
                                 std::io::ErrorKind::Other,
                                 format!(
-                                    "Command `{command_str}` failed status, stderr:\n{}\n",
+                                    "Command `{command_str}` failed{}, stderr:\n{}\n",
+                                    if let Some(code) = output.status.code() {
+                                        format!(" status {code}")
+                                    } else {
+                                        "".to_string()
+                                    },
                                     String::from_utf8(output.stderr)
                                         .unwrap_or_else(|_e| String::from("<Non-UTF-8>"))
                                 ),

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -133,16 +133,14 @@ impl Action for CreateGroup {
                 patch: _,
             }
             | OperatingSystem::Darwin => {
-                // TODO(@hoverbear): Make this actually work...
-                // Right now, our test machines do not have a secure token and cannot delete users.
-                // tracing::warn!("`nix-installer` currently cannot delete groups on Mac due to https://github.com/DeterminateSystems/nix-installer/issues/33. This is a no-op, installing with `nix-installer` again will use the existing group.");
-                execute_command(
+                let output = execute_command(
                     Command::new("/usr/bin/dscl")
                         .args([".", "-delete", &format!("/Groups/{name}")])
                         .stdin(std::process::Stdio::null()),
                 )
                 .await
                 .map_err(|e| ActionError::Command(e))?;
+                if !output.status.success() {}
             },
             _ => {
                 execute_command(

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -135,14 +135,14 @@ impl Action for CreateGroup {
             | OperatingSystem::Darwin => {
                 // TODO(@hoverbear): Make this actually work...
                 // Right now, our test machines do not have a secure token and cannot delete users.
-                tracing::warn!("`nix-installer` currently cannot delete groups on Mac due to https://github.com/DeterminateSystems/nix-installer/issues/33. This is a no-op, installing with `nix-installer` again will use the existing group.");
-                // execute_command(Command::new("/usr/bin/dscl").args([
-                //     ".",
-                //     "-delete",
-                //     &format!("/Groups/{name}"),
-                // ]).stdin(std::process::Stdio::null()))
-                // .await
-                // .map_err(|e| CreateGroupError::Command(e).boxed())?;
+                // tracing::warn!("`nix-installer` currently cannot delete groups on Mac due to https://github.com/DeterminateSystems/nix-installer/issues/33. This is a no-op, installing with `nix-installer` again will use the existing group.");
+                execute_command(
+                    Command::new("/usr/bin/dscl")
+                        .args([".", "-delete", &format!("/Groups/{name}")])
+                        .stdin(std::process::Stdio::null()),
+                )
+                .await
+                .map_err(|e| ActionError::Command(e))?;
             },
             _ => {
                 execute_command(

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -269,16 +269,15 @@ impl Action for CreateUser {
                 patch: _,
             }
             | OperatingSystem::Darwin => {
-                // TODO(@hoverbear): Make this actually work...
-                // Right now, our test machines do not have a secure token and cannot delete users.
-                tracing::warn!("`nix-installer` currently cannot delete groups on Mac due to https://github.com/DeterminateSystems/nix-installer/issues/33. This is a no-op, installing with `nix-installer` again will use the existing user.");
-                // execute_command(Command::new("/usr/bin/dscl").args([
-                //     ".",
-                //     "-delete",
-                //     &format!("/Users/{name}"),
-                // ]).stdin(std::process::Stdio::null()))
-                // .await
-                // .map_err(|e| CreateUserError::Command(e).boxed())?;
+                // TODO: Some automated test machines do not have a secure token and cannot delete users.
+                // tracing::warn!("`nix-installer` currently cannot delete groups on Mac due to https://github.com/DeterminateSystems/nix-installer/issues/33. This is a no-op, installing with `nix-installer` again will use the existing user.");
+                execute_command(
+                    Command::new("/usr/bin/dscl")
+                        .args([".", "-delete", &format!("/Users/{name}")])
+                        .stdin(std::process::Stdio::null()),
+                )
+                .await
+                .map_err(|e| ActionError::Command(e))?;
             },
             _ => {
                 execute_command(

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -63,7 +63,7 @@ impl CreateUser {
                     patch: _,
                 }
                 | OperatingSystem::Darwin => {
-                    let mut command = Command::new("/usr/bin/dseditgroup");
+                    let mut command = Command::new("/usr/sbin/dseditgroup");
                     command.process_group(0);
                     command.args(["-o", "checkmember", "-m"]);
                     command.arg(&this.name);

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -252,7 +252,7 @@ impl Action for CreateUser {
                     .output()
                     .await
                     .map_err(|e| ActionError::Command(e))?;
-                let stderr = String::from_utf8(output.stderr)?;
+                let stderr = String::from_utf8_lossy(&output.stderr);
                 match output.status.code() {
                     Some(0) => (),
                     Some(40) if stderr.contains("-14120") => {

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -258,7 +258,7 @@ impl Action for CreateUser {
                     Some(40) if stderr.contains("-14120") => {
                         // The user is on an ephemeral Mac, like detsys uses
                         // These Macs cannot always delete users, as sometimes there is no graphical login
-                        tracing::warn!("Encountered an exit code 40 with -14120 error while removing user, this is likely because the initial executing user did not have a secure token, or that there was no graphical login session. To delete the user, log in graphically, then in a shell (which may be over ssh) run `/usr/bin/dscl . -delete /Users/{name}");
+                        tracing::warn!("Encountered an exit code 40 with -14120 error while removing user, this is likely because the initial executing user did not have a secure token, or that there was no graphical login session. To delete the user, log in graphically, then run `/usr/bin/dscl . -delete /Users/{name}");
                     },
                     status => {
                         let command_str = format!("{:?}", command.as_std());

--- a/src/action/base/mod.rs
+++ b/src/action/base/mod.rs
@@ -1,5 +1,6 @@
 //! Base [`Action`](crate::action::Action)s that themselves have no other actions as dependencies
 
+pub(crate) mod add_user_to_group;
 pub(crate) mod create_directory;
 pub(crate) mod create_file;
 pub(crate) mod create_group;
@@ -9,6 +10,7 @@ pub(crate) mod fetch_and_unpack_nix;
 pub(crate) mod move_unpacked_nix;
 pub(crate) mod setup_default_profile;
 
+pub use add_user_to_group::AddUserToGroup;
 pub use create_directory::CreateDirectory;
 pub use create_file::CreateFile;
 pub use create_group::CreateGroup;

--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -157,8 +157,7 @@ impl Action for SetupDefaultProfile {
                         } else {
                             "".to_string()
                         },
-                        String::from_utf8(output.stderr)
-                            .unwrap_or_else(|_e| String::from("<Non-UTF-8>"))
+                        String::from_utf8_lossy(&output.stderr)
                     ),
                 )));
             };

--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -151,7 +151,12 @@ impl Action for SetupDefaultProfile {
                 return Err(ActionError::Command(std::io::Error::new(
                     std::io::ErrorKind::Other,
                     format!(
-                        "Command `{load_db_command_str}` failed status, stderr:\n{}\n",
+                        "Command `{load_db_command_str}` failed{}, stderr:\n{}\n",
+                        if let Some(code) = output.status.code() {
+                            format!(" status {code}")
+                        } else {
+                            "".to_string()
+                        },
                         String::from_utf8(output.stderr)
                             .unwrap_or_else(|_e| String::from("<Non-UTF-8>"))
                     ),

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -1,6 +1,6 @@
 use crate::{
     action::{
-        base::{CreateGroup, CreateUser},
+        base::{AddUserToGroup, CreateGroup, CreateUser},
         Action, ActionDescription, ActionError, StatefulAction,
     },
     settings::CommonSettings,
@@ -17,6 +17,7 @@ pub struct CreateUsersAndGroups {
     nix_build_user_id_base: u32,
     create_group: StatefulAction<CreateGroup>,
     create_users: Vec<StatefulAction<CreateUser>>,
+    add_users_to_groups: Vec<StatefulAction<AddUserToGroup>>,
 }
 
 impl CreateUsersAndGroups {
@@ -26,16 +27,28 @@ impl CreateUsersAndGroups {
             settings.nix_build_group_name.clone(),
             settings.nix_build_group_id,
         )?;
-        let create_users = (0..settings.nix_build_user_count)
-            .map(|count| {
+        let mut create_users = Vec::with_capacity(settings.nix_build_user_count as usize);
+        let mut add_users_to_groups = Vec::with_capacity(settings.nix_build_user_count as usize);
+        for index in 0..settings.nix_build_user_count {
+            create_users.push(
                 CreateUser::plan(
-                    format!("{}{count}", settings.nix_build_user_prefix),
-                    settings.nix_build_user_id_base + count,
+                    format!("{}{index}", settings.nix_build_user_prefix),
+                    settings.nix_build_user_id_base + index,
                     settings.nix_build_group_name.clone(),
                     settings.nix_build_group_id,
                 )
-            })
-            .collect::<Result<_, _>>()?;
+                .await?,
+            );
+            add_users_to_groups.push(
+                AddUserToGroup::plan(
+                    format!("{}{index}", settings.nix_build_user_prefix),
+                    settings.nix_build_user_id_base + index,
+                    settings.nix_build_group_name.clone(),
+                    settings.nix_build_group_id,
+                )
+                .await?,
+            );
+        }
         Ok(Self {
             nix_build_user_count: settings.nix_build_user_count,
             nix_build_group_name: settings.nix_build_group_name,
@@ -44,6 +57,7 @@ impl CreateUsersAndGroups {
             nix_build_user_id_base: settings.nix_build_user_id_base,
             create_group,
             create_users,
+            add_users_to_groups,
         }
         .into())
     }
@@ -82,12 +96,20 @@ impl Action for CreateUsersAndGroups {
             nix_build_user_id_base: _,
             create_group,
             create_users,
+            add_users_to_groups,
         } = &self;
 
         let mut create_users_descriptions = Vec::new();
         for create_user in create_users {
             if let Some(val) = create_user.describe_execute().iter().next() {
                 create_users_descriptions.push(val.description.clone())
+            }
+        }
+
+        let mut add_user_to_group_descriptions = Vec::new();
+        for add_user_to_group in add_users_to_groups {
+            if let Some(val) = add_user_to_group.describe_execute().iter().next() {
+                add_user_to_group_descriptions.push(val.description.clone())
             }
         }
 
@@ -98,6 +120,7 @@ impl Action for CreateUsersAndGroups {
             explanation.push(val.description.clone())
         }
         explanation.append(&mut create_users_descriptions);
+        explanation.append(&mut add_user_to_group_descriptions);
 
         vec![ActionDescription::new(self.tracing_synopsis(), explanation)]
     }
@@ -107,6 +130,7 @@ impl Action for CreateUsersAndGroups {
         let Self {
             create_users,
             create_group,
+            add_users_to_groups,
             nix_build_user_count: _,
             nix_build_group_name: _,
             nix_build_group_id: _,
@@ -160,6 +184,10 @@ impl Action for CreateUsersAndGroups {
             },
         };
 
+        for add_user_to_group in add_users_to_groups.iter_mut() {
+            add_user_to_group.try_execute().await?;
+        }
+
         Ok(())
     }
 
@@ -172,11 +200,19 @@ impl Action for CreateUsersAndGroups {
             nix_build_user_id_base: _,
             create_group,
             create_users,
+            add_users_to_groups,
         } = &self;
         let mut create_users_descriptions = Vec::new();
         for create_user in create_users {
             if let Some(val) = create_user.describe_revert().iter().next() {
                 create_users_descriptions.push(val.description.clone())
+            }
+        }
+
+        let mut add_user_to_group_descriptions = Vec::new();
+        for add_user_to_group in add_users_to_groups {
+            if let Some(val) = add_user_to_group.describe_revert().iter().next() {
+                add_user_to_group_descriptions.push(val.description.clone())
             }
         }
 
@@ -187,6 +223,7 @@ impl Action for CreateUsersAndGroups {
             explanation.push(val.description.clone())
         }
         explanation.append(&mut create_users_descriptions);
+        explanation.append(&mut add_user_to_group_descriptions);
 
         vec![ActionDescription::new(
             format!("Remove Nix users and group"),
@@ -199,6 +236,7 @@ impl Action for CreateUsersAndGroups {
         let Self {
             create_users,
             create_group,
+            add_users_to_groups: _,
             nix_build_user_count: _,
             nix_build_group_name: _,
             nix_build_group_id: _,
@@ -233,6 +271,11 @@ impl Action for CreateUsersAndGroups {
                 return Err(ActionError::Children(errors));
             }
         }
+
+        // We don't actually need to do this, when a user is deleted they are removed from groups
+        // for add_user_to_group in add_users_to_groups.iter_mut() {
+        //     add_user_to_group.try_revert().await?;
+        // }
 
         // Create group
         create_group.try_revert().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ async fn execute_command(command: &mut Command) -> Result<Output, std::io::Error
                 } else {
                     "".to_string()
                 },
-                String::from_utf8(output.stderr).unwrap_or_else(|_e| String::from("<Non-UTF-8>"))
+                String::from_utf8_lossy(&output.stderr)
             ),
         )),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,12 @@ async fn execute_command(command: &mut Command) -> Result<Output, std::io::Error
         false => Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             format!(
-                "Command `{command_str}` failed status, stderr:\n{}\n",
+                "Command `{command_str}` failed{}, stderr:\n{}\n",
+                if let Some(code) = output.status.code() {
+                    format!(" status {code}")
+                } else {
+                    "".to_string()
+                },
                 String::from_utf8(output.stderr).unwrap_or_else(|_e| String::from("<Non-UTF-8>"))
             ),
         )),

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -325,6 +325,296 @@
                 },
                 "state": "Uncompleted"
               }
+            ],
+            "add_users_to_groups": [
+              {
+                "action": {
+                  "name": "nixbld0",
+                  "uid": 3000,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld1",
+                  "uid": 3001,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld2",
+                  "uid": 3002,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld3",
+                  "uid": 3003,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld4",
+                  "uid": 3004,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld5",
+                  "uid": 3005,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld6",
+                  "uid": 3006,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld7",
+                  "uid": 3007,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld8",
+                  "uid": 3008,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld9",
+                  "uid": 3009,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld10",
+                  "uid": 3010,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld11",
+                  "uid": 3011,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld12",
+                  "uid": 3012,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld13",
+                  "uid": 3013,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld14",
+                  "uid": 3014,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld15",
+                  "uid": 3015,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld16",
+                  "uid": 3016,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld17",
+                  "uid": 3017,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld18",
+                  "uid": 3018,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld19",
+                  "uid": 3019,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld20",
+                  "uid": 3020,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld21",
+                  "uid": 3021,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld22",
+                  "uid": 3022,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld23",
+                  "uid": 3023,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld24",
+                  "uid": 3024,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld25",
+                  "uid": 3025,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld26",
+                  "uid": 3026,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld27",
+                  "uid": 3027,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld28",
+                  "uid": 3028,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld29",
+                  "uid": 3029,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld30",
+                  "uid": 3030,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld31",
+                  "uid": 3031,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              }
             ]
           },
           "state": "Uncompleted"

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,617 +1,630 @@
 {
-    "version": "0.3.0",
-    "actions": [
-      {
-        "action": {
-          "action": "create_directory",
-          "path": "/home/nix",
-          "user": null,
-          "group": null,
-          "mode": 493,
-          "force_prune_on_revert": true
-        },
-        "state": "Uncompleted"
+  "version": "0.3.0",
+  "actions": [
+    {
+      "action": {
+        "action": "create_directory",
+        "path": "/nix",
+        "user": null,
+        "group": null,
+        "mode": 493,
+        "force_prune_on_revert": true
       },
-      {
-        "action": {
-          "action": "create_file",
-          "path": "/etc/systemd/system/nix-directory.service",
-          "user": null,
-          "group": null,
-          "mode": 420,
-          "buf": "[Unit]\nDescription=Create a `/nix` directory to be used for bind mounting\nPropagatesStopTo=nix-daemon.service\nPropagatesStopTo=nix.mount\nDefaultDependencies=no\nAfter=grub-recordfail.service\nAfter=steamos-finish-oobe-migration.service\n\n[Service]\nType=oneshot\nExecStart=steamos-readonly disable\nExecStart=mkdir -vp /nix\nExecStart=chmod -v 0755 /nix\nExecStart=chown -v root /nix\nExecStart=chgrp -v root /nix\nExecStart=steamos-readonly enable\nExecStop=steamos-readonly disable\nExecStop=rmdir /nix\nExecStop=steamos-readonly enable\nRemainAfterExit=true\n",
-          "force": false
-        },
-        "state": "Uncompleted"
-      },
-      {
-        "action": {
-          "action": "create_file",
-          "path": "/etc/systemd/system/nix.mount",
-          "user": null,
-          "group": null,
-          "mode": 420,
-          "buf": "[Unit]\nDescription=Mount `/home/nix` on `/nix`\nPropagatesStopTo=nix-daemon.service\nPropagatesStopTo=nix-directory.service\nAfter=nix-directory.service\nRequires=nix-directory.service\nConditionPathIsDirectory=/nix\nDefaultDependencies=no\n\n[Mount]\nWhat=/home/nix\nWhere=/nix\nType=none\nDirectoryMode=0755\nOptions=bind\n",
-          "force": false
-        },
-        "state": "Uncompleted"
-      },
-      {
-        "action": {
-          "action": "create_file",
-          "path": "/etc/systemd/system/ensure-symlinked-units-resolve.service",
-          "user": null,
-          "group": null,
-          "mode": 420,
-          "buf": "[Unit]\nDescription=Ensure Nix related units which are symlinked resolve\nAfter=nix.mount\nRequires=nix-directory.service\nRequires=nix.mount\nPropagatesStopTo=nix-directory.service\nPropagatesStopTo=nix.mount\nDefaultDependencies=no\n\n[Service]\nType=oneshot\nRemainAfterExit=yes\nExecStart=/usr/bin/systemctl daemon-reload\nExecStart=/usr/bin/systemctl restart --no-block sockets.target timers.target multi-user.target\n\n[Install]\nWantedBy=sysinit.target\n",
-          "force": false
-        },
-        "state": "Uncompleted"
-      },
-      {
-        "action": {
-          "action": "start_systemd_unit",
-          "unit": "ensure-symlinked-units-resolve.service",
-          "enable": true
-        },
-        "state": "Uncompleted"
-      },
-      {
-        "action": {
-          "action": "provision_nix",
-          "fetch_nix": {
-            "action": {
-              "url": "https://releases.nixos.org/nix/nix-2.12.0/nix-2.12.0-x86_64-linux.tar.xz",
-              "dest": "/nix/temp-install-dir"
-            },
-            "state": "Uncompleted"
+      "state": "Uncompleted"
+    },
+    {
+      "action": {
+        "action": "provision_nix",
+        "fetch_nix": {
+          "action": {
+            "url": "https://releases.nixos.org/nix/nix-2.13.2/nix-2.13.2-x86_64-linux.tar.xz",
+            "dest": "/nix/temp-install-dir"
           },
-          "create_users_and_group": {
-            "action": {
-              "nix_build_user_count": 32,
-              "nix_build_group_name": "nixbld",
-              "nix_build_group_id": 3000,
-              "nix_build_user_prefix": "nixbld",
-              "nix_build_user_id_base": 3000,
-              "create_group": {
+          "state": "Uncompleted"
+        },
+        "create_users_and_group": {
+          "action": {
+            "nix_build_user_count": 32,
+            "nix_build_group_name": "nixbld",
+            "nix_build_group_id": 3000,
+            "nix_build_user_prefix": "nixbld",
+            "nix_build_user_id_base": 3000,
+            "create_group": {
+              "action": {
+                "name": "nixbld",
+                "gid": 3000
+              },
+              "state": "Uncompleted"
+            },
+            "create_users": [
+              {
                 "action": {
-                  "name": "nixbld",
+                  "name": "nixbld0",
+                  "uid": 3000,
+                  "groupname": "nixbld",
                   "gid": 3000
                 },
                 "state": "Uncompleted"
               },
-              "create_users": [
-                {
-                  "action": {
-                    "name": "nixbld0",
-                    "uid": 3000,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld1",
-                    "uid": 3001,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld2",
-                    "uid": 3002,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld3",
-                    "uid": 3003,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld4",
-                    "uid": 3004,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld5",
-                    "uid": 3005,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld6",
-                    "uid": 3006,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld7",
-                    "uid": 3007,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld8",
-                    "uid": 3008,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld9",
-                    "uid": 3009,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld10",
-                    "uid": 3010,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld11",
-                    "uid": 3011,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld12",
-                    "uid": 3012,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld13",
-                    "uid": 3013,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld14",
-                    "uid": 3014,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld15",
-                    "uid": 3015,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld16",
-                    "uid": 3016,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld17",
-                    "uid": 3017,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld18",
-                    "uid": 3018,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld19",
-                    "uid": 3019,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld20",
-                    "uid": 3020,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld21",
-                    "uid": 3021,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld22",
-                    "uid": 3022,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld23",
-                    "uid": 3023,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld24",
-                    "uid": 3024,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld25",
-                    "uid": 3025,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld26",
-                    "uid": 3026,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld27",
-                    "uid": 3027,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld28",
-                    "uid": 3028,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld29",
-                    "uid": 3029,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld30",
-                    "uid": 3030,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "name": "nixbld31",
-                    "uid": 3031,
-                    "groupname": "nixbld",
-                    "gid": 3000
-                  },
-                  "state": "Uncompleted"
-                }
-              ]
-            },
-            "state": "Uncompleted"
-          },
-          "create_nix_tree": {
-            "action": {
-              "create_directories": [
-                {
-                  "action": {
-                    "path": "/nix/var",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/log",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/log/nix",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/log/nix/drvs",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix/db",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix/gcroots",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix/gcroots/per-user",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix/profiles",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix/profiles/per-user",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix/temproots",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix/userpool",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/nix/var/nix/daemon-socket",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "force_prune_on_revert": false
-                  },
-                  "state": "Uncompleted"
-                }
-              ]
-            },
-            "state": "Uncompleted"
-          },
-          "move_unpacked_nix": {
-            "action": {
-              "src": "/nix/temp-install-dir"
-            },
-            "state": "Uncompleted"
-          }
-        },
-        "state": "Uncompleted"
-      },
-      {
-        "action": {
-          "action": "configure_nix",
-          "setup_default_profile": {
-            "action": {
-              "channels": [
-                [
-                  "nixpkgs",
-                  "https://nixos.org/channels/nixpkgs-unstable"
-                ]
-              ]
-            },
-            "state": "Uncompleted"
-          },
-          "configure_shell_profile": {
-            "action": {
-              "create_directories": [],
-              "create_or_insert_into_files": [
-                {
-                  "action": {
-                    "path": "/etc/bashrc",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
-                    "position": "Beginning"
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/etc/profile.d/nix.sh",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
-                    "position": "Beginning"
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/etc/zshenv",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
-                    "position": "Beginning"
-                  },
-                  "state": "Uncompleted"
-                },
-                {
-                  "action": {
-                    "path": "/etc/bash.bashrc",
-                    "user": null,
-                    "group": null,
-                    "mode": 493,
-                    "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
-                    "position": "Beginning"
-                  },
-                  "state": "Uncompleted"
-                }
-              ]
-            },
-            "state": "Uncompleted"
-          },
-          "place_channel_configuration": {
-            "action": {
-              "channels": [
-                [
-                  "nixpkgs",
-                  "https://nixos.org/channels/nixpkgs-unstable"
-                ]
-              ],
-              "create_file": {
+              {
                 "action": {
-                  "path": "/home/ana/.nix-channels",
-                  "user": null,
-                  "group": null,
-                  "mode": 436,
-                  "buf": "https://nixos.org/channels/nixpkgs-unstable nixpkgs",
-                  "force": false
+                  "name": "nixbld1",
+                  "uid": 3001,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld2",
+                  "uid": 3002,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld3",
+                  "uid": 3003,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld4",
+                  "uid": 3004,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld5",
+                  "uid": 3005,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld6",
+                  "uid": 3006,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld7",
+                  "uid": 3007,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld8",
+                  "uid": 3008,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld9",
+                  "uid": 3009,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld10",
+                  "uid": 3010,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld11",
+                  "uid": 3011,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld12",
+                  "uid": 3012,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld13",
+                  "uid": 3013,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld14",
+                  "uid": 3014,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld15",
+                  "uid": 3015,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld16",
+                  "uid": 3016,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld17",
+                  "uid": 3017,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld18",
+                  "uid": 3018,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld19",
+                  "uid": 3019,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld20",
+                  "uid": 3020,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld21",
+                  "uid": 3021,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld22",
+                  "uid": 3022,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld23",
+                  "uid": 3023,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld24",
+                  "uid": 3024,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld25",
+                  "uid": 3025,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld26",
+                  "uid": 3026,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld27",
+                  "uid": 3027,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld28",
+                  "uid": 3028,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld29",
+                  "uid": 3029,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld30",
+                  "uid": 3030,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld31",
+                  "uid": 3031,
+                  "groupname": "nixbld",
+                  "gid": 3000
                 },
                 "state": "Uncompleted"
               }
-            },
-            "state": "Uncompleted"
-          },
-          "place_nix_configuration": {
-            "action": {
-              "create_directory": {
+            ],
+            "add_users_to_groups": [
+              {
                 "action": {
-                  "path": "/etc/nix",
+                  "name": "nixbld0",
+                  "uid": 3000,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld1",
+                  "uid": 3001,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld2",
+                  "uid": 3002,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld3",
+                  "uid": 3003,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld4",
+                  "uid": 3004,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld5",
+                  "uid": 3005,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld6",
+                  "uid": 3006,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld7",
+                  "uid": 3007,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld8",
+                  "uid": 3008,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld9",
+                  "uid": 3009,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld10",
+                  "uid": 3010,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld11",
+                  "uid": 3011,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld12",
+                  "uid": 3012,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld13",
+                  "uid": 3013,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld14",
+                  "uid": 3014,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld15",
+                  "uid": 3015,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld16",
+                  "uid": 3016,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld17",
+                  "uid": 3017,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld18",
+                  "uid": 3018,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld19",
+                  "uid": 3019,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld20",
+                  "uid": 3020,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld21",
+                  "uid": 3021,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld22",
+                  "uid": 3022,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld23",
+                  "uid": 3023,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld24",
+                  "uid": 3024,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld25",
+                  "uid": 3025,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld26",
+                  "uid": 3026,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld27",
+                  "uid": 3027,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld28",
+                  "uid": 3028,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld29",
+                  "uid": 3029,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld30",
+                  "uid": 3030,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "nixbld31",
+                  "uid": 3031,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              }
+            ]
+          },
+          "state": "Uncompleted"
+        },
+        "create_nix_tree": {
+          "action": {
+            "create_directories": [
+              {
+                "action": {
+                  "path": "/nix/var",
                   "user": null,
                   "group": null,
                   "mode": 493,
@@ -619,51 +632,309 @@
                 },
                 "state": "Uncompleted"
               },
-              "create_file": {
+              {
                 "action": {
-                  "path": "/etc/nix/nix.conf",
+                  "path": "/nix/var/log",
                   "user": null,
                   "group": null,
-                  "mode": 436,
-                  "buf": "# Generated by https://github.com/DeterminateSystems/nix-installer, version 0.1.0-unreleased.\n\n\n\nbuild-users-group = nixbld\n\nexperimental-features = nix-command flakes\n\nauto-optimise-store = true\n\nbash-prompt-prefix = (nix:$name)\\040\n",
-                  "force": false
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/log/nix",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/log/nix/drvs",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix/db",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix/gcroots",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix/gcroots/per-user",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix/profiles",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix/profiles/per-user",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix/temproots",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix/userpool",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/nix/var/nix/daemon-socket",
+                  "user": null,
+                  "group": null,
+                  "mode": 493,
+                  "force_prune_on_revert": false
                 },
                 "state": "Uncompleted"
               }
-            },
-            "state": "Uncompleted"
-          }
+            ]
+          },
+          "state": "Uncompleted"
         },
-        "state": "Uncompleted"
+        "move_unpacked_nix": {
+          "action": {
+            "src": "/nix/temp-install-dir"
+          },
+          "state": "Uncompleted"
+        }
       },
-      {
-        "action": {
-          "action": "configure_nix_daemon",
-          "init": "Systemd",
-          "start_daemon": true
+      "state": "Uncompleted"
+    },
+    {
+      "action": {
+        "action": "configure_nix",
+        "setup_default_profile": {
+          "action": {
+            "channels": [
+              [
+                "nixpkgs",
+                "https://nixos.org/channels/nixpkgs-unstable"
+              ]
+            ]
+          },
+          "state": "Uncompleted"
         },
-        "state": "Uncompleted"
-      }
-    ],
-    "planner": {
-      "planner": "steam-deck",
-      "persistence": "/home/nix",
-      "settings": {
-        "channels": [
-          [
-            "nixpkgs",
-            "https://nixos.org/channels/nixpkgs-unstable"
-          ]
-        ],
-        "modify_profile": true,
-        "nix_build_user_count": 32,
-        "nix_build_group_name": "nixbld",
-        "nix_build_group_id": 3000,
-        "nix_build_user_prefix": "nixbld",
-        "nix_build_user_id_base": 3000,
-        "nix_package_url": "https://releases.nixos.org/nix/nix-2.12.0/nix-2.12.0-x86_64-linux.tar.xz",
-        "extra_conf": [],
-        "force": false
-      }
+        "configure_shell_profile": {
+          "action": {
+            "create_directories": [
+              {
+                "action": {
+                  "path": "/etc/fish/conf.d",
+                  "user": null,
+                  "group": null,
+                  "mode": 420,
+                  "force_prune_on_revert": false
+                },
+                "state": "Skipped"
+              }
+            ],
+            "create_or_insert_into_files": [
+              {
+                "action": {
+                  "path": "/etc/bashrc",
+                  "user": null,
+                  "group": null,
+                  "mode": 33188,
+                  "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
+                  "position": "Beginning"
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/etc/profile.d/nix.sh",
+                  "user": null,
+                  "group": null,
+                  "mode": 33188,
+                  "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
+                  "position": "Beginning"
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/etc/zshenv",
+                  "user": null,
+                  "group": null,
+                  "mode": 33188,
+                  "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
+                  "position": "Beginning"
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/etc/bash.bashrc",
+                  "user": null,
+                  "group": null,
+                  "mode": 33188,
+                  "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
+                  "position": "Beginning"
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "path": "/etc/fish/conf.d/nix.fish",
+                  "user": null,
+                  "group": null,
+                  "mode": 33188,
+                  "buf": "\n# Nix\nif test -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.fish'\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.fish'\nend\n# End Nix\n\n",
+                  "position": "Beginning"
+                },
+                "state": "Uncompleted"
+              }
+            ]
+          },
+          "state": "Uncompleted"
+        },
+        "place_channel_configuration": {
+          "action": {
+            "channels": [
+              [
+                "nixpkgs",
+                "https://nixos.org/channels/nixpkgs-unstable"
+              ]
+            ],
+            "create_file": {
+              "action": {
+                "path": "/home/deck/.nix-channels",
+                "user": null,
+                "group": null,
+                "mode": 436,
+                "buf": "https://nixos.org/channels/nixpkgs-unstable nixpkgs",
+                "force": false
+              },
+              "state": "Uncompleted"
+            }
+          },
+          "state": "Uncompleted"
+        },
+        "place_nix_configuration": {
+          "action": {
+            "create_directory": {
+              "action": {
+                "path": "/etc/nix",
+                "user": null,
+                "group": null,
+                "mode": 493,
+                "force_prune_on_revert": false
+              },
+              "state": "Uncompleted"
+            },
+            "create_file": {
+              "action": {
+                "path": "/etc/nix/nix.conf",
+                "user": null,
+                "group": null,
+                "mode": 436,
+                "buf": "# Generated by https://github.com/DeterminateSystems/nix-installer, version 0.3.0.\n\n\n\nbuild-users-group = nixbld\n\nexperimental-features = nix-command flakes\n\nauto-optimise-store = true\n\nbash-prompt-prefix = (nix:$name)\\040\n",
+                "force": false
+              },
+              "state": "Uncompleted"
+            }
+          },
+          "state": "Uncompleted"
+        }
+      },
+      "state": "Uncompleted"
+    },
+    {
+      "action": {
+        "action": "configure_nix_daemon",
+        "init": "Systemd",
+        "start_daemon": true
+      },
+      "state": "Uncompleted"
+    }
+  ],
+  "planner": {
+    "planner": "linux",
+    "settings": {
+      "channels": [
+        [
+          "nixpkgs",
+          "https://nixos.org/channels/nixpkgs-unstable"
+        ]
+      ],
+      "modify_profile": true,
+      "nix_build_user_count": 32,
+      "nix_build_group_name": "nixbld",
+      "nix_build_group_id": 3000,
+      "nix_build_user_prefix": "nixbld",
+      "nix_build_user_id_base": 3000,
+      "nix_package_url": "https://releases.nixos.org/nix/nix-2.13.2/nix-2.13.2-x86_64-linux.tar.xz",
+      "extra_conf": [],
+      "force": false
+    },
+    "init": {
+      "init": "Systemd",
+      "start_daemon": true
     }
   }
+}

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -13,7 +13,7 @@
             "path": "/etc/synthetic.conf",
             "user": null,
             "group": null,
-            "mode": 429,
+            "mode": null,
             "buf": "nix\n",
             "position": "End"
           },
@@ -82,7 +82,7 @@
         "action": "provision_nix",
         "fetch_nix": {
           "action": {
-            "url": "https://releases.nixos.org/nix/nix-2.12.0/nix-2.12.0-aarch64-darwin.tar.xz",
+            "url": "https://releases.nixos.org/nix/nix-2.13.2/nix-2.13.2-aarch64-darwin.tar.xz",
             "dest": "/nix/temp-install-dir"
           },
           "state": "Uncompleted"
@@ -102,6 +102,296 @@
               "state": "Uncompleted"
             },
             "create_users": [
+              {
+                "action": {
+                  "name": "_nixbld0",
+                  "uid": 300,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld1",
+                  "uid": 301,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld2",
+                  "uid": 302,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld3",
+                  "uid": 303,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld4",
+                  "uid": 304,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld5",
+                  "uid": 305,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld6",
+                  "uid": 306,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld7",
+                  "uid": 307,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld8",
+                  "uid": 308,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld9",
+                  "uid": 309,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld10",
+                  "uid": 310,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld11",
+                  "uid": 311,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld12",
+                  "uid": 312,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld13",
+                  "uid": 313,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld14",
+                  "uid": 314,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld15",
+                  "uid": 315,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld16",
+                  "uid": 316,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld17",
+                  "uid": 317,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld18",
+                  "uid": 318,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld19",
+                  "uid": 319,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld20",
+                  "uid": 320,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld21",
+                  "uid": 321,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld22",
+                  "uid": 322,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld23",
+                  "uid": 323,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld24",
+                  "uid": 324,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld25",
+                  "uid": 325,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld26",
+                  "uid": 326,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld27",
+                  "uid": 327,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld28",
+                  "uid": 328,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld29",
+                  "uid": 329,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld30",
+                  "uid": 330,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
+                  "name": "_nixbld31",
+                  "uid": 331,
+                  "groupname": "nixbld",
+                  "gid": 3000
+                },
+                "state": "Uncompleted"
+              }
+            ],
+            "add_users_to_groups": [
               {
                 "action": {
                   "name": "_nixbld0",
@@ -563,7 +853,7 @@
                   "path": "/etc/bashrc",
                   "user": null,
                   "group": null,
-                  "mode": 493,
+                  "mode": 33060,
                   "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
                   "position": "Beginning"
                 },
@@ -574,7 +864,7 @@
                   "path": "/etc/zshenv",
                   "user": null,
                   "group": null,
-                  "mode": 493,
+                  "mode": 33060,
                   "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
                   "position": "Beginning"
                 },
@@ -585,7 +875,7 @@
                   "path": "/etc/bash.bashrc",
                   "user": null,
                   "group": null,
-                  "mode": 493,
+                  "mode": 33060,
                   "buf": "\n# Nix\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n\n        \n",
                   "position": "Beginning"
                 },
@@ -635,7 +925,7 @@
                 "user": null,
                 "group": null,
                 "mode": 436,
-                "buf": "# Generated by https://github.com/DeterminateSystems/nix-installer, version 0.1.0-unreleased.\n\n\n\nbuild-users-group = nixbld\n\nexperimental-features = nix-command flakes\n\nauto-optimise-store = true\n\nbash-prompt-prefix = (nix:$name)\\040\n",
+                "buf": "# Generated by https://github.com/DeterminateSystems/nix-installer, version 0.3.0.\n\n\n\nbuild-users-group = nixbld\n\nexperimental-features = nix-command flakes\n\nauto-optimise-store = true\n\nbash-prompt-prefix = (nix:$name)\\040\n",
                 "force": false
               },
               "state": "Uncompleted"
@@ -670,7 +960,7 @@
       "nix_build_group_id": 3000,
       "nix_build_user_prefix": "_nixbld",
       "nix_build_user_id_base": 300,
-      "nix_package_url": "https://releases.nixos.org/nix/nix-2.12.0/nix-2.12.0-aarch64-darwin.tar.xz",
+      "nix_package_url": "https://releases.nixos.org/nix/nix-2.13.2/nix-2.13.2-aarch64-darwin.tar.xz",
       "extra_conf": [],
       "force": false
     },

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -7,29 +7,29 @@ const STEAM_DECK: &str = include_str!("./fixtures/linux/steam-deck.json");
 #[cfg(target_os = "macos")]
 const MACOS: &str = include_str!("./fixtures/macos/macos.json");
 
-// Ensure existing plans still parse
-// If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
-#[cfg(target_os = "linux")]
-#[test]
-fn plan_compat_linux() -> eyre::Result<()> {
-    let _: InstallPlan = serde_json::from_str(LINUX)?;
-    Ok(())
-}
+// // Ensure existing plans still parse
+// // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
+// #[cfg(target_os = "linux")]
+// #[test]
+// fn plan_compat_linux() -> eyre::Result<()> {
+//     let _: InstallPlan = serde_json::from_str(LINUX)?;
+//     Ok(())
+// }
 
-// Ensure existing plans still parse
-// If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
-#[cfg(target_os = "linux")]
-#[test]
-fn plan_compat_steam_deck() -> eyre::Result<()> {
-    let _: InstallPlan = serde_json::from_str(STEAM_DECK)?;
-    Ok(())
-}
+// // Ensure existing plans still parse
+// // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
+// #[cfg(target_os = "linux")]
+// #[test]
+// fn plan_compat_steam_deck() -> eyre::Result<()> {
+//     let _: InstallPlan = serde_json::from_str(STEAM_DECK)?;
+//     Ok(())
+// }
 
-// Ensure existing plans still parse
-// If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
-#[cfg(target_os = "macos")]
-#[test]
-fn plan_compat_macos() -> eyre::Result<()> {
-    let _: InstallPlan = serde_json::from_str(MACOS)?;
-    Ok(())
-}
+// // Ensure existing plans still parse
+// // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
+// #[cfg(target_os = "macos")]
+// #[test]
+// fn plan_compat_macos() -> eyre::Result<()> {
+//     let _: InstallPlan = serde_json::from_str(MACOS)?;
+//     Ok(())
+// }

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -7,29 +7,29 @@ const STEAM_DECK: &str = include_str!("./fixtures/linux/steam-deck.json");
 #[cfg(target_os = "macos")]
 const MACOS: &str = include_str!("./fixtures/macos/macos.json");
 
-// // Ensure existing plans still parse
-// // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
-// #[cfg(target_os = "linux")]
-// #[test]
-// fn plan_compat_linux() -> eyre::Result<()> {
-//     let _: InstallPlan = serde_json::from_str(LINUX)?;
-//     Ok(())
-// }
+// Ensure existing plans still parse
+// If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
+#[cfg(target_os = "linux")]
+#[test]
+fn plan_compat_linux() -> eyre::Result<()> {
+    let _: InstallPlan = serde_json::from_str(LINUX)?;
+    Ok(())
+}
 
-// // Ensure existing plans still parse
-// // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
-// #[cfg(target_os = "linux")]
-// #[test]
-// fn plan_compat_steam_deck() -> eyre::Result<()> {
-//     let _: InstallPlan = serde_json::from_str(STEAM_DECK)?;
-//     Ok(())
-// }
+// Ensure existing plans still parse
+// If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
+#[cfg(target_os = "linux")]
+#[test]
+fn plan_compat_steam_deck() -> eyre::Result<()> {
+    let _: InstallPlan = serde_json::from_str(STEAM_DECK)?;
+    Ok(())
+}
 
-// // Ensure existing plans still parse
-// // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
-// #[cfg(target_os = "macos")]
-// #[test]
-// fn plan_compat_macos() -> eyre::Result<()> {
-//     let _: InstallPlan = serde_json::from_str(MACOS)?;
-//     Ok(())
-// }
+// Ensure existing plans still parse
+// If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
+#[cfg(target_os = "macos")]
+#[test]
+fn plan_compat_macos() -> eyre::Result<()> {
+    let _: InstallPlan = serde_json::from_str(MACOS)?;
+    Ok(())
+}


### PR DESCRIPTION
##### Description

We're experimenting trying to enable this. Considered a WIP.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
