### PR TITLE
Use `launchctl load -w` on macOS

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -114,7 +114,7 @@ impl Action for ConfigureInitService {
                 execute_command(
                     Command::new("launchctl")
                         .process_group(0)
-                        .arg("load")
+                        .args(&["load", "-w"])
                         .arg(DARWIN_NIX_DAEMON_DEST)
                         .stdin(std::process::Stdio::null()),
                 )


### PR DESCRIPTION
    Usage: launchctl load <service-path, service-path2, ...>
            -w      If the service is disabled, it will be enabled. In previous
                    versions of launchd, being disabled meant that a service was
                    not loaded. Now, services are always loaded. If a service is
                    disabled, launchd does not advertise its service endpoints
                    (sockets, Mach ports, etc.).

##### Description

Attempts a simple fix for https://github.com/DeterminateSystems/nix-installer/issues/295.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
