### PR TITLE
Set the correct permissions on the zshenv

### DIFF
--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -70,7 +70,7 @@ impl ConfigureShellProfile {
                         profile_target_path,
                         None,
                         None,
-                        0o0644,
+                        0o100644,
                         shell_buf.to_string(),
                         create_or_insert_into_file::Position::Beginning,
                     )
@@ -112,7 +112,7 @@ impl ConfigureShellProfile {
                     profile_target,
                     None,
                     None,
-                    0o0644,
+                    0o100644,
                     fish_buf.to_string(),
                     create_or_insert_into_file::Position::Beginning,
                 )

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -70,7 +70,7 @@ impl ConfigureShellProfile {
                         profile_target_path,
                         None,
                         None,
-                        None,
+                        0o0755,
                         shell_buf.to_string(),
                         create_or_insert_into_file::Position::Beginning,
                     )

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -70,7 +70,7 @@ impl ConfigureShellProfile {
                         profile_target_path,
                         None,
                         None,
-                        0o0755,
+                        0o0644,
                         shell_buf.to_string(),
                         create_or_insert_into_file::Position::Beginning,
                     )
@@ -112,7 +112,7 @@ impl ConfigureShellProfile {
                     profile_target,
                     None,
                     None,
-                    0o0755,
+                    0o0644,
                     fish_buf.to_string(),
                     create_or_insert_into_file::Position::Beginning,
                 )

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -270,7 +270,7 @@ pub enum ActionError {
     PathUserMismatch(std::path::PathBuf, u32, u32),
     #[error("`{0}` exists with a different gid ({1}) than planned ({2}), consider removing it with `rm {0}`")]
     PathGroupMismatch(std::path::PathBuf, u32, u32),
-    #[error("`{0}` exists with a different mode ({1:o}) than planned ({2:o}), consider removing it with `rm {0}`")]
+    #[error("`{0}` exists with a different mode ({1:o}) than planned ({2:o}), consider updating it with `chmod {2} {0}`")]
     PathModeMismatch(std::path::PathBuf, u32, u32),
     #[error("Getting metadata for {0}`")]
     GettingMetadata(std::path::PathBuf, #[source] std::io::Error),

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -270,7 +270,7 @@ pub enum ActionError {
     PathUserMismatch(std::path::PathBuf, u32, u32),
     #[error("`{0}` exists with a different gid ({1}) than planned ({2}), consider removing it with `rm {0}`")]
     PathGroupMismatch(std::path::PathBuf, u32, u32),
-    #[error("`{0}` exists with a different mode ({1:o}) than planned ({2:o}), consider updating it with `chmod {2} {0}`")]
+    #[error("`{0}` exists with a different mode ({1:o}) than planned ({2:o}), consider updating it with `chmod {2:o} {0}`")]
     PathModeMismatch(std::path::PathBuf, u32, u32),
     #[error("Getting metadata for {0}`")]
     GettingMetadata(std::path::PathBuf, #[source] std::io::Error),


### PR DESCRIPTION
##### Description

I'm a bit curious how we didn't catch https://github.com/DeterminateSystems/nix-installer/issues/254 in testing, since we do that `nix` is on path:

https://github.com/DeterminateSystems/nix-installer/blob/c150d603eac35fea0f68ca0de8672786a6b90a31/.github/workflows/ci.yml#L123-L126

And that should have failed....

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
