### PR TITLE
Explicit proxy support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower-service",
  "url",
@@ -1761,6 +1762,18 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ eyre = { version = "0.6.8", default-features = false, features = [ "track-caller
 glob = { version = "0.3.0", default-features = false }
 nix = { version = "0.26.0", default-features = false, features = ["user", "fs", "process", "term"] }
 owo-colors = { version = "3.5.0", default-features = false, features = [ "supports-colors" ] }
-reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.11.11", default-features = false, features = ["rustls-tls", "stream", "socks"] }
 serde = { version = "1.0.144", default-features = false, features = [ "std", "derive" ] }
 serde_json = { version = "1.0.85", default-features = false, features = [ "std" ] }
 serde_with = { version = "2.0.1", default-features = false, features = [ "std", "macros" ] }

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -37,7 +37,7 @@ impl FetchAndUnpackNix {
 
         if let Some(proxy) = &proxy {
             match proxy.scheme() {
-                "https" | "socks5" => (),
+                "https" | "http" | "socks5" => (),
                 _ => {
                     return Err(ActionError::Custom(Box::new(
                         FetchUrlError::UnknownProxyScheme,

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -153,6 +153,6 @@ pub enum FetchUrlError {
     Unarchive(#[source] std::io::Error),
     #[error("Unknown url scheme, `file://`, `https://` and `http://` supported")]
     UnknownUrlScheme,
-    #[error("Unknown url scheme, `https://` and `socks5://` supported")]
+    #[error("Unknown url scheme, `https://`, `socks5://`, and `http://` supported")]
     UnknownProxyScheme,
 }

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -36,7 +36,7 @@ impl FetchAndUnpackNix {
         };
 
         if let Some(proxy) = &proxy {
-            match url.scheme() {
+            match proxy.scheme() {
                 "https" | "socks5" => (),
                 _ => {
                     return Err(ActionError::Custom(Box::new(

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -24,9 +24,12 @@ pub struct ProvisionNix {
 impl ProvisionNix {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(settings: &CommonSettings) -> Result<StatefulAction<Self>, ActionError> {
-        let fetch_nix =
-            FetchAndUnpackNix::plan(settings.nix_package_url.clone(), PathBuf::from(SCRATCH_DIR))
-                .await?;
+        let fetch_nix = FetchAndUnpackNix::plan(
+            settings.nix_package_url.clone(),
+            PathBuf::from(SCRATCH_DIR),
+            settings.proxy.clone(),
+        )
+        .await?;
         let create_users_and_group = CreateUsersAndGroups::plan(settings.clone())
             .await
             .map_err(|e| ActionError::Child(CreateUsersAndGroups::action_tag(), Box::new(e)))?;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -172,7 +172,7 @@ pub struct CommonSettings {
     )]
     pub(crate) nix_package_url: Url,
 
-    /// The proxy to use (if any), valid proxy bases are `http://$URL` and `socks5://$URL`
+    /// The proxy to use (if any), valid proxy bases are `https://$URL`, `http://$URL` and `socks5://$URL`
     #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_PROXY"))]
     pub(crate) proxy: Option<Url>,
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -173,6 +173,7 @@ pub struct CommonSettings {
     pub(crate) nix_package_url: Url,
 
     /// The proxy to use (if any), valid proxy bases are `http://$URL` and `socks5://$URL`
+    #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_PROXY"))]
     pub(crate) proxy: Option<Url>,
 
     /// Extra configuration lines for `/etc/nix.conf`

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -172,6 +172,9 @@ pub struct CommonSettings {
     )]
     pub(crate) nix_package_url: Url,
 
+    /// The proxy to use (if any), valid proxy bases are `http://$URL` and `socks5://$URL`
+    pub(crate) proxy: Option<Url>,
+
     /// Extra configuration lines for `/etc/nix.conf`
     #[cfg_attr(feature = "cli", clap(long, action = ArgAction::Set, num_args = 0.., value_delimiter = ',', env = "NIX_INSTALLER_EXTRA_CONF", global = true))]
     pub extra_conf: Vec<String>,
@@ -273,6 +276,7 @@ impl CommonSettings {
             nix_build_user_prefix: nix_build_user_prefix.to_string(),
             nix_build_user_id_base,
             nix_package_url: url.parse()?,
+            proxy: Default::default(),
             extra_conf: Default::default(),
             force: false,
             #[cfg(feature = "diagnostics")]
@@ -292,6 +296,7 @@ impl CommonSettings {
             nix_build_user_prefix,
             nix_build_user_id_base,
             nix_package_url,
+            proxy,
             extra_conf,
             force,
             #[cfg(feature = "diagnostics")]
@@ -327,6 +332,7 @@ impl CommonSettings {
             "nix_package_url".into(),
             serde_json::to_value(nix_package_url)?,
         );
+        map.insert("proxy".into(), serde_json::to_value(proxy)?);
         map.insert("extra_conf".into(), serde_json::to_value(extra_conf)?);
         map.insert("force".into(), serde_json::to_value(force)?);
 


### PR DESCRIPTION
##### Description

Adds explicit proxy support for #289

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
