### PR TITLE
Don't specify chmod on synthetic.conf

### DIFF
--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -48,7 +48,7 @@ impl CreateNixVolume {
             "/etc/synthetic.conf",
             None,
             None,
-            0o0655,
+            None,
             "nix\n".into(), /* The newline is required otherwise it segfaults */
             create_or_insert_into_file::Position::End,
         )


### PR DESCRIPTION
##### Description

This should fix #255 .

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
