### PR TITLE
Support busybox user/group modification, more informational errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +986,7 @@ dependencies = [
  "typetag",
  "url",
  "uuid",
+ "which",
  "xz2",
 ]
 
@@ -2066,6 +2073,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ os-release = { version = "0.1.0", default-features = false, optional = true }
 is_ci = { version = "1.1.1", default-features = false, optional = true }
 strum = { version = "0.24.1", features = ["derive"] }
 nix-config-parser = { version = "0.1.2", features = ["serde"] }
+which = "4.4.0"
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -276,9 +276,9 @@ impl Action for AddUserToGroup {
                             .stdin(std::process::Stdio::null()),
                     )
                     .await?;
-                } else if which::which("deluser").is_ok() {
+                } else if which::which("delgroup").is_ok() {
                     execute_command(
-                        Command::new("deluser")
+                        Command::new("delgroup")
                             .process_group(0)
                             .args([name, groupname])
                             .stdin(std::process::Stdio::null()),

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -267,14 +267,26 @@ impl Action for AddUserToGroup {
                 .await?;
             },
             _ => {
-                execute_command(
-                    Command::new("gpasswd")
-                        .process_group(0)
-                        .args(["-d"])
-                        .args([&name.to_string(), &groupname.to_string()])
-                        .stdin(std::process::Stdio::null()),
-                )
-                .await?;
+                if which::which("gpasswd").is_ok() {
+                    execute_command(
+                        Command::new("gpasswd")
+                            .process_group(0)
+                            .args(["-d"])
+                            .args([&name.to_string(), &groupname.to_string()])
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else if which::which("deluser").is_ok() {
+                    execute_command(
+                        Command::new("deluser")
+                            .process_group(0)
+                            .args([name, groupname])
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else {
+                    return Err(ActionError::MissingRemoveUserFromGroupCommand);
+                }
             },
         };
 

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -202,14 +202,26 @@ impl Action for AddUserToGroup {
                 .await?;
             },
             _ => {
-                execute_command(
-                    Command::new("gpasswd")
-                        .process_group(0)
-                        .args(["-a"])
-                        .args([&name.to_string(), &groupname.to_string()])
-                        .stdin(std::process::Stdio::null()),
-                )
-                .await?;
+                if which::which("gpasswd").is_ok() {
+                    execute_command(
+                        Command::new("gpasswd")
+                            .process_group(0)
+                            .args(["-a"])
+                            .args([name, groupname])
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else if which::which("addgroup").is_ok() {
+                    execute_command(
+                        Command::new("addgroup")
+                            .process_group(0)
+                            .args([name, groupname])
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else {
+                    return Err(ActionError::MissingAddUserToGroupCommand);
+                }
             },
         }
 

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -155,13 +155,25 @@ impl Action for CreateGroup {
                 if !output.status.success() {}
             },
             _ => {
-                execute_command(
-                    Command::new("groupdel")
-                        .process_group(0)
-                        .arg(&name)
-                        .stdin(std::process::Stdio::null()),
-                )
-                .await?;
+                if which::which("groupdel").is_ok() {
+                    execute_command(
+                        Command::new("groupdel")
+                            .process_group(0)
+                            .arg(name)
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else if which::which("delgroup").is_ok() {
+                    execute_command(
+                        Command::new("delgroup")
+                            .process_group(0)
+                            .arg(name)
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else {
+                    return Err(ActionError::MissingGroupDeletionCommand);
+                }
             },
         };
 

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -99,13 +99,25 @@ impl Action for CreateGroup {
                 .await?;
             },
             _ => {
-                execute_command(
-                    Command::new("groupadd")
-                        .process_group(0)
-                        .args(["-g", &gid.to_string(), "--system", &name])
-                        .stdin(std::process::Stdio::null()),
-                )
-                .await?;
+                if which::which("groupadd").is_ok() {
+                    execute_command(
+                        Command::new("groupadd")
+                            .process_group(0)
+                            .args(["-g", &gid.to_string(), "--system", &name])
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else if which::which("addgroup").is_ok() {
+                    execute_command(
+                        Command::new("addgroup")
+                            .process_group(0)
+                            .args(["-g", &gid.to_string(), "--system", &name])
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else {
+                    return Err(ActionError::MissingGroupCreationCommand);
+                }
             },
         };
 

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -92,7 +92,7 @@ impl Action for CreateGroup {
                             "Nix build group for nix-daemon",
                             "-i",
                             &format!("{gid}"),
-                            name.as_str(),
+                            name,
                         ])
                         .stdin(std::process::Stdio::null()),
                 )
@@ -103,7 +103,7 @@ impl Action for CreateGroup {
                     execute_command(
                         Command::new("groupadd")
                             .process_group(0)
-                            .args(["-g", &gid.to_string(), "--system", &name])
+                            .args(["-g", &gid.to_string(), "--system", name])
                             .stdin(std::process::Stdio::null()),
                     )
                     .await?;
@@ -111,7 +111,7 @@ impl Action for CreateGroup {
                     execute_command(
                         Command::new("addgroup")
                             .process_group(0)
-                            .args(["-g", &gid.to_string(), "--system", &name])
+                            .args(["-g", &gid.to_string(), "--system", name])
                             .stdin(std::process::Stdio::null()),
                     )
                     .await?;

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -98,7 +98,7 @@ impl Action for CreateUser {
         let Self {
             name,
             uid,
-            groupname: _,
+            groupname,
             gid,
         } = self;
 
@@ -178,31 +178,57 @@ impl Action for CreateUser {
                 .await?;
             },
             _ => {
-                execute_command(
-                    Command::new("useradd")
-                        .process_group(0)
-                        .args([
-                            "--home-dir",
-                            "/var/empty",
-                            "--comment",
-                            &format!("\"Nix build user\""),
-                            "--gid",
-                            &gid.to_string(),
-                            "--groups",
-                            &gid.to_string(),
-                            "--no-user-group",
-                            "--system",
-                            "--shell",
-                            "/sbin/nologin",
-                            "--uid",
-                            &uid.to_string(),
-                            "--password",
-                            "\"!\"",
-                            &name.to_string(),
-                        ])
-                        .stdin(std::process::Stdio::null()),
-                )
-                .await?;
+                if which::which("useradd").is_ok() {
+                    execute_command(
+                        Command::new("useradd")
+                            .process_group(0)
+                            .args([
+                                "--home-dir",
+                                "/var/empty",
+                                "--comment",
+                                &format!("\"Nix build user\""),
+                                "--gid",
+                                &gid.to_string(),
+                                "--groups",
+                                &gid.to_string(),
+                                "--no-user-group",
+                                "--system",
+                                "--shell",
+                                "/sbin/nologin",
+                                "--uid",
+                                &uid.to_string(),
+                                "--password",
+                                "\"!\"",
+                                &name.to_string(),
+                            ])
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else if which::which("adduser").is_ok() {
+                    execute_command(
+                        Command::new("adduser")
+                            .process_group(0)
+                            .args([
+                                "--home",
+                                "/var/empty",
+                                "--gecos",
+                                "Nix build user",
+                                "--ingroup",
+                                groupname,
+                                "--system",
+                                "--shell",
+                                "/sbin/nologin",
+                                "--uid",
+                                &uid.to_string(),
+                                "--disabled-password",
+                                &name.to_string(),
+                            ])
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else {
+                    return Err(ActionError::MissingUserCreationCommand);
+                }
             },
         }
 

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -186,7 +186,7 @@ impl Action for CreateUser {
                                 "--home-dir",
                                 "/var/empty",
                                 "--comment",
-                                &format!("\"Nix build user\""),
+                                "Nix build user",
                                 "--gid",
                                 &gid.to_string(),
                                 "--groups",
@@ -198,8 +198,8 @@ impl Action for CreateUser {
                                 "--uid",
                                 &uid.to_string(),
                                 "--password",
-                                "\"!\"",
-                                &name.to_string(),
+                                "!",
+                                name,
                             ])
                             .stdin(std::process::Stdio::null()),
                     )
@@ -221,7 +221,7 @@ impl Action for CreateUser {
                                 "--uid",
                                 &uid.to_string(),
                                 "--disabled-password",
-                                &name.to_string(),
+                                name,
                             ])
                             .stdin(std::process::Stdio::null()),
                     )

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -292,13 +292,25 @@ impl Action for CreateUser {
                 }
             },
             _ => {
-                execute_command(
-                    Command::new("userdel")
-                        .process_group(0)
-                        .args([&name.to_string()])
-                        .stdin(std::process::Stdio::null()),
-                )
-                .await?;
+                if which::which("userdel").is_ok() {
+                    execute_command(
+                        Command::new("userdel")
+                            .process_group(0)
+                            .arg(name)
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else if which::which("deluser").is_ok() {
+                    execute_command(
+                        Command::new("deluser")
+                            .process_group(0)
+                            .arg(name)
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await?;
+                } else {
+                    return Err(ActionError::MissingUserDeletionCommand);
+                }
             },
         };
 

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -5,8 +5,7 @@ use crate::{
     },
     settings::CommonSettings,
 };
-use tokio::task::JoinSet;
-use tracing::{span, Instrument, Span};
+use tracing::{span, Span};
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct CreateUsersAndGroups {

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -259,7 +259,7 @@ impl Action for CreateUsersAndGroups {
         let Self {
             create_users,
             create_group,
-            add_users_to_groups: _,
+            add_users_to_groups,
             nix_build_user_count: _,
             nix_build_group_name: _,
             nix_build_group_id: _,
@@ -299,10 +299,9 @@ impl Action for CreateUsersAndGroups {
             }
         }
 
-        // We don't actually need to do this, when a user is deleted they are removed from groups
-        // for add_user_to_group in add_users_to_groups.iter_mut() {
-        //     add_user_to_group.try_revert().await?;
-        // }
+        for add_user_to_group in add_users_to_groups.iter_mut() {
+            add_user_to_group.try_revert().await?;
+        }
 
         // Create group
         create_group

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -265,24 +265,11 @@ impl Action for CreateUsersAndGroups {
             nix_build_user_prefix: _,
             nix_build_user_id_base: _,
         } = self;
-        let mut errors = Vec::default();
-
         for create_user in create_users.iter_mut() {
-            if let Err(e) = create_user
+            create_user
                 .try_revert()
                 .await
-                .map_err(|e| ActionError::Child(create_user.action_tag(), Box::new(e)))
-            {
-                errors.push(Box::new(e));
-            }
-        }
-
-        if !errors.is_empty() {
-            if errors.len() == 1 {
-                return Err(*errors.into_iter().next().unwrap());
-            } else {
-                return Err(ActionError::Children(errors));
-            }
+                .map_err(|e| ActionError::Child(create_user.action_tag(), Box::new(e)))?;
         }
 
         // We don't actually need to do this, when a user is deleted they are removed from groups

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -435,6 +435,12 @@ pub enum ActionError {
     MissingGroupCreationCommand,
     #[error("Could not find a supported command to add users to groups in PATH; please install `gpasswd` or `addgroup`")]
     MissingAddUserToGroupCommand,
+    #[error(
+        "Could not find a supported command to delete users in PATH; please install `userdel` or `deluser`"
+    )]
+    MissingUserDeletionCommand,
+    #[error("Could not find a supported command to delete groups in PATH; please install `groupdel` or `delgroup`")]
+    MissingGroupDeletionCommand,
 }
 
 impl ActionError {

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -441,6 +441,8 @@ pub enum ActionError {
     MissingUserDeletionCommand,
     #[error("Could not find a supported command to delete groups in PATH; please install `groupdel` or `delgroup`")]
     MissingGroupDeletionCommand,
+    #[error("Could not find a supported command to remove users from groups in PATH; please install `gpasswd` or `deluser`")]
+    MissingRemoveUserFromGroupCommand,
 }
 
 impl ActionError {

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -427,6 +427,14 @@ pub enum ActionError {
     Plist(#[from] plist::Error),
     #[error("Unexpected binary tarball contents found, the build result from `https://releases.nixos.org/?prefix=nix/` or `nix build nix#hydraJobs.binaryTarball.$SYSTEM` is expected")]
     MalformedBinaryTarball,
+    #[error(
+        "Could not find a supported command to create users in PATH; please install `useradd` or `adduser`"
+    )]
+    MissingUserCreationCommand,
+    #[error("Could not find a supported command to create groups in PATH; please install `groupadd` or `addgroup`")]
+    MissingGroupCreationCommand,
+    #[error("Could not find a supported command to add users to groups in PATH; please install `gpasswd` or `addgroup`")]
+    MissingAddUserToGroupCommand,
 }
 
 impl ActionError {


### PR DESCRIPTION
##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/284.
Closes https://github.com/DeterminateSystems/nix-installer/issues/282. (Though since alpine is not systemd-based, it is essentially a single-user install.)

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
