### PR TITLE
Default to systemd, refer to documentation if systemd is not available

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ jobs:
       run: nix build .
 ```
 
+## Without systemd (Linux only)
+
+> **Warning**
+> When installed this way, _only_ `root` or users who can elevate to `root` privileges can run Nix:
+>
+> ```bash
+> sudo -i nix run nixpkgs#hello
+> ```
+
+If you don't use [systemd], you can still install Nix by explicitly specifying the `linux` plan and `--init none`:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux --init none
+```
+
 ## In a container
 
 In Docker/Podman containers or WSL2 instances where an init (like `systemd`) is not present, pass `--init none`.

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -75,6 +75,13 @@ impl ConfigureInitService {
             },
             #[cfg(target_os = "linux")]
             InitSystem::Systemd => {
+                // If /run/systemd/system exists, we can be reasonably sure the machine is booted
+                // with systemd: https://www.freedesktop.org/software/systemd/man/sd_booted.html
+                if !(Path::new("/run/systemd/system").exists() || which::which("systemctl").is_ok())
+                {
+                    return Err(ActionError::SystemdMissing);
+                }
+
                 Self::check_if_systemd_unit_exists(SERVICE_SRC, SERVICE_DEST).await?;
                 Self::check_if_systemd_unit_exists(SOCKET_SRC, SOCKET_DEST).await?;
             },

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -443,6 +443,11 @@ pub enum ActionError {
     MissingGroupDeletionCommand,
     #[error("Could not find a supported command to remove users from groups in PATH; please install `gpasswd` or `deluser`")]
     MissingRemoveUserFromGroupCommand,
+    #[error("\
+        Could not detect systemd; you may be able to get up and running without systemd with `nix-installer install linux --init none`.\n\
+        See https://github.com/DeterminateSystems/nix-installer#without-systemd-linux-only for documentation on usage and drawbacks.\
+        ")]
+    SystemdMissing,
 }
 
 impl ActionError {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -340,13 +340,11 @@ impl CommonSettings {
     }
 }
 #[cfg(target_os = "linux")]
-async fn linux_detect_init() -> (InitSystem, bool) {
+async fn linux_detect_systemd_started() -> bool {
     use std::process::Stdio;
 
-    let mut detected = InitSystem::None;
     let mut started = false;
     if std::path::Path::new("/run/systemd/system").exists() {
-        detected = InitSystem::Systemd;
         started = if tokio::process::Command::new("systemctl")
             .arg("status")
             .stdin(Stdio::null())
@@ -365,7 +363,7 @@ async fn linux_detect_init() -> (InitSystem, bool) {
     }
 
     // TODO: Other inits
-    (detected, started)
+    started
 }
 
 // Builder Pattern
@@ -465,33 +463,26 @@ pub struct InitSettings {
 impl InitSettings {
     /// The default settings for the given Architecture & Operating System
     pub async fn default() -> Result<Self, InstallSettingsError> {
-        let init;
-        let start_daemon;
-
         use target_lexicon::{Architecture, OperatingSystem};
-        match (Architecture::host(), OperatingSystem::host()) {
+        let (init, start_daemon) = match (Architecture::host(), OperatingSystem::host()) {
             #[cfg(target_os = "linux")]
             (Architecture::X86_64, OperatingSystem::Linux) => {
-                (init, start_daemon) = linux_detect_init().await;
+                (InitSystem::Systemd, linux_detect_systemd_started().await)
             },
             #[cfg(target_os = "linux")]
             (Architecture::X86_32(_), OperatingSystem::Linux) => {
-                (init, start_daemon) = linux_detect_init().await;
+                (InitSystem::Systemd, linux_detect_systemd_started().await)
             },
             #[cfg(target_os = "linux")]
             (Architecture::Aarch64(_), OperatingSystem::Linux) => {
-                (init, start_daemon) = linux_detect_init().await;
+                (InitSystem::Systemd, linux_detect_systemd_started().await)
             },
             #[cfg(target_os = "macos")]
             (Architecture::X86_64, OperatingSystem::MacOSX { .. })
-            | (Architecture::X86_64, OperatingSystem::Darwin) => {
-                (init, start_daemon) = (InitSystem::Launchd, true);
-            },
+            | (Architecture::X86_64, OperatingSystem::Darwin) => (InitSystem::Launchd, true),
             #[cfg(target_os = "macos")]
             (Architecture::Aarch64(_), OperatingSystem::MacOSX { .. })
-            | (Architecture::Aarch64(_), OperatingSystem::Darwin) => {
-                (init, start_daemon) = (InitSystem::Launchd, true);
-            },
+            | (Architecture::Aarch64(_), OperatingSystem::Darwin) => (InitSystem::Launchd, true),
             _ => {
                 return Err(InstallSettingsError::UnsupportedArchitecture(
                     target_lexicon::HOST,


### PR DESCRIPTION
…able

##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/308.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```

---

We used to default to `InitSystem::None` if we couldn't detect `systemd`, but that form of running has some drawbacks (well, one drawback: only root and root-privileged users can use Nix), but that would lead to not obviously-broken installations for users who expected it to work without root.

We now make `InitSystem::Systemd` the default and error if `/run/systemd/system` doesn't exist and `systemctl` does not exist in the PATH (apparently the second may succeed on podman...? cc @Hoverbear you suggested `systemd-daemon`, but that doesn't exist for me, so I went with the other obvious indication of `systemd`).

This error suggests `--init none`, which we used to fall back to, but also links to some (brief) documentation in our README on the drawbacks of installing with `InitSystem::None`.