### PR TITLE
Detect WSL1 and error

### DIFF
--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -39,6 +39,10 @@ impl Planner for Linux {
             return Err(PlannerError::NixOs);
         }
 
+        if std::env::var("WSL_DISTRO_NAME").is_ok() && !Path::new("/run/WSL").exists() {
+            return Err(PlannerError::Wsl1);
+        }
+
         // We currently do not support SELinux
         match Command::new("getenforce").output().await {
             Ok(output) => {

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -39,7 +39,7 @@ impl Planner for Linux {
             return Err(PlannerError::NixOs);
         }
 
-        if std::env::var("WSL_DISTRO_NAME").is_ok() && !Path::new("/run/WSL").exists() {
+        if std::env::var("WSL_DISTRO_NAME").is_ok() && std::env::var("WSL_INTEROP").is_err() {
             return Err(PlannerError::Wsl1);
         }
 

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -301,7 +301,7 @@ pub enum PlannerError {
     NixOs,
     #[error("`nix` is already a valid command, so it is installed")]
     NixExists,
-    #[error("WSL1 is not supported, please upgrade to WSL2")]
+    #[error("WSL1 is not supported, please upgrade to WSL2: https://learn.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2")]
     Wsl1,
 }
 

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -301,6 +301,8 @@ pub enum PlannerError {
     NixOs,
     #[error("`nix` is already a valid command, so it is installed")]
     NixExists,
+    #[error("WSL1 is not supported, please upgrade to WSL2")]
+    Wsl1,
 }
 
 impl HasExpectedErrors for PlannerError {
@@ -315,6 +317,7 @@ impl HasExpectedErrors for PlannerError {
             PlannerError::Custom(_) => None,
             this @ PlannerError::NixOs => Some(Box::new(this)),
             this @ PlannerError::NixExists => Some(Box::new(this)),
+            this @ PlannerError::Wsl1 => Some(Box::new(this)),
         }
     }
 }


### PR DESCRIPTION
WSL1 is not supported because some things Nix relies on to work are not available.

##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/281.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
