### PR TITLE
Update default nix_package_url to Nix 2.14.1

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,19 +10,19 @@ use crate::channel_value::ChannelValue;
 
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux x86_64
 pub const NIX_X64_64_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.13.3/nix-2.13.3-x86_64-linux.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-x86_64-linux.tar.xz";
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux x86 (32 bit)
 pub const NIX_I686_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.13.3/nix-2.13.3-i686-linux.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-i686-linux.tar.xz";
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux aarch64
 pub const NIX_AARCH64_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.13.3/nix-2.13.3-aarch64-linux.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-aarch64-linux.tar.xz";
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Darwin x86_64
 pub const NIX_X64_64_DARWIN_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.13.3/nix-2.13.3-x86_64-darwin.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-x86_64-darwin.tar.xz";
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Darwin aarch64
 pub const NIX_AARCH64_DARWIN_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.13.3/nix-2.13.3-aarch64-darwin.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-aarch64-darwin.tar.xz";
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,19 +10,19 @@ use crate::channel_value::ChannelValue;
 
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux x86_64
 pub const NIX_X64_64_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-x86_64-linux.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.1/nix-2.14.1-x86_64-linux.tar.xz";
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux x86 (32 bit)
 pub const NIX_I686_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-i686-linux.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.1/nix-2.14.1-i686-linux.tar.xz";
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux aarch64
 pub const NIX_AARCH64_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-aarch64-linux.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.1/nix-2.14.1-aarch64-linux.tar.xz";
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Darwin x86_64
 pub const NIX_X64_64_DARWIN_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-x86_64-darwin.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.1/nix-2.14.1-x86_64-darwin.tar.xz";
 /// Default [`nix_package_url`](CommonSettings::nix_package_url) for Darwin aarch64
 pub const NIX_AARCH64_DARWIN_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.14.0/nix-2.14.0-aarch64-darwin.tar.xz";
+    "https://releases.nixos.org/nix/nix-2.14.1/nix-2.14.1-aarch64-darwin.tar.xz";
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]


### PR DESCRIPTION
##### Description

2.14.0 was released today.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```

---

Drafted until ~~https://github.com/NixOS/nix/pull/7920~~ https://github.com/NixOS/nix/pull/7925 is resolved, as that could break some CI machines.