### PR TITLE
Add suggestion on --no-confirm flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,16 @@ If systemd is not enabled, pass `--init none` at the end of the command:
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --init none
 ```
 
+## Skip confirmation
+
+If you'd like to bypass the confirmation step, you can apply the `--no-confirm` flag:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+```
+
+This is especially useful when using the installer in non-interactive scripts.
+
 ## Building a binary
 
 Since you'll be using `nix-installer` to install Nix on systems without Nix, the default build is a static binary.


### PR DESCRIPTION
- Add some more branding to action (#129)
- buildkite: run on x86_64 and aarch64 linux (#131)
- Remove newline before access-tokens (#136)
- BUGFIX: Call `nix-store --load-db` & add sandboxed Qemu tests (#138)
- Fix ubuntu 16.04 support (#140)
- Resolve a system unit ordering bug after update (#144)
- Note how to test action in CONTRIBUTING.md (#141)
- Correctly expected error in default planner if nix installed (#151)
- Un-whoops success message (#153)
- release: init action to create release with buildkite artifacts (#150)
- Document release flow (#155)
- Show revert instead of step while reverting (#158)
- Fix use of UID where username should be on Github actions (#157)
- Be more friendly to light terminals (#149)
- installplan should not copy self binary (#161)
- release: create releases for specified branches (#152)
- Linus/ds 576 nix store should be in path directly (#148)
- release: init action to release first party PRs (#162)
- Fixup fdesetup isactive outputting when it should not (#163)
- Update locks (#164)
- When an artifact already exists for an MD5, skip it without failure (#166)
- upload_s3: sync already-existing dir to its destination (#167)
- Rename daemon-user-count and make an alias (#159)
- Update README.md to reflect recent changes (#165)
- upload_s3: provide git ish as argument (#169)
- upload_s3: move arguments to the top (#170)
- Release v0.0.1 (#168)
- Fixup badges in README.md (#172)
- bump v0.0.2-unreleased (#176)
- Action extra conf can be lacking newline (#175)
- Add some tests to CreateFile (#182)
- BUGFIX: CreateDirectory now properly prunes when it should (#181)
- BUGFIX: CreateOrInsertIntoFile was not reverting (#180)
- Refactor the README.md (#178)
- Allow users to answer e at prompts (#183)
- Trim irrelevant mac warning (#186)
- Use remote action (#185)
- Upload tags to S3 as well to avoid egress limits (#187)
- Update action section in readme with tag (#189)
- Add `(nix:$name)` as a prefix to the bash prompt (#191)
- enter-env.sh: init (#190)
- README: recommend safer curl options (#197)
- Pass SHELL through self-escalation (#195)
- Release v0.0.2 (#198)
- Revert "Release v0.0.2 (#198)" (#200)
- release-tags: needs write permissions to id-token for oidc authentication (#199)
- Re-release v0.0.2 (#201)
- upload_s3: improve tags handling (#202)
- release: add instructions on how to use uploaded artifacts (#204)
- Improve Mac explain output (#205)
- Correct --no-modify-profile (#206)
- CONTRIBUTING: `nix check` -> `nix flake check` (#207)
- Release v0.1.0 (#208)
- v0.1.0-unreleased (#210)
- Use a UUID instead of volume name for fstab on Mac (#215)
- Add a friendly top comment about `nix-installer.sh` (#216)
- Verify the apfs volume doesn't already exist before trying to create it (#217)
- Add plist use to the CreateFstabEntry action (#221)
- Use 30k range not 3k range for UIDs on Linux and 30k for a GID on all (#222)
- init-less install (#188)
- Release v0.2.0 (#230)
- v0.2.1-unreleased (#232)
- release: only run one release action at a time (#231)
- Update dependencies (#233)
- Add 32 bit support (#229)
- Bump Nix to 2.13.2 (#236)
- Attempt to minimize steam deck display manager restart risk (#237)
- Better support users/groups existing before install (#238)
- Better support existing files with CreateFile and CreateorInsertIntoFile (#239)
- It's the Determinate Nix Installer (#242)
- Bump DeterminateSystems/update-flake-lock from 14 to 16 (#223)
- Rename some of the planners (#243)
- Make systemd unit start detect already running unit (#240)
- Offer users better error if fstab entries exist (#241)
- Workaround some Mac issues in CI (#247)
- Clarify stability (#244)
- Repair some tests (#248)
- How about a CI API call reduction? (#245)
- Release v0.3.0 (#249)
- Mac support note (#251)
- Remove some bad merge code (#252)
- Improve error message guidance (#258)
- Don't specify chmod on synthetic.conf (#259)
- Don't parallize user creation (#260)
- Add note on --no-confirm flag

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
