### PR TITLE
Add diagnostics reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
  "eyre",
  "glob",
  "nix",
+ "os-release",
  "owo-colors",
  "plist",
  "rand 0.8.5",
@@ -1003,6 +1004,15 @@ name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "os-release"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f29ae2f71b53ec19cc23385f8e4f3d90975195aa3d09171ba3bef7159bec27"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "os_str_bytes"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "strum",
  "tar",
  "target-lexicon",
  "tempdir",
@@ -1550,6 +1551,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 
 [features]
-default = ["cli"]
+default = ["cli", "diagnostics"]
 cli = ["eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error", "atty"]
+diagnostics = ["os-release"]
 
 [[bin]]
 name = "nix-installer"
@@ -53,6 +54,7 @@ rand = { version = "0.8.5", default-features = false, features = [ "std", "std_r
 semver = { version = "1.0.14", default-features = false, features = ["serde", "std"] }
 term = { version = "0.7.0", default-features = false }
 uuid = { version = "1.2.2", features = ["serde"] }
+os-release = { version = "0.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ semver = { version = "1.0.14", default-features = false, features = ["serde", "s
 term = { version = "0.7.0", default-features = false }
 uuid = { version = "1.2.2", features = ["serde"] }
 os-release = { version = "0.1.0", default-features = false, optional = true }
+strum = { version = "0.24.1", features = ["derive"] }
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -80,6 +80,7 @@ impl Action for PlaceNixConfiguration {
 
         create_directory.try_execute().await?;
         create_file.try_execute().await?;
+        return Err(ActionError::NoGroup("boof".into()));
 
         Ok(())
     }

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -80,7 +80,6 @@ impl Action for PlaceNixConfiguration {
 
         create_directory.try_execute().await?;
         create_file.try_execute().await?;
-        return Err(ActionError::NoGroup("boof".into()));
 
         Ok(())
     }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -244,7 +244,7 @@ impl ActionDescription {
 }
 
 /// An error occurring during an action
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum ActionError {
     /// A custom error
     #[error(transparent)]

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -133,6 +133,15 @@ impl Planner for MyPlanner {
 
         Ok(map)
     }
+
+    #[cfg(feature = "diagnostics")]
+    async fn diagnostic_data(&self) -> Result<nix_installer::diagnostics::DiagnosticData, PlannerError> {
+        Ok(nix_installer::diagnostics::DiagnosticData::new(
+            self.common.diagnostic_endpoint.clone(),
+            self.typetag_name().into(),
+            self.configured_settings().await?,
+        ))
+    }
 }
 
 # async fn custom_planner_install() -> color_eyre::Result<()> {

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -47,6 +47,7 @@ pub struct Install {
         global = true
     )]
     pub explain: bool,
+
     #[clap(env = "NIX_INSTALLER_PLAN")]
     pub plan: Option<PathBuf>,
 

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -134,12 +134,12 @@ impl CommandExecute for Install {
                         let res = builtin_planner.plan().await;
                         match res {
                             Ok(plan) => plan,
-                            Err(e) => {
-                                if let Some(expected) = e.expected() {
+                            Err(err) => {
+                                if let Some(expected) = err.expected() {
                                     eprintln!("{}", expected.red());
                                     return Ok(ExitCode::FAILURE);
                                 }
-                                return Err(e.into())
+                                return Err(err.into())
                             }
                         }
                     },

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -28,6 +28,7 @@ pub struct Uninstall {
         global = true
     )]
     pub no_confirm: bool,
+
     #[clap(
         long,
         env = "NIX_INSTALLER_EXPLAIN",
@@ -36,6 +37,7 @@ pub struct Uninstall {
         global = true
     )]
     pub explain: bool,
+
     #[clap(default_value = RECEIPT_LOCATION)]
     pub receipt: PathBuf,
 }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 When enabled with the `diagnostics` feature (default) this module provides automated install success/failure reporting to an endpoint.
 
-That endpoint can be a URL such as `https://our.project.org/nix-installer/diagnostics` or `file:///home/$USER/diagnostic.json` which recieves a [`DiagnosticReport`] in JSON format.
+That endpoint can be a URL such as `https://our.project.org/nix-installer/diagnostics` or `file:///home/$USER/diagnostic.json` which receives a [`DiagnosticReport`] in JSON format.
 */
 
 use std::time::Duration;

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,137 @@
+use os_release::OsRelease;
+use reqwest::Url;
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy)]
+pub enum DiagnosticStatus {
+    Cancelled,
+    Success,
+    Failure,
+    Pending,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy)]
+pub enum DiagnosticAction {
+    Install,
+    Uninstall,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct DiagnosticReport {
+    version: String,
+    planner: String,
+    configured_settings: Vec<String>,
+    os_name: String,
+    os_version: String,
+    architecture: String,
+    action: DiagnosticAction,
+    status: DiagnosticStatus,
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct DiagnosticData {
+    version: String,
+    planner: String,
+    configured_settings: Vec<String>,
+    os_name: String,
+    os_version: String,
+    architecture: String,
+    endpoint: Option<Url>,
+}
+
+impl DiagnosticData {
+    pub fn new(endpoint: Option<Url>, planner: String, configured_settings: Vec<String>) -> Self {
+        let (os_name, os_version) = match OsRelease::new() {
+            Ok(os_release) => (os_release.name, os_release.version),
+            Err(_) => ("unknown".into(), "unknown".into()),
+        };
+        Self {
+            endpoint,
+            version: env!("CARGO_PKG_VERSION").into(),
+            planner,
+            configured_settings,
+            os_name,
+            os_version,
+            architecture: std::env::consts::ARCH.to_string(),
+        }
+    }
+
+    pub fn report(&self, action: DiagnosticAction, status: DiagnosticStatus) -> DiagnosticReport {
+        let Self {
+            version,
+            planner,
+            configured_settings,
+            os_name,
+            os_version,
+            architecture,
+            endpoint: _,
+        } = self;
+        DiagnosticReport {
+            version: version.clone(),
+            planner: planner.clone(),
+            configured_settings: configured_settings.clone(),
+            os_name: os_name.clone(),
+            os_version: os_version.clone(),
+            architecture: architecture.clone(),
+            action,
+            status,
+        }
+    }
+
+    pub async fn send(
+        self,
+        action: DiagnosticAction,
+        status: DiagnosticStatus,
+    ) -> Result<(), DiagnosticError> {
+        let serialized = serde_json::to_string_pretty(&self.report(action, status))?;
+
+        let endpoint = match self.endpoint {
+            Some(endpoint) => endpoint,
+            None => return Ok(()),
+        };
+
+        match endpoint.scheme() {
+            "https" | "http" => {
+                let client = reqwest::Client::new();
+                let res = client
+                    .post(endpoint.clone())
+                    .body(serialized)
+                    .header("Content-Type", "application/json")
+                    .send()
+                    .await;
+
+                if let Err(err) = res {
+                    tracing::info!(?err, "Failed to send diagnostic to endpoint, continuing")
+                }
+            },
+            "file" => {
+                let res = tokio::fs::write(endpoint.path(), serialized).await;
+
+                if let Err(err) = res {
+                    tracing::info!(?err, "Failed to send diagnostic to endpoint, continuing")
+                }
+            },
+            _ => return Err(DiagnosticError::UnknownUrlScheme),
+        };
+        Ok(())
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DiagnosticError {
+    #[error("Unknown url scheme")]
+    UnknownUrlScheme,
+    #[error("Request error")]
+    Reqwest(
+        #[from]
+        #[source]
+        reqwest::Error,
+    ),
+    #[error("Write path `{0}`")]
+    Write(std::path::PathBuf, #[source] std::io::Error),
+    #[error("Serializing receipt")]
+    Serializing(
+        #[from]
+        #[source]
+        serde_json::Error,
+    ),
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -35,7 +35,7 @@ pub struct DiagnosticReport {
     pub configured_settings: Vec<String>,
     pub os_name: String,
     pub os_version: String,
-    pub architecture: String,
+    pub triple: String,
     pub action: DiagnosticAction,
     pub status: DiagnosticStatus,
 }
@@ -48,7 +48,7 @@ pub struct DiagnosticData {
     configured_settings: Vec<String>,
     os_name: String,
     os_version: String,
-    architecture: String,
+    triple: String,
     endpoint: Option<Url>,
 }
 
@@ -65,7 +65,7 @@ impl DiagnosticData {
             configured_settings,
             os_name,
             os_version,
-            architecture: std::env::consts::ARCH.to_string(),
+            triple: target_lexicon::HOST.to_string(),
         }
     }
 
@@ -76,7 +76,7 @@ impl DiagnosticData {
             configured_settings,
             os_name,
             os_version,
-            architecture,
+            triple,
             endpoint: _,
         } = self;
         DiagnosticReport {
@@ -85,7 +85,7 @@ impl DiagnosticData {
             configured_settings: configured_settings.clone(),
             os_name: os_name.clone(),
             os_version: os_version.clone(),
-            architecture: architecture.clone(),
+            triple: triple.clone(),
             action,
             status,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,15 @@ pub enum NixInstallerError {
         #[source]
         InstallSettingsError,
     ),
+
+    #[cfg(feature = "diagnostics")]
+    /// Diagnostics
+    #[error("Diagnostic error")]
+    Diagnostic(
+        #[from]
+        #[source]
+        crate::diagnostics::DiagnosticError,
+    ),
 }
 
 pub(crate) trait HasExpectedErrors: std::error::Error + Sized + Send + Sync {
@@ -70,6 +79,8 @@ impl HasExpectedErrors for NixInstallerError {
             NixInstallerError::SemVer(_) => None,
             NixInstallerError::Planner(planner_error) => planner_error.expected(),
             NixInstallerError::InstallSettings(_) => None,
+            #[cfg(feature = "diagnostics")]
+            NixInstallerError::Diagnostic(_) => None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use crate::{action::ActionError, planner::PlannerError, settings::InstallSettingsError};
 
 /// An error occurring during a call defined in this crate
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum NixInstallerError {
     /// An error originating from an [`Action`](crate::action::Action)
     #[error("Error executing action")]
@@ -55,7 +55,7 @@ pub enum NixInstallerError {
     ),
 
     #[cfg(feature = "diagnostics")]
-    /// Diagnostics
+    /// Diagnostic error
     #[error("Diagnostic error")]
     Diagnostic(
         #[from]
@@ -84,3 +84,20 @@ impl HasExpectedErrors for NixInstallerError {
         }
     }
 }
+
+// #[cfg(feature = "diagnostics")]
+// impl NixInstallerError {
+//     pub fn diagnostic_synopsis(&self) -> &'static str {
+//         match self {
+//             NixInstallerError::Action(inner) => inner.into(),
+//             NixInstallerError::Planner(inner) => inner.into(),
+//             NixInstallerError::RecordingReceipt(_, _)
+//             | NixInstallerError::CopyingSelf(_)
+//             | NixInstallerError::SerializingReceipt(_)
+//             | NixInstallerError::Cancelled
+//             | NixInstallerError::SemVer(_)
+//             | NixInstallerError::Diagnostic(_)
+//             | NixInstallerError::InstallSettings(_) => self.into(),
+//         }
+//     }
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ pub mod action;
 mod channel_value;
 #[cfg(feature = "cli")]
 pub mod cli;
+#[cfg(feature = "diagnostics")]
+pub mod diagnostics;
 mod error;
 mod os;
 mod plan;

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -96,6 +96,15 @@ impl Planner for Linux {
 
         Ok(map)
     }
+
+    #[cfg(feature = "diagnostics")]
+    async fn diagnostic_data(&self) -> Result<crate::diagnostics::DiagnosticData, PlannerError> {
+        Ok(crate::diagnostics::DiagnosticData::new(
+            self.settings.diagnostic_endpoint.clone(),
+            self.typetag_name().into(),
+            self.configured_settings().await?,
+        ))
+    }
 }
 
 impl Into<BuiltinPlanner> for Linux {

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -169,6 +169,15 @@ impl Planner for Macos {
 
         Ok(map)
     }
+
+    #[cfg(feature = "diagnostics")]
+    async fn diagnostic_data(&self) -> Result<crate::diagnostics::DiagnosticData, PlannerError> {
+        Ok(crate::diagnostics::DiagnosticData::new(
+            self.settings.diagnostic_endpoint.clone(),
+            self.typetag_name().into(),
+            self.configured_settings().await?,
+        ))
+    }
 }
 
 impl Into<BuiltinPlanner> for Macos {

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -261,7 +261,7 @@ impl BuiltinPlanner {
 }
 
 /// An error originating from a [`Planner`]
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum PlannerError {
     /// `nix-installer` does not have a default planner for the target architecture right now
     #[error("`nix-installer` does not have a default planner for the `{0}` architecture right now, pass a specific archetype")]

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -52,6 +52,15 @@ impl Planner for MyPlanner {
 
         Ok(map)
     }
+
+    #[cfg(feature = "diagnostics")]
+    async fn diagnostic_data(&self) -> Result<nix_installer::diagnostics::DiagnosticData, PlannerError> {
+        Ok(nix_installer::diagnostics::DiagnosticData::new(
+            self.common.diagnostic_endpoint.clone(),
+            self.typetag_name().into(),
+            self.configured_settings().await?,
+        ))
+    }
 }
 
 # async fn custom_planner_install() -> color_eyre::Result<()> {

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -252,6 +252,15 @@ impl Planner for SteamDeck {
 
         Ok(map)
     }
+
+    #[cfg(feature = "diagnostics")]
+    async fn diagnostic_data(&self) -> Result<crate::diagnostics::DiagnosticData, PlannerError> {
+        Ok(crate::diagnostics::DiagnosticData::new(
+            self.settings.diagnostic_endpoint.clone(),
+            self.typetag_name().into(),
+            self.configured_settings().await?,
+        ))
+    }
 }
 
 impl Into<BuiltinPlanner> for SteamDeck {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -224,7 +224,7 @@ pub struct CommonSettings {
         long,
         env = "NIX_INSTALLER_DIAGNOSTIC_ENDPOINT",
         global = true,
-        default_value = "https://install.determinate.systems/nix/diagnostics"
+        default_value = "https://install.determinate.systems/nix/diagnostic"
     )]
     pub diagnostic_endpoint: Option<Url>,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -224,7 +224,7 @@ pub struct CommonSettings {
         long,
         env = "NIX_INSTALLER_DIAGNOSTIC_ENDPOINT",
         global = true,
-        default_value = "https://install.determinate.systems/diagnostics"
+        default_value = "https://install.determinate.systems/nix/diagnostics"
     )]
     pub diagnostic_endpoint: Option<Url>,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -214,7 +214,7 @@ pub struct CommonSettings {
     ///     "configured-settings": [ "modify_profile" ],
     ///     "os-name": "Ubuntu",
     ///     "os-version": "22.04.1 LTS (Jammy Jellyfish)",
-    ///     "architecture": "x86_64",
+    ///     "triple": "x86_64-unknown-linux-gnu",
     ///     "action": "Install",
     ///     "status": "Success"
     /// }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -209,13 +209,14 @@ pub struct CommonSettings {
     /// Sample of the data sent:
     ///
     /// {
+    ///     "version": "0.3.0",
     ///     "planner": "linux",
     ///     "configured-settings": [ "modify_profile" ],
     ///     "os-name": "Ubuntu",
-    ///     "os-version": "22.10",
+    ///     "os-version": "22.04.1 LTS (Jammy Jellyfish)",
     ///     "architecture": "x86_64",
-    ///     "action": "install",
-    ///     "status": "success"
+    ///     "action": "Install",
+    ///     "status": "Success"
     /// }
     ///
     /// To disable diagnostic reporting, unset the default with `--diagnostic-endpoint=`
@@ -241,19 +242,19 @@ impl CommonSettings {
             (Architecture::X86_64, OperatingSystem::Linux) => {
                 url = NIX_X64_64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
-                nix_build_user_id_base = 3000;
+                nix_build_user_id_base = 30000;
             },
             #[cfg(target_os = "linux")]
             (Architecture::X86_32(_), OperatingSystem::Linux) => {
                 url = NIX_I686_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
-                nix_build_user_id_base = 3000;
+                nix_build_user_id_base = 30000;
             },
             #[cfg(target_os = "linux")]
             (Architecture::Aarch64(_), OperatingSystem::Linux) => {
                 url = NIX_AARCH64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
-                nix_build_user_id_base = 3000;
+                nix_build_user_id_base = 30000;
             },
             #[cfg(target_os = "macos")]
             (Architecture::X86_64, OperatingSystem::MacOSX { .. })


### PR DESCRIPTION
##### Description

Add preliminary diagnostic reporting about pass/fail on uninstall/install attempts. This is a generic implementation that can report to any url or file path and contains minimal information.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
