### PR TITLE
Tweak the logging levels in CI and in some instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           local-root: install-root/
           logger: pretty
-          log-directives: nix_installer=trace
+          log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Initial uninstall (without a `nix run` first)
@@ -78,7 +78,7 @@ jobs:
         env:
           NIX_INSTALLER_NO_CONFIRM: true
           NIX_INSTALLER_LOGGER: pretty
-          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
         run: |
@@ -99,7 +99,7 @@ jobs:
         with:
           local-root: install-root/
           logger: pretty
-          log-directives: nix_installer=trace
+          log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: echo $PATH
@@ -133,7 +133,7 @@ jobs:
         env:
           NIX_INSTALLER_NO_CONFIRM: true
           NIX_INSTALLER_LOGGER: pretty
-          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
         run: |
@@ -176,7 +176,7 @@ jobs:
           planner: linux
           local-root: install-root/
           logger: pretty
-          log-directives: nix_installer=trace
+          log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Ensure daemon was not configured with init
@@ -194,7 +194,7 @@ jobs:
         env:
           NIX_INSTALLER_NO_CONFIRM: true
           NIX_INSTALLER_LOGGER: pretty
-          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
         run: |
@@ -209,7 +209,7 @@ jobs:
           planner: linux
           local-root: install-root/
           logger: pretty
-          log-directives: nix_installer=trace
+          log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: echo $PATH
@@ -243,7 +243,7 @@ jobs:
         env:
           NIX_INSTALLER_NO_CONFIRM: true
           NIX_INSTALLER_LOGGER: pretty
-          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
         run: |
@@ -290,7 +290,7 @@ jobs:
         with:
           local-root: install-root/
           logger: pretty
-          log-directives: nix_installer=trace
+          log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           planner: steam-deck
@@ -300,7 +300,7 @@ jobs:
         env:
           NIX_INSTALLER_NO_CONFIRM: true
           NIX_INSTALLER_LOGGER: pretty
-          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
         run: |
@@ -325,7 +325,7 @@ jobs:
         with:
           local-root: install-root/
           logger: pretty
-          log-directives: nix_installer=trace
+          log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           planner: steam-deck
@@ -361,7 +361,7 @@ jobs:
         env:
           NIX_INSTALLER_NO_CONFIRM: true
           NIX_INSTALLER_LOGGER: pretty
-          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full
       - name: Ensure `nix` is removed
         run: |
@@ -406,7 +406,7 @@ jobs:
         with:
           local-root: install-root/
           logger: pretty
-          log-directives: nix_installer=trace
+          log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
@@ -416,14 +416,14 @@ jobs:
         env:
           NIX_INSTALLER_NO_CONFIRM: true
           NIX_INSTALLER_LOGGER: pretty
-          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
           local-root: install-root/
           logger: pretty
-          log-directives: nix_installer=trace
+          log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: trusted-users = root runner
@@ -459,5 +459,5 @@ jobs:
         env:
           NIX_INSTALLER_NO_CONFIRM: true
           NIX_INSTALLER_LOGGER: pretty
-          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full

--- a/nix/tests/container-test/default/Dockerfile
+++ b/nix/tests/container-test/default/Dockerfile
@@ -3,7 +3,7 @@ COPY nix-installer /nix-installer
 RUN chmod +x /nix-installer
 COPY binary-tarball /binary-tarball
 RUN mv /binary-tarball/nix-*.tar.xz nix.tar.xz
-RUN /nix-installer/bin/nix-installer install linux --nix-package-url file:///nix.tar.xz --init none --extra-conf "sandbox = false" --no-confirm -vvv
+RUN /nix-installer/bin/nix-installer install linux --logger pretty --log-directive nix_installer=debug --nix-package-url file:///nix.tar.xz --init none --extra-conf "sandbox = false" --no-confirm -vvv
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 RUN nix-build --no-substitute -E 'derivation { name = "foo"; system = "x86_64-linux"; builder = "/bin/sh"; args = ["-c" "echo foobar > $out"]; }'
 RUN /nix/nix-installer uninstall --no-confirm

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -7,7 +7,7 @@ let
     install-default = {
       install = ''
         NIX_PATH=$(readlink -f nix.tar.xz)
-        RUST_BACKTRACE="full" ./nix-installer install --logger pretty --log-directive nix_installer=trace --nix-package-url "file://$NIX_PATH" --no-confirm
+        RUST_BACKTRACE="full" ./nix-installer install --logger pretty --log-directive nix_installer=debug --nix-package-url "file://$NIX_PATH" --no-confirm
       '';
       check = ''
         set -ex

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -34,7 +34,7 @@ pub struct NixInstallerCli {
 
 #[async_trait::async_trait]
 impl CommandExecute for NixInstallerCli {
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self {
             instrumentation: _,

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -57,7 +57,7 @@ pub struct Install {
 
 #[async_trait::async_trait]
 impl CommandExecute for Install {
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self {
             no_confirm,


### PR DESCRIPTION
##### Description

Make some CI/test output a bit more terse.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
