### PR TITLE
Repair is_ci handling, sudo was erasing the variables

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -62,7 +62,8 @@ impl DiagnosticData {
             Ok(os_release) => (os_release.name, os_release.version),
             Err(_) => ("unknown".into(), "unknown".into()),
         };
-        let is_ci = is_ci::cached();
+        let is_ci = is_ci::cached()
+            || std::env::var("NIX_INSTALLER_CI").unwrap_or_else(|_| "0".into()) == "1";
         Self {
             endpoint,
             version: env!("CARGO_PKG_VERSION").into(),


### PR DESCRIPTION
##### Description

`sudo` was erasing the variables which `is_ci` checks for CI. Instead of preserving the entire list, we opt to run it once and set a `nix-installer` specific env for CI and `or` with `is_ci`'s result later.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
