### PR TITLE
Groom plan synopsis

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -292,8 +292,8 @@ impl Action for ConfigureInitService {
                 vec![ActionDescription::new(
                     "Unconfigure Nix daemon related settings with systemd".to_string(),
                     vec![
-                        "Run `systemctl disable {SOCKET_SRC}`".to_string(),
-                        "Run `systemctl disable {SERVICE_SRC}`".to_string(),
+                        format!("Run `systemctl disable {SOCKET_SRC}`"),
+                        format!("Run `systemctl disable {SERVICE_SRC}`"),
                         "Run `systemd-tempfiles --remove --prefix=/nix/var/nix`".to_string(),
                         "Run `systemctl daemon-reload`".to_string(),
                     ],

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -198,6 +198,7 @@ impl CommandExecute for Install {
                         match interaction::prompt(
                             install_plan
                                 .describe_uninstall(currently_explaining)
+                                .await
                                 .map_err(|e| eyre!(e))?,
                             PromptChoice::Yes,
                             currently_explaining,

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -106,6 +106,7 @@ impl CommandExecute for Uninstall {
             loop {
                 match interaction::prompt(
                     plan.describe_uninstall(currently_explaining)
+                        .await
                         .map_err(|e| eyre!(e))?,
                     PromptChoice::Yes,
                     currently_explaining,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -90,24 +90,25 @@ impl InstallPlan {
         let buf = format!(
             "\
             Nix install plan (v{version})\n\
-            \n\
-            Planner: {planner}\n\
+            Planner: {planner} {maybe_default_setting_note}\n\
             \n\
             {maybe_plan_settings}\
-            \
-            The following actions will be taken:\n\
-            \n\
+            Planned actions:\n\
             {actions}\n\
         ",
             planner = planner.typetag_name(),
+            maybe_default_setting_note = if plan_settings.is_empty() {
+                String::from(" (with default settings)")
+            } else {
+                String::new()
+            },
             maybe_plan_settings = if plan_settings.is_empty() {
                 String::new()
             } else {
                 // TODO: "Changed planner settings"?
                 format!(
                     "\
-                    Planner settings:\n\
-                    \n\
+                    Configured settings:\n\
                     {plan_settings}\n\
                     \n\
                 ",
@@ -213,39 +214,57 @@ impl InstallPlan {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    pub fn describe_uninstall(&self, explain: bool) -> Result<String, NixInstallerError> {
+    pub async fn describe_uninstall(&self, explain: bool) -> Result<String, NixInstallerError> {
         let Self {
-            version: _,
+            version,
             planner,
             actions,
             ..
         } = self;
+
+        let plan_settings = if explain {
+            // List all settings when explaining
+            planner.settings()?
+        } else {
+            // Otherwise, only list user-configured settings
+            planner.configured_settings().await?
+        };
+        let mut plan_settings = plan_settings
+            .into_iter()
+            .map(|(k, v)| format!("* {k}: {v}", k = k.bold()))
+            .collect::<Vec<_>>();
+        // Stabilize output order
+        plan_settings.sort();
+
         let buf = format!(
             "\
-            Nix uninstall plan\n\
+            Nix uninstall plan (v{version})\n\
             \n\
-            Planner: {planner}\n\
+            Planner: {planner} {maybe_default_setting_note}\n\
             \n\
-            Planner settings:\n\
-            \n\
-            {plan_settings}\n\
-            \n\
-            The following actions will be taken{maybe_explain}:\n\
-            \n\
+            {maybe_plan_settings}\
+            Planned actions:\n\
             {actions}\n\
         ",
-            maybe_explain = if !explain {
-                " (`--explain` for more context)"
-            } else {
-                ""
-            },
             planner = planner.typetag_name(),
-            plan_settings = planner
-                .settings()?
-                .into_iter()
-                .map(|(k, v)| format!("* {k}: {v}", k = k.bold()))
-                .collect::<Vec<_>>()
-                .join("\n"),
+            maybe_default_setting_note = if plan_settings.is_empty() {
+                String::from(" (with default settings)")
+            } else {
+                String::new()
+            },
+            maybe_plan_settings = if plan_settings.is_empty() {
+                String::new()
+            } else {
+                // TODO: "Changed planner settings"?
+                format!(
+                    "\
+                Configured settings:\n\
+                {plan_settings}\n\
+                \n\
+            ",
+                    plan_settings = plan_settings.join("\n")
+                )
+            },
             actions = actions
                 .iter()
                 .rev()


### PR DESCRIPTION
##### Description

Tweak and tune how we print plans:

![image](https://user-images.githubusercontent.com/130903/225079145-3643e6f2-b2d8-40a1-a9fb-7832cb88c5bd.png)
![image](https://user-images.githubusercontent.com/130903/225079273-704777dd-514a-4e11-a616-8919492cce24.png)


##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
