### PR TITLE
Use extra-nix-path to resolve nix-shell -p not working

### DIFF
--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -35,6 +35,8 @@ impl PlaceNixConfiguration {
             auto-optimise-store = true\n\
             \n\
             bash-prompt-prefix = (nix:$name)\\040\n\
+            \n\
+            extra-nix-path = nixpkgs=flake:nixpkgs\n\
         ",
             extra_conf = extra_conf.join("\n"),
             version = env!("CARGO_PKG_VERSION"),


### PR DESCRIPTION
##### Description

This should address #234! After installing I tested:
```
ana@ubuntu-base:~/Downloads$ nix-shell -p
these 40 paths will be fetched (72.04 MiB download, 333.53 MiB unpacked):
  /nix/store/12wczkzi5db1ajbjp4hdyif3v9y5rbi5-xz-5.4.1-bin
  /nix/store/17pkxcz3js3549kn9dc3hhvp4adbwvs1-bzip2-1.0.8-bin
  /nix/store/1f44s1ddm915dn3kdaycabhf3a8xnfnb-gawk-5.2.1
  /nix/store/2a6yagz3pa8kiawg5mk2js70f8kwqzqd-bzip2-1.0.8
  /nix/store/35s126gfkfrwbiv49kv9kxqdpd9zvcvm-ncurses-6.4
  /nix/store/4grm35slwd5il8v9sfkibl164ays38hp-glibc-2.35-224-dev
  /nix/store/502zrfyc2agh928111zhwy6959bqd8m0-xz-5.4.1
  /nix/store/561wgc73s0x1250hrgp7jm22hhv7yfln-bash-5.2-p15
  /nix/store/72nvsslmgq8mp6ywxnl9i0rr8x174sjw-binutils-wrapper-2.40
  /nix/store/7w1s50i8yplw2gkpf9hpha6n9vci8g98-coreutils-9.1
  /nix/store/83q5sbysda8285svx8mjlpc17bd3n630-attr-2.5.1

````

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
