### PR TITLE
Describe Diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,17 +303,17 @@ Here is a table of the [diagnostic data we collect][diagnosticdata]:
 | Field                 | Use                                                                                                   |
 | --------------------- | ----------------------------------------------------------------------------------------------------- |
 | `version`             | The version of the Determinate Nix Installer.                                                         |
-| `planner`             | The method of installing Nix ("linux", "macos", "steam-deck")                                         |
-| `configured-settings` | The names of planner settings which were changed from their default. Does not include the values.     |
-| `os-name`             | The running operating system.                                                                         |
-| `os-version`          | The version of the operating system.                                                                  |
+| `planner`             | The method of installing Nix (`linux`, `macos`, `steam-deck`)                                         |
+| `configured_settings` | The names of planner settings which were changed from their default. Does not include the values.     |
+| `os_name`             | The running operating system.                                                                         |
+| `os_version`          | The version of the operating system.                                                                  |
 | `triple`              | The architecture/os/binary format of your system.                                                     |
-| `is-ci`               | Whether the installer is being used in CI (e.g. GitHub Actions).                                      |
-| `action`              | Either "install" or "uninstall".                                                                      |
-| `status`              | "Success", "Failure", etc.                                                                            |
-| `failure_variant`     | A high level description of what the failure was, if any. For example: "Command" if a command failed. |
+| `is_ci`               | Whether the installer is being used in CI (e.g. GitHub Actions).                                      |
+| `action`              | Either `Install` or `Uninstall`.                                                                      |
+| `status`              | `Success`, `Failure`, etc.                                                                            |
+| `failure_variant`     | A high level description of what the failure was, if any. For example: `Command` if a command failed. |
 
-To disable diagnostic reporting, set the diagnostics URL to an empty string by passing `--diagnostic-endpoint=""`
+To disable diagnostic reporting, set the diagnostics URL to an empty string by passing `--diagnostic-endpoint=""` or setting `NIX_INSTALLER_DIAGNOSTIC_ENDPOINT=""`.
 
 You can read the full privacy policy for [Determinate Systems][detsys], the creators of the Determinate Nix Installer, [here][privacy].
 

--- a/README.md
+++ b/README.md
@@ -293,4 +293,30 @@ nix build github:DeterminateSystems/nix-installer#nix-installer.doc
 firefox result-doc/nix-installer/index.html
 ```
 
+## Diagnostics
+
+The goal of the Determinate Nix Installer is to successfully and correctly install Nix.
+The `curl | sh` pipeline and the installer collects a little bit of diagnostic information to help us make that true.
+
+Here is a table of the [diagnostic data we collect][diagnosticdata]:
+
+| Field                 | Use                                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `version`             | The version of the Determinate Nix Installer.                                                         |
+| `planner`             | The method of installing Nix ("linux", "macos", "steam-deck")                                         |
+| `configured-settings` | The names of planner settings which were changed from their default. Does not include the values.     |
+| `os-name`             | The running operating system.                                                                         |
+| `os-version`          | The version of the operating system.                                                                  |
+| `triple`              | The architecture/os/binary format of your system.                                                     |
+| `is-ci`               | Whether the installer is being used in CI (e.g. GitHub Actions).                                      |
+| `action`              | Either "install" or "uninstall".                                                                      |
+| `status`              | "Success", "Failure", etc.                                                                            |
+| `failure_variant`     | A high level description of what the failure was, if any. For example: "Command" if a command failed. |
+
+To disable diagnostic reporting, set the diagnostics URL to an empty string by passing `--diagnostic-endpoint=""`
+
+You can read the full privacy policy for [Determinate Systems], the creators of the Determinate Nix Installer, [here][privacy].
+
+[privacy]: https://determinate.systems/privacy
+[diagnosticdata]: https://github.com/DeterminateSystems/nix-installer/blob/f9f927840d532b71f41670382a30cfcbea2d8a35/src/diagnostics.rs#L29-L43
 [systemd]: https://systemd.io

--- a/README.md
+++ b/README.md
@@ -315,8 +315,9 @@ Here is a table of the [diagnostic data we collect][diagnosticdata]:
 
 To disable diagnostic reporting, set the diagnostics URL to an empty string by passing `--diagnostic-endpoint=""`
 
-You can read the full privacy policy for [Determinate Systems], the creators of the Determinate Nix Installer, [here][privacy].
+You can read the full privacy policy for [Determinate Systems][detsys], the creators of the Determinate Nix Installer, [here][privacy].
 
-[privacy]: https://determinate.systems/privacy
+[detsys]: https://determinate.systems/
 [diagnosticdata]: https://github.com/DeterminateSystems/nix-installer/blob/f9f927840d532b71f41670382a30cfcbea2d8a35/src/diagnostics.rs#L29-L43
+[privacy]: https://determinate.systems/privacy
 [systemd]: https://systemd.io

--- a/README.md
+++ b/README.md
@@ -304,13 +304,13 @@ Here is a table of the [diagnostic data we collect][diagnosticdata]:
 | --------------------- | ----------------------------------------------------------------------------------------------------- |
 | `version`             | The version of the Determinate Nix Installer.                                                         |
 | `planner`             | The method of installing Nix (`linux`, `macos`, `steam-deck`)                                         |
-| `configured_settings` | The names of planner settings which were changed from their default. Does not include the values.     |
+| `configured_settings` | The names of planner settings which were changed from their default. Does _not_ include the values.   |
 | `os_name`             | The running operating system.                                                                         |
 | `os_version`          | The version of the operating system.                                                                  |
-| `triple`              | The architecture/os/binary format of your system.                                                     |
+| `triple`              | The architecture/operating system/binary format of your system.                                       |
 | `is_ci`               | Whether the installer is being used in CI (e.g. GitHub Actions).                                      |
 | `action`              | Either `Install` or `Uninstall`.                                                                      |
-| `status`              | `Success`, `Failure`, etc.                                                                            |
+| `status`              | One of `Success`, `Failure`, `Pending`, or `Cancelled`.                                               |
 | `failure_variant`     | A high level description of what the failure was, if any. For example: `Command` if a command failed. |
 
 To disable diagnostic reporting, set the diagnostics URL to an empty string by passing `--diagnostic-endpoint=""` or setting `NIX_INSTALLER_DIAGNOSTIC_ENDPOINT=""`.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -211,14 +211,14 @@ pub struct CommonSettings {
     /// {
     ///     "version": "0.4.0",
     ///     "planner": "linux",
-    ///     "configured-settings": [ "modify_profile" ],
-    ///     "os-name": "Ubuntu",
-    ///     "os-version": "22.04.1 LTS (Jammy Jellyfish)",
+    ///     "configured_settings": [ "modify_profile" ],
+    ///     "os_name": "Ubuntu",
+    ///     "os_version": "22.04.1 LTS (Jammy Jellyfish)",
     ///     "triple": "x86_64-unknown-linux-gnu",
-    ///     "is-ci": false,
+    ///     "is_ci": false,
     ///     "action": "Install",
     ///     "status": "Failure",
-    ///     "failure-variant": "Symlink"
+    ///     "failure_variant": "Symlink"
     /// }
     ///
     /// To disable diagnostic reporting, unset the default with `--diagnostic-endpoint=`

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -215,8 +215,10 @@ pub struct CommonSettings {
     ///     "os-name": "Ubuntu",
     ///     "os-version": "22.04.1 LTS (Jammy Jellyfish)",
     ///     "triple": "x86_64-unknown-linux-gnu",
+    ///     "is-ci": false,
     ///     "action": "Install",
-    ///     "status": "Success"
+    ///     "status": "Failure",
+    ///     "failure-variant": "Symlink"
     /// }
     ///
     /// To disable diagnostic reporting, unset the default with `--diagnostic-endpoint=`


### PR DESCRIPTION
##### Description

I noticed we didn't add a note about diagnostics when we added it to the repo, so this describes it. I also noticed we don't include a couple fields in the help output, so I added those too.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
