### PR TITLE
Release v0.5.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ surprises.
 
 # What kinds of contributions are needed?
 
-Riff can benefit from all kinds of contributions:
+`nix-installer` can benefit from all kinds of contributions:
 
 * Bug reports
 * Code improvements
@@ -27,7 +27,7 @@ Riff can benefit from all kinds of contributions:
 * Graphical/visual asset improvement
 * Kind words or recommendation on your own site, repo, stream, or social media
   account
-* Onboarding others to using Riff
+* Onboarding others to using `nix-installer`
 
 
 # What are the expectations you can have of the maintainers?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,8 +362,16 @@ If you are working on the `action.yml` There is an integration test for `action.
 
 To cut a release:
 
+* Ensure the `flake.lock`, `Cargo.lock`, and Rust dependencies are up-to-date with the following:
+  + `nix flake update --commit-lock-file`
+  + `cargo update` (and commit)
+  + `cargo outdated`
 * Create a release branch from `main` (`git checkout -b release-v0.0.1`)
 * Remove the `-unreleased` from the `version` field in `Cargo.toml` and `flake.nix`
+* Ensure the VM / container tests still pass with the following:
+  + `nix flake check -L`
+  + `nix build .#hydraJobs.container-test.all.x86_64-linux.all -L`
+  + `nix build .#hydraJobs.vm-test.all.x86_64-linux.all -L`
 * Push the branch, create a PR ("Release v0.0.1")
 * Once the PR tests pass and it has been reviewed, merge it
 * `git pull` on the `main` branch
@@ -376,7 +384,7 @@ To cut a release:
 * Undraft the release
 * Once you are certain the release is good, `cargo publish` it
   + **Warning:** While you can re-release Github releases, it is not possible to do the same on `crates.io`
-* Create a PR bumping the version up one minor in the `Cargo.toml` and `flake.nix`, adding `-unreleased` at the end (`v0.0.2-unreleased`)
+* Create a PR bumping the version up one minor in the `Cargo.toml`, `flake.nix`, and fixture JSON files, adding `-unreleased` at the end (`v0.0.2-unreleased`)
 
 # Who maintains `nix-installer` and why?
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix-installer"
 description = "The Determinate Nix Installer"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 resolver = "2"
 license = "LGPL-2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
           };
           sharedAttrs = {
             pname = "nix-installer";
-            version = "0.4.0";
+            version = "0.5.0";
             src = builtins.path {
               name = "nix-installer-source";
               path = self;

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.0",
   "actions": [
     {
       "action": {

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.0",
   "actions": [
     {
       "action": {

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0",
+  "version": "0.5.0",
   "actions": [
     {
       "action": {


### PR DESCRIPTION
##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/295.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
