### PR TITLE
Make `nix-installer plan invalid-plan` fail

### DIFF
--- a/src/cli/subcommand/plan.rs
+++ b/src/cli/subcommand/plan.rs
@@ -15,8 +15,8 @@ pub struct Plan {
     pub planner: Option<BuiltinPlanner>,
     /// Where to write the generated plan (in JSON format)
     #[clap(
-        long = "plan-file",
-        env = "NIX_INSTALLER_PLAN",
+        long = "out-file",
+        env = "NIX_INSTALLER_PLAN_OUT_FILE",
         default_value = "/dev/stdout"
     )]
     pub output: PathBuf,

--- a/src/cli/subcommand/plan.rs
+++ b/src/cli/subcommand/plan.rs
@@ -13,7 +13,12 @@ use crate::cli::CommandExecute;
 pub struct Plan {
     #[clap(subcommand)]
     pub planner: Option<BuiltinPlanner>,
-    #[clap(env = "NIX_INSTALLER_PLAN", default_value = "/dev/stdout")]
+    /// Where to write the generated plan (in JSON format)
+    #[clap(
+        long = "plan-file",
+        env = "NIX_INSTALLER_PLAN",
+        default_value = "/dev/stdout"
+    )]
     pub output: PathBuf,
 }
 


### PR DESCRIPTION
Prior to this change, the `invalid-plan` would unexpectedly be interpreted as the output path. Now there is a flag to specify where the plan should be written to.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
