### PR TITLE
Use 0o644 for files, not 0o664

### DIFF
--- a/src/action/common/place_channel_configuration.rs
+++ b/src/action/common/place_channel_configuration.rs
@@ -32,7 +32,7 @@ impl PlaceChannelConfiguration {
                 .join(".nix-channels"),
             None,
             None,
-            0o0664,
+            0o0644,
             buf,
             force,
         )


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
