### PR TITLE
Make CreateUser idempotent

### DIFF
--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -51,6 +51,9 @@ impl CreateUser {
                     gid,
                 ));
             }
+
+            tracing::debug!("Creating user `{}` already complete", this.name);
+            return Ok(StatefulAction::completed(this));
         }
 
         Ok(StatefulAction::uncompleted(this))


### PR DESCRIPTION
##### Description

When we detect a user exists who meets our needs, just use it.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
