### PR TITLE
Add fish vendor_conf.d support

### DIFF
--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -8,7 +8,7 @@ use tokio::task::JoinSet;
 use tracing::{span, Instrument, Span};
 
 // Fish has different syntax than zsh/bash, treat it separate
-const PROFILE_FISH_CONFD_SUFFIX: &str = "vendor_conf.d/nix.fish";
+const PROFILE_FISH_VENDOR_CONFD_SUFFIX: &str = "vendor_conf.d/nix.fish";
 /**
  Each of these are common values of $__fish_vendor_confdir,
 under which Fish will look for a file named
@@ -18,7 +18,7 @@ More info: https://fishshell.com/docs/3.3/index.html#configuration-files
 */
 const PROFILE_FISH_VENDOR_CONFD_PREFIXES: &[&str] = &["/usr/share/fish/", "/usr/local/share/fish/"];
 
-const PROFILE_FISH_VENDOR_CONFD_SUFFIX: &str = "conf.d/nix.fish";
+const PROFILE_FISH_CONFD_SUFFIX: &str = "conf.d/nix.fish";
 /**
  Each of these are common values of $__fish_sysconf_dir,
 under which Fish will look for a file named


### PR DESCRIPTION
##### Description

Closes #302

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
