### PR TITLE
Only symlink if the link doesn't already exist

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -210,26 +210,30 @@ impl Action for ConfigureInitService {
                 // cli, interactively ask for permission to remove the file
 
                 Self::check_if_systemd_unit_exists(SERVICE_SRC, SERVICE_DEST).await?;
-                tokio::fs::symlink(SERVICE_SRC, SERVICE_DEST)
-                    .await
-                    .map_err(|e| {
-                        ActionError::Symlink(
-                            PathBuf::from(SERVICE_SRC),
-                            PathBuf::from(SERVICE_DEST),
-                            e,
-                        )
-                    })?;
+                if !Path::new(SERVICE_DEST).exists() {
+                    tokio::fs::symlink(SERVICE_SRC, SERVICE_DEST)
+                        .await
+                        .map_err(|e| {
+                            ActionError::Symlink(
+                                PathBuf::from(SERVICE_SRC),
+                                PathBuf::from(SERVICE_DEST),
+                                e,
+                            )
+                        })?;
+                }
 
                 Self::check_if_systemd_unit_exists(SOCKET_SRC, SOCKET_DEST).await?;
-                tokio::fs::symlink(SOCKET_SRC, SOCKET_DEST)
-                    .await
-                    .map_err(|e| {
-                        ActionError::Symlink(
-                            PathBuf::from(SOCKET_SRC),
-                            PathBuf::from(SOCKET_DEST),
-                            e,
-                        )
-                    })?;
+                if !Path::new(SOCKET_DEST).exists() {
+                    tokio::fs::symlink(SOCKET_SRC, SOCKET_DEST)
+                        .await
+                        .map_err(|e| {
+                            ActionError::Symlink(
+                                PathBuf::from(SOCKET_SRC),
+                                PathBuf::from(SOCKET_DEST),
+                                e,
+                            )
+                        })?;
+                }
 
                 if *start_daemon {
                     execute_command(


### PR DESCRIPTION

##### Description

`check_if_systemd_unit_exists` doesn't error if we don't need to make the symlink, so we need to check if the symlink needs to be made still.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
