### PR TITLE
Prelease tidy and add is_ci to Diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "dyn-clone",
  "eyre",
  "glob",
+ "is_ci",
  "nix",
  "os-release",
  "owo-colors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.4"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc831ee6a32dd495436e317595e639a587aa9907bef96fe6e6abc290ab6204e9"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94331d54f1b1a8895cd81049f7eaaaef9d05a7dcb4d1fd08bf3ff0806246789d"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -262,15 +262,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dcd35ba14ca9b40d6e4b4b39961f23d835dbb8eed74565ded361d93e1feb8a"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bbeb29798b407ccd82a3324ade1a7286e0d29851475990b612670f6f5124d2"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
  "darling_core",
  "quote",
@@ -410,14 +410,14 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glob"
@@ -592,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,9 +605,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
@@ -762,14 +768,14 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -891,14 +897,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1003,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "os-release"
@@ -1086,11 +1092,11 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plist"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5329b8f106a176ab0dce4aae5da86bfcb139bb74fb00882859e03745011f3635"
+checksum = "9469799ca90293a376f68f6fcb8f11990d9cff55602cfba0ba83893c973a7f46"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "indexmap",
  "line-wrap",
  "quick-xml",
@@ -1130,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -1339,16 +1345,16 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1443,9 +1449,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -1503,18 +1509,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
@@ -1587,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1609,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempdir"
@@ -1665,18 +1671,19 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if",
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "serde",
@@ -1692,9 +1699,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
 dependencies = [
  "time-core",
 ]
@@ -1710,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1770,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes 1.4.0",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,12 +443,6 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -732,6 +735,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,7 +949,7 @@ dependencies = [
  "os-release",
  "owo-colors",
  "plist",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "semver",
  "serde",
@@ -946,7 +958,7 @@ dependencies = [
  "strum",
  "tar",
  "target-lexicon",
- "tempdir",
+ "tempfile",
  "term",
  "thiserror",
  "tokio",
@@ -1163,26 +1175,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1192,23 +1191,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1217,15 +1201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1620,13 +1595,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
+name = "tempfile"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "rand 0.4.6",
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
  "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 [features]
 default = ["cli", "diagnostics"]
 cli = ["eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error", "atty"]
-diagnostics = ["os-release"]
+diagnostics = ["os-release", "is_ci"]
 
 [[bin]]
 name = "nix-installer"
@@ -55,6 +55,7 @@ semver = { version = "1.0.14", default-features = false, features = ["serde", "s
 term = { version = "0.7.0", default-features = false }
 uuid = { version = "1.2.2", features = ["serde"] }
 os-release = { version = "0.1.0", default-features = false, optional = true }
+is_ci = { version = "1.1.1", default-features = false, optional = true }
 strum = { version = "0.24.1", features = ["derive"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }
-tempdir = "0.3.7"
+tempfile = "3.3.0"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1675319011,
-        "narHash": "sha256-03XIeP5ohqMs+AXhKirbZXMjEfmWmasrcnQIZW1hPbM=",
+        "lastModified": 1677219923,
+        "narHash": "sha256-gvNqjERVoc7f9NSBqZCA5RqAX3HjJA+KOhjN0jNaXw0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "5039231f7fbf180ea25b5d7eac907d5058382c1c",
+        "rev": "20d2fcd01df0c3db0429112ab3d911ee0bc3a3b5",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1675701457,
-        "narHash": "sha256-5KssNLx3G9crNjdXPQjb+b+gPYV3zejYoujtxmAOIh0=",
+        "lastModified": 1670461440,
+        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b9118e0197990d717e7ee3430d38db38e1621c49",
+        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1675281619,
-        "narHash": "sha256-cxZylukIcY5Ik29zXD+7e8krHVZ4XnTYJsjLkQRk3v8=",
+        "lastModified": 1676976502,
+        "narHash": "sha256-D0l5hvE4IFUqspKeorawIlLQRMKqCkMAhZ58KjDXJl8=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "ccd142c6163c992dfb482b85bbddbb7b3370c9c8",
+        "rev": "27239fbb58a115915ffc1ce65ededc951eb00fd2",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,7 @@
               toolchain
               rust-analyzer
               cargo-outdated
+              cargo-audit
               nixpkgs-fmt
               check.check-rustfmt
               check.check-spelling

--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -222,7 +222,7 @@ mod test {
 
     #[tokio::test]
     async fn creates_and_deletes_empty_directory() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_dir = temp_dir.path().join("creates_and_deletes_empty_directory");
         let mut action = CreateDirectory::plan(test_dir.clone(), None, None, None, false).await?;
 
@@ -237,7 +237,7 @@ mod test {
 
     #[tokio::test]
     async fn creates_and_deletes_populated_directory_if_prune_true() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_dir = temp_dir
             .path()
             .join("creates_and_deletes_populated_directory_if_prune_true");
@@ -257,7 +257,7 @@ mod test {
 
     #[tokio::test]
     async fn creates_and_leaves_populated_directory_if_prune_false() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_dir = temp_dir
             .path()
             .join("creates_and_leaves_populated_directory_if_prune_false");

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -261,7 +261,7 @@ mod test {
 
     #[tokio::test]
     async fn creates_and_deletes_file() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir.path().join("creates_and_deletes_file");
         let mut action =
             CreateFile::plan(test_file.clone(), None, None, None, "Test".into(), false).await?;
@@ -277,7 +277,7 @@ mod test {
 
     #[tokio::test]
     async fn creates_and_deletes_file_even_if_edited() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir
             .path()
             .join("creates_and_deletes_file_even_if_edited");
@@ -297,7 +297,7 @@ mod test {
 
     #[tokio::test]
     async fn recognizes_existing_exact_files_and_reverts_them() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir
             .path()
             .join("recognizes_existing_exact_files_and_reverts_them");
@@ -326,7 +326,7 @@ mod test {
 
     #[tokio::test]
     async fn recognizes_existing_different_files_and_errors() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir
             .path()
             .join("recognizes_existing_different_files_and_errors");
@@ -354,7 +354,7 @@ mod test {
 
     #[tokio::test]
     async fn recognizes_wrong_mode_and_errors() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir.path().join("recognizes_wrong_mode_and_errors");
         let initial_mode = 0o777;
         let expected_mode = 0o000;
@@ -392,7 +392,7 @@ mod test {
 
     #[tokio::test]
     async fn recognizes_correct_mode() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir.path().join("recognizes_correct_mode");
         let initial_mode = 0o777;
 
@@ -421,7 +421,7 @@ mod test {
 
     #[tokio::test]
     async fn errors_on_dir() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_file")?;
+        let temp_dir = tempfile::tempdir()?;
 
         match CreateFile::plan(
             temp_dir.path(),

--- a/src/action/base/create_or_insert_into_file.rs
+++ b/src/action/base/create_or_insert_into_file.rs
@@ -361,7 +361,7 @@ mod test {
 
     #[tokio::test]
     async fn creates_and_deletes_file() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_create_or_insert_into_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir.path().join("creates_and_deletes_file");
         let mut action = CreateOrInsertIntoFile::plan(
             test_file.clone(),
@@ -384,7 +384,7 @@ mod test {
 
     #[tokio::test]
     async fn edits_and_reverts_file() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_create_or_insert_into_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir.path().join("edits_and_reverts_file");
 
         let test_content = "Some other content";
@@ -419,7 +419,7 @@ mod test {
 
     #[tokio::test]
     async fn recognizes_existing_containing_exact_contents_and_reverts_it() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_create_or_insert_into_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir
             .path()
             .join("recognizes_existing_containing_exact_contents_and_reverts_it");
@@ -457,7 +457,7 @@ mod test {
 
     #[tokio::test]
     async fn recognizes_wrong_mode_and_errors() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_or_insert_into_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir.path().join("recognizes_wrong_mode_and_errors");
         let initial_mode = 0o777;
         let expected_mode = 0o000;
@@ -495,7 +495,7 @@ mod test {
 
     #[tokio::test]
     async fn recognizes_correct_mode() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_or_insert_into_file")?;
+        let temp_dir = tempfile::tempdir()?;
         let test_file = temp_dir.path().join("recognizes_correct_mode");
         let initial_mode = 0o777;
 
@@ -524,7 +524,7 @@ mod test {
 
     #[tokio::test]
     async fn errors_on_dir() -> eyre::Result<()> {
-        let temp_dir = tempdir::TempDir::new("nix_installer_tests_create_or_insert_into_file")?;
+        let temp_dir = tempfile::tempdir()?;
 
         match CreateOrInsertIntoFile::plan(
             temp_dir.path(),

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -39,7 +39,7 @@ pub struct DiagnosticReport {
     pub action: DiagnosticAction,
     pub status: DiagnosticStatus,
     /// Generally this includes the [`strum::IntoStaticStr`] representation of the error, we take special care not to include parameters of the error (which may include secrets)
-    pub error_variant: Option<String>,
+    pub failure_variant: Option<String>,
 }
 
 /// A preparation of data to be sent to the `endpoint`.
@@ -53,7 +53,7 @@ pub struct DiagnosticData {
     triple: String,
     is_ci: bool,
     endpoint: Option<Url>,
-    error_variant: Option<String>,
+    failure_variant: Option<String>,
 }
 
 impl DiagnosticData {
@@ -72,12 +72,12 @@ impl DiagnosticData {
             os_version,
             triple: target_lexicon::HOST.to_string(),
             is_ci,
-            error_variant: None,
+            failure_variant: None,
         }
     }
 
     pub fn variant(mut self, variant: String) -> Self {
-        self.error_variant = Some(variant);
+        self.failure_variant = Some(variant);
         self
     }
 
@@ -91,7 +91,7 @@ impl DiagnosticData {
             triple,
             is_ci,
             endpoint: _,
-            error_variant: variant,
+            failure_variant: variant,
         } = self;
         DiagnosticReport {
             version: version.clone(),
@@ -103,7 +103,7 @@ impl DiagnosticData {
             is_ci: *is_ci,
             action,
             status,
-            error_variant: variant.clone(),
+            failure_variant: variant.clone(),
         }
     }
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -39,7 +39,7 @@ pub struct DiagnosticReport {
     pub action: DiagnosticAction,
     pub status: DiagnosticStatus,
     /// Generally this includes the [`strum::IntoStaticStr`] representation of the error, we take special care not to include parameters of the error (which may include secrets)
-    pub variant: Option<String>,
+    pub error_variant: Option<String>,
 }
 
 /// A preparation of data to be sent to the `endpoint`.
@@ -53,7 +53,7 @@ pub struct DiagnosticData {
     triple: String,
     is_ci: bool,
     endpoint: Option<Url>,
-    variant: Option<String>,
+    error_variant: Option<String>,
 }
 
 impl DiagnosticData {
@@ -72,12 +72,12 @@ impl DiagnosticData {
             os_version,
             triple: target_lexicon::HOST.to_string(),
             is_ci,
-            variant: None,
+            error_variant: None,
         }
     }
 
     pub fn variant(mut self, variant: String) -> Self {
-        self.variant = Some(variant);
+        self.error_variant = Some(variant);
         self
     }
 
@@ -91,7 +91,7 @@ impl DiagnosticData {
             triple,
             is_ci,
             endpoint: _,
-            variant,
+            error_variant: variant,
         } = self;
         DiagnosticReport {
             version: version.clone(),
@@ -103,7 +103,7 @@ impl DiagnosticData {
             is_ci: *is_ci,
             action,
             status,
-            variant: variant.clone(),
+            error_variant: variant.clone(),
         }
     }
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -15,9 +15,8 @@ use reqwest::Url;
 pub enum DiagnosticStatus {
     Cancelled,
     Success,
-    /// This includes the [`strum::IntoStaticStr`] representation of the error, we take special care not to include parameters of the error (which may include secrets)
-    Failure(String),
     Pending,
+    Failure,
 }
 
 /// The action attempted
@@ -36,8 +35,11 @@ pub struct DiagnosticReport {
     pub os_name: String,
     pub os_version: String,
     pub triple: String,
+    pub is_ci: bool,
     pub action: DiagnosticAction,
     pub status: DiagnosticStatus,
+    /// Generally this includes the [`strum::IntoStaticStr`] representation of the error, we take special care not to include parameters of the error (which may include secrets)
+    pub variant: Option<String>,
 }
 
 /// A preparation of data to be sent to the `endpoint`.
@@ -49,7 +51,9 @@ pub struct DiagnosticData {
     os_name: String,
     os_version: String,
     triple: String,
+    is_ci: bool,
     endpoint: Option<Url>,
+    variant: Option<String>,
 }
 
 impl DiagnosticData {
@@ -58,6 +62,7 @@ impl DiagnosticData {
             Ok(os_release) => (os_release.name, os_release.version),
             Err(_) => ("unknown".into(), "unknown".into()),
         };
+        let is_ci = is_ci::cached();
         Self {
             endpoint,
             version: env!("CARGO_PKG_VERSION").into(),
@@ -66,7 +71,14 @@ impl DiagnosticData {
             os_name,
             os_version,
             triple: target_lexicon::HOST.to_string(),
+            is_ci,
+            variant: None,
         }
+    }
+
+    pub fn variant(mut self, variant: String) -> Self {
+        self.variant = Some(variant);
+        self
     }
 
     pub fn report(&self, action: DiagnosticAction, status: DiagnosticStatus) -> DiagnosticReport {
@@ -77,7 +89,9 @@ impl DiagnosticData {
             os_name,
             os_version,
             triple,
+            is_ci,
             endpoint: _,
+            variant,
         } = self;
         DiagnosticReport {
             version: version.clone(),
@@ -86,8 +100,10 @@ impl DiagnosticData {
             os_name: os_name.clone(),
             os_version: os_version.clone(),
             triple: triple.clone(),
+            is_ci: *is_ci,
             action,
             status,
+            variant: variant.clone(),
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,20 +84,3 @@ impl HasExpectedErrors for NixInstallerError {
         }
     }
 }
-
-// #[cfg(feature = "diagnostics")]
-// impl NixInstallerError {
-//     pub fn diagnostic_synopsis(&self) -> &'static str {
-//         match self {
-//             NixInstallerError::Action(inner) => inner.into(),
-//             NixInstallerError::Planner(inner) => inner.into(),
-//             NixInstallerError::RecordingReceipt(_, _)
-//             | NixInstallerError::CopyingSelf(_)
-//             | NixInstallerError::SerializingReceipt(_)
-//             | NixInstallerError::Cancelled
-//             | NixInstallerError::SemVer(_)
-//             | NixInstallerError::Diagnostic(_)
-//             | NixInstallerError::InstallSettings(_) => self.into(),
-//         }
-//     }
-// }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -162,12 +162,13 @@ impl InstallPlan {
                 if let Some(diagnostic_data) = &self.diagnostic_data {
                     diagnostic_data
                         .clone()
+                        .variant({
+                            let x: &'static str = (&err).into();
+                            x.to_string()
+                        })
                         .send(
                             crate::diagnostics::DiagnosticAction::Install,
-                            crate::diagnostics::DiagnosticStatus::Failure({
-                                let x: &'static str = (&err).into();
-                                x.to_string()
-                            }),
+                            crate::diagnostics::DiagnosticStatus::Failure,
                         )
                         .await?;
                 }
@@ -294,12 +295,13 @@ impl InstallPlan {
                 if let Some(diagnostic_data) = &self.diagnostic_data {
                     diagnostic_data
                         .clone()
+                        .variant({
+                            let x: &'static str = (&err).into();
+                            x.to_string()
+                        })
                         .send(
                             crate::diagnostics::DiagnosticAction::Uninstall,
-                            crate::diagnostics::DiagnosticStatus::Failure({
-                                let x: &'static str = (&err).into();
-                                x.to_string()
-                            }),
+                            crate::diagnostics::DiagnosticStatus::Failure,
                         )
                         .await?;
                 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -216,7 +216,7 @@ pub struct CommonSettings {
     ///     "os-version": "22.04.1 LTS (Jammy Jellyfish)",
     ///     "triple": "x86_64-unknown-linux-gnu",
     ///     "action": "Install",
-    ///     "status": "Success"I
+    ///     "status": "Success"
     /// }
     ///
     /// To disable diagnostic reporting, unset the default with `--diagnostic-endpoint=`

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -216,7 +216,7 @@ pub struct CommonSettings {
     ///     "os-version": "22.04.1 LTS (Jammy Jellyfish)",
     ///     "triple": "x86_64-unknown-linux-gnu",
     ///     "action": "Install",
-    ///     "status": "Success"
+    ///     "status": "Success"I
     /// }
     ///
     /// To disable diagnostic reporting, unset the default with `--diagnostic-endpoint=`
@@ -286,7 +286,7 @@ impl CommonSettings {
             )],
             modify_profile: true,
             nix_build_group_name: String::from("nixbld"),
-            nix_build_group_id: 3000,
+            nix_build_group_id: 30_000,
             nix_build_user_prefix: nix_build_user_prefix.to_string(),
             nix_build_user_id_base,
             nix_package_url: url.parse()?,
@@ -294,7 +294,7 @@ impl CommonSettings {
             force: false,
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint: Some(
-                "https://install.determinate.systems/diagnostics".try_into()?,
+                "https://install.determinate.systems/nix/diagnostic".try_into()?,
             ),
         })
     }


### PR DESCRIPTION
##### Description

Fix use of a deprecated crate, update some deps, remove some dead code.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
