### PR TITLE
Improve error message guidance

### DIFF
--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -266,11 +266,11 @@ pub enum ActionError {
         "`{0}` exists with different content than planned, consider removing it with `rm {0}`"
     )]
     Exists(std::path::PathBuf),
-    #[error("`{0}` exists with a different uid ({1}) than planned ({2}), consider removing it with `rm {0}`")]
+    #[error("`{0}` exists with a different uid ({1}) than planned ({2}), consider updating it with `chown {2} {0}`")]
     PathUserMismatch(std::path::PathBuf, u32, u32),
-    #[error("`{0}` exists with a different gid ({1}) than planned ({2}), consider removing it with `rm {0}`")]
+    #[error("`{0}` exists with a different gid ({1}) than planned ({2}), consider updating it with `chgrp {2} {0}`")]
     PathGroupMismatch(std::path::PathBuf, u32, u32),
-    #[error("`{0}` exists with a different mode ({1:o}) than planned ({2:o}), consider removing it with `rm {0}`")]
+    #[error("`{0}` exists with a different mode ({1:o}) than planned ({2:o}), consider updating it with `chmod {2} {0}`")]
     PathModeMismatch(std::path::PathBuf, u32, u32),
     #[error("Getting metadata for {0}`")]
     GettingMetadata(std::path::PathBuf, #[source] std::io::Error),

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -270,7 +270,7 @@ pub enum ActionError {
     PathUserMismatch(std::path::PathBuf, u32, u32),
     #[error("`{0}` exists with a different gid ({1}) than planned ({2}), consider updating it with `chgrp {2} {0}`")]
     PathGroupMismatch(std::path::PathBuf, u32, u32),
-    #[error("`{0}` exists with a different mode ({1:o}) than planned ({2:o}), consider updating it with `chmod {2} {0}`")]
+    #[error("`{0}` exists with a different mode ({1:o}) than planned ({2:o}), consider updating it with `chmod {2:o} {0}`")]
     PathModeMismatch(std::path::PathBuf, u32, u32),
     #[error("Getting metadata for {0}`")]
     GettingMetadata(std::path::PathBuf, #[source] std::io::Error),


### PR DESCRIPTION
##### Description

Noticed in #257 that there are others to improve too.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
