### PR TITLE
Only list changed plan settings in summary

### DIFF
--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -137,12 +137,31 @@ impl Planner for MyPlanner {
         Ok(map)
     }
 
+    async fn configured_settings(
+        &self,
+    ) -> Result<HashMap<String, serde_json::Value>, PlannerError> {
+        let default = Self::default().await?.settings()?;
+        let configured = self.settings()?;
+
+        let mut settings: HashMap<String, serde_json::Value> = HashMap::new();
+        for (key, value) in configured.iter() {
+            if default.get(key) != Some(value) {
+                settings.insert(key.clone(), value.clone());
+            }
+        }
+
+        Ok(settings)
+    }
+
     #[cfg(feature = "diagnostics")]
     async fn diagnostic_data(&self) -> Result<nix_installer::diagnostics::DiagnosticData, PlannerError> {
         Ok(nix_installer::diagnostics::DiagnosticData::new(
             self.common.diagnostic_endpoint.clone(),
             self.typetag_name().into(),
-            self.configured_settings().await?,
+            self.configured_settings()
+                .await?
+                .into_keys()
+                .collect::<Vec<_>>(),
         ))
     }
 }

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -158,6 +158,7 @@ impl CommandExecute for Install {
                 match interaction::prompt(
                     install_plan
                         .describe_install(currently_explaining)
+                        .await
                         .map_err(|e| eyre!(e))?,
                     PromptChoice::Yes,
                     currently_explaining,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -73,9 +73,14 @@ impl InstallPlan {
             ..
         } = self;
 
-        let plan_settings = planner
-            .configured_settings()
-            .await?
+        let plan_settings = if explain {
+            // List all settings when explaining
+            planner.settings()?
+        } else {
+            // Otherwise, only list user-configured settings
+            planner.configured_settings().await?
+        };
+        let plan_settings = plan_settings
             .into_iter()
             .map(|(k, v)| format!("* {k}: {v}", k = k.bold()))
             .collect::<Vec<_>>();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -65,34 +65,48 @@ impl InstallPlan {
         })
     }
     #[tracing::instrument(level = "debug", skip_all)]
-    pub fn describe_install(&self, explain: bool) -> Result<String, NixInstallerError> {
+    pub async fn describe_install(&self, explain: bool) -> Result<String, NixInstallerError> {
         let Self {
             planner,
             actions,
             version,
             ..
         } = self;
+
+        let plan_settings = planner
+            .configured_settings()
+            .await?
+            .into_iter()
+            .map(|(k, v)| format!("* {k}: {v}", k = k.bold()))
+            .collect::<Vec<_>>();
+
         let buf = format!(
             "\
             Nix install plan (v{version})\n\
             \n\
             Planner: {planner}\n\
             \n\
-            Planner settings:\n\
-            \n\
-            {plan_settings}\n\
-            \n\
+            {maybe_plan_settings}\
+            \
             The following actions will be taken:\n\
             \n\
             {actions}\n\
         ",
             planner = planner.typetag_name(),
-            plan_settings = planner
-                .settings()?
-                .into_iter()
-                .map(|(k, v)| format!("* {k}: {v}", k = k.bold()))
-                .collect::<Vec<_>>()
-                .join("\n"),
+            maybe_plan_settings = if plan_settings.is_empty() {
+                String::new()
+            } else {
+                // TODO: "Changed planner settings"?
+                format!(
+                    "\
+                    Planner settings:\n\
+                    \n\
+                    {plan_settings}\n\
+                    \n\
+                ",
+                    plan_settings = plan_settings.join("\n")
+                )
+            },
             actions = actions
                 .iter()
                 .map(|v| v.describe_execute())

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -80,10 +80,12 @@ impl InstallPlan {
             // Otherwise, only list user-configured settings
             planner.configured_settings().await?
         };
-        let plan_settings = plan_settings
+        let mut plan_settings = plan_settings
             .into_iter()
             .map(|(k, v)| format!("* {k}: {v}", k = k.bold()))
             .collect::<Vec<_>>();
+        // Stabilize output order
+        plan_settings.sort();
 
         let buf = format!(
             "\

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -105,12 +105,31 @@ impl Planner for Linux {
         Ok(map)
     }
 
+    async fn configured_settings(
+        &self,
+    ) -> Result<HashMap<String, serde_json::Value>, PlannerError> {
+        let default = Self::default().await?.settings()?;
+        let configured = self.settings()?;
+
+        let mut settings: HashMap<String, serde_json::Value> = HashMap::new();
+        for (key, value) in configured.iter() {
+            if default.get(key) != Some(value) {
+                settings.insert(key.clone(), value.clone());
+            }
+        }
+
+        Ok(settings)
+    }
+
     #[cfg(feature = "diagnostics")]
     async fn diagnostic_data(&self) -> Result<crate::diagnostics::DiagnosticData, PlannerError> {
         Ok(crate::diagnostics::DiagnosticData::new(
             self.settings.diagnostic_endpoint.clone(),
             self.typetag_name().into(),
-            self.configured_settings().await?,
+            self.configured_settings()
+                .await?
+                .into_keys()
+                .collect::<Vec<_>>(),
         ))
     }
 }

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -175,12 +175,31 @@ impl Planner for Macos {
         Ok(map)
     }
 
+    async fn configured_settings(
+        &self,
+    ) -> Result<HashMap<String, serde_json::Value>, PlannerError> {
+        let default = Self::default().await?.settings()?;
+        let configured = self.settings()?;
+
+        let mut settings: HashMap<String, serde_json::Value> = HashMap::new();
+        for (key, value) in configured.iter() {
+            if default.get(key) != Some(value) {
+                settings.insert(key.clone(), value.clone());
+            }
+        }
+
+        Ok(settings)
+    }
+
     #[cfg(feature = "diagnostics")]
     async fn diagnostic_data(&self) -> Result<crate::diagnostics::DiagnosticData, PlannerError> {
         Ok(crate::diagnostics::DiagnosticData::new(
             self.settings.diagnostic_endpoint.clone(),
             self.typetag_name().into(),
-            self.configured_settings().await?,
+            self.configured_settings()
+                .await?
+                .into_keys()
+                .collect::<Vec<_>>(),
         ))
     }
 }

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -257,12 +257,31 @@ impl Planner for SteamDeck {
         Ok(map)
     }
 
+    async fn configured_settings(
+        &self,
+    ) -> Result<HashMap<String, serde_json::Value>, PlannerError> {
+        let default = Self::default().await?.settings()?;
+        let configured = self.settings()?;
+
+        let mut settings: HashMap<String, serde_json::Value> = HashMap::new();
+        for (key, value) in configured.iter() {
+            if default.get(key) != Some(value) {
+                settings.insert(key.clone(), value.clone());
+            }
+        }
+
+        Ok(settings)
+    }
+
     #[cfg(feature = "diagnostics")]
     async fn diagnostic_data(&self) -> Result<crate::diagnostics::DiagnosticData, PlannerError> {
         Ok(crate::diagnostics::DiagnosticData::new(
             self.settings.diagnostic_endpoint.clone(),
             self.typetag_name().into(),
-            self.configured_settings().await?,
+            self.configured_settings()
+                .await?
+                .into_keys()
+                .collect::<Vec<_>>(),
         ))
     }
 }


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```

---

There are two possible interfaces -- the one provided in 6d735fc03bfbe7c246e4b3ca2b35fd028f49eee7 (current) and the one provided in ee7d24c968750762036a33649e40e9c4afb581b0 (old).

idk which one I prefer, but they're both pretty Not Ideal.