### PR TITLE
Make errors non-exhaustive

### DIFF
--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -105,6 +105,7 @@ impl Action for FetchAndUnpackNix {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum FetchUrlError {
     #[error("Request error")]

--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -96,6 +96,7 @@ impl Action for MoveUnpackedNix {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum MoveUnpackedNixError {
     #[error("Glob pattern error")]

--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -246,6 +246,7 @@ impl Action for SetupDefaultProfile {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum SetupDefaultProfileError {
     #[error("Glob pattern error")]

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -333,6 +333,7 @@ impl Action for ConfigureInitService {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigureNixDaemonServiceError {
     #[error("No supported init system found")]

--- a/src/action/common/place_channel_configuration.rs
+++ b/src/action/common/place_channel_configuration.rs
@@ -107,6 +107,7 @@ impl Action for PlaceChannelConfiguration {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum PlaceChannelConfigurationError {
     #[error("No root home found to place channel configuration in")]

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -138,6 +138,7 @@ impl Action for StartSystemdUnit {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum StartSystemdUnitError {
     #[error("Failed to execute command")]

--- a/src/action/macos/bootstrap_apfs_volume.rs
+++ b/src/action/macos/bootstrap_apfs_volume.rs
@@ -95,6 +95,7 @@ impl Action for BootstrapApfsVolume {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum BootstrapVolumeError {
     #[error("Failed to execute command")]

--- a/src/action/macos/create_apfs_volume.rs
+++ b/src/action/macos/create_apfs_volume.rs
@@ -136,6 +136,7 @@ impl Action for CreateApfsVolume {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum CreateApfsVolumeError {
     #[error("Existing volume called `{0}` found in `diskutil apfs list`, delete it with `diskutil apfs deleteVolume \"{0}\"`")]

--- a/src/action/macos/create_fstab_entry.rs
+++ b/src/action/macos/create_fstab_entry.rs
@@ -200,6 +200,7 @@ fn fstab_entry(uuid: &Uuid, apfs_volume_label: &str) -> String {
     )
 }
 
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum CreateFstabEntryError {
     #[error("An `/etc/fstab` entry for the `/nix` path already exists, consider removing the entry for `/nix`d from `/etc/fstab`")]

--- a/src/action/macos/create_synthetic_objects.rs
+++ b/src/action/macos/create_synthetic_objects.rs
@@ -88,6 +88,7 @@ impl Action for CreateSyntheticObjects {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum CreateSyntheticObjectsError {
     #[error("Failed to execute command")]

--- a/src/action/macos/enable_ownership.rs
+++ b/src/action/macos/enable_ownership.rs
@@ -93,6 +93,7 @@ impl Action for EnableOwnership {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum EnableOwnershipError {
     #[error("Failed to execute command")]

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -253,6 +253,7 @@ impl ActionDescription {
 }
 
 /// An error occurring during an action
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum ActionError {
     /// A custom error

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -152,6 +152,7 @@ impl DiagnosticData {
     }
 }
 
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum DiagnosticError {
     #[error("Unknown url scheme")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use crate::{action::ActionError, planner::PlannerError, settings::InstallSettingsError};
 
 /// An error occurring during a call defined in this crate
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum NixInstallerError {
     /// An error originating from an [`Action`](crate::action::Action)

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -270,6 +270,7 @@ impl BuiltinPlanner {
 }
 
 /// An error originating from a [`Planner`]
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum PlannerError {
     /// `nix-installer` does not have a default planner for the target architecture right now

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -269,8 +269,9 @@ impl Into<BuiltinPlanner> for SteamDeck {
     }
 }
 
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
-enum SteamDeckError {
+pub enum SteamDeckError {
     #[error("`{0}` is not a path that can be canonicalized into an absolute path, bind mounts require an absolute path")]
     AbsolutePathRequired(PathBuf),
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -561,6 +561,7 @@ impl InitSettings {
 }
 
 /// An error originating from a [`Planner::settings`](crate::planner::Planner::settings)
+#[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum InstallSettingsError {
     /// `nix-installer` does not support the architecture right now


### PR DESCRIPTION
##### Description

Adding a new error variant shouldn't force us to bump the version due to being semver-incompatible.

Done with the following:

```
rg 'enum .+Error.* \{' --no-heading -n | cut -d: -f1-2 | while read file; hx "$file"; end
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
