### PR TITLE
Add test for missing users and groups

### DIFF
--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -377,7 +377,7 @@ vm-tests // rec {
   });
   all."x86_64-linux".install-preexisting-self-broken-missing-users-and-group = (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); pkgs.releaseTools.aggregate {
     name = "all";
-    constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".install-preexisting-self-broken-missing-users) vm-tests;
+    constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".install-preexisting-self-broken-missing-users-and-group) vm-tests;
   });
   all."x86_64-linux".install-preexisting-self-broken-daemon-disabled = (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); pkgs.releaseTools.aggregate {
     name = "all";

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -97,6 +97,19 @@ let
       install = install-default.install;
       check = install-default.check;
     };
+    install-preexisting-self-broken-missing-users-and-group = {
+      preinstall = ''
+        NIX_PATH=$(readlink -f nix.tar.xz)
+        RUST_BACKTRACE="full" ./nix-installer install --nix-package-url "file://$NIX_PATH" --no-confirm
+        sudo mv /nix/receipt.json /nix/old-receipt.json
+        for i in {0..31}; do
+          sudo userdel "nixbld''${i}"
+        done
+        sudo groupdel nixbld
+      '';
+      install = install-default.install;
+      check = install-default.check;
+    };
     install-preexisting-self-broken-daemon-disabled = {
       preinstall = ''
         NIX_PATH=$(readlink -f nix.tar.xz)
@@ -362,6 +375,10 @@ vm-tests // rec {
     name = "all";
     constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".install-preexisting-self-broken-missing-users) vm-tests;
   });
+  all."x86_64-linux".install-preexisting-self-broken-missing-users-and-group = (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); pkgs.releaseTools.aggregate {
+    name = "all";
+    constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".install-preexisting-self-broken-missing-users) vm-tests;
+  });
   all."x86_64-linux".install-preexisting-self-broken-daemon-disabled = (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); pkgs.releaseTools.aggregate {
     name = "all";
     constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".install-preexisting-self-broken-daemon-disabled) vm-tests;
@@ -383,6 +400,7 @@ vm-tests // rec {
       all."x86_64-linux".install-preexisting-self-working
       # all."x86_64-linux".install-preexisting-self-broken-no-nix-path
       all."x86_64-linux".install-preexisting-self-broken-missing-users
+      all."x86_64-linux".install-preexisting-self-broken-missing-users-and-group
       all."x86_64-linux".install-preexisting-self-broken-daemon-disabled
       all."x86_64-linux".install-preexisting-self-broken-no-etc-nix
       all."x86_64-linux".install-preexisting-self-broken-unmodified-bashrc


### PR DESCRIPTION
##### Description

Add a test for if all users/groups are missing.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
