### PR TITLE
Update zshrc, not zshenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ zsh:1: command not found: nix-store
 error: cannot connect to '$USER@$HOST'
 ```
 
-The way MacOS populates the `PATH` environment differs from other environments. ([Some background](https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2).)
+The way MacOS populates the `PATH` environment differs from other environments. ([Some background](https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2))
 
 There are two possible workarounds for this:
 
@@ -340,7 +340,7 @@ There are two possible workarounds for this:
   fi
   # End Nix
   ```
-  Note that this strategy has some behavioral caveats. For example, if `PATH` gets unset then a script invoked, `PATH` may not be as empty as expected:
+  This strategy has some behavioral caveats. For example, if `PATH` gets unset then a script invoked, `PATH` may not be as empty as expected:
   ```bash
   $ cat example.sh     
   #! /bin/zsh
@@ -348,6 +348,7 @@ There are two possible workarounds for this:
   $ PATH= ./example.sh 
   /Users/ephemeraladmin/.nix-profile/bin:/nix/var/nix/profiles/default/bin:
   ```
+  > Note: This strategy results in Nix's paths being present on `$PATH` and may have a minor impact on performance
 
 ## Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -314,8 +314,6 @@ While `nix-installer` tries to provide a complete and seamless experience, there
 
 ### Using MacOS remote SSH builders, Nix binaries are not on `$PATH`
 
-The way MacOS populates the `PATH` environment differs from other environments. ([Some background](https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2)).
-
 When connecting to a Mac remote SSH builder users may sometimes see this error:
 
 ```
@@ -325,12 +323,15 @@ zsh:1: command not found: nix-store
 error: cannot connect to '$USER@$HOST'
 ```
 
+The way MacOS populates the `PATH` environment differs from other environments. ([Some background](https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2)).
+
 There are two possible workarounds for this:
 
 * **(Preferred)** Update the remote builder URL to include the `remote-program` parameter pointing to `nix-store`. For example:
   ```bash
   nix store ping --store "ssh://$USER@$HOST?remote-program=/nix/var/nix/profiles/default/bin/nix-store"
   ```
+  If you are unsure where the `nix-store` binary is located, run `which nix-store` on the remote.
 * Update `/etc/zshenv` on the remote so that `zsh` populates the Nix path for every shell, even those that are neither *interactive* or *login*:
   ```bash
   # Nix
@@ -339,7 +340,7 @@ There are two possible workarounds for this:
   fi
   # End Nix
   ```
-  Note that this strategy has some behavioral caveats. For example:
+  Note that this strategy has some behavioral caveats. For example, if `PATH` gets unset then a script invoked, `PATH` may not be as empty as expected:
   ```bash
   $ cat example.sh     
   #! /bin/zsh
@@ -366,7 +367,7 @@ Here is a table of the [diagnostic data we collect][diagnosticdata]:
 | `is_ci`               | Whether the installer is being used in CI (e.g. GitHub Actions).                                      |
 | `action`              | Either `Install` or `Uninstall`.                                                                      |
 | `status`              | One of `Success`, `Failure`, `Pending`, or `Cancelled`.                                               |
-| `failure_variant`     | A high level description of what the failure was, if any. For example: `Command` if a command failed. |
+| `failure_chain`     | A high level description of what the failure was, if any. For example: `Command("diskutil")` if the command `diskutil list` failed. |
 
 To disable diagnostic reporting, set the diagnostics URL to an empty string by passing `--diagnostic-endpoint=""` or setting `NIX_INSTALLER_DIAGNOSTIC_ENDPOINT=""`.
 

--- a/README.md
+++ b/README.md
@@ -340,15 +340,20 @@ There are two possible workarounds for this:
   fi
   # End Nix
   ```
-  This strategy has some behavioral caveats. For example, if `PATH` gets unset then a script invoked, `PATH` may not be as empty as expected:
-  ```bash
-  $ cat example.sh     
-  #! /bin/zsh
-  echo $PATH
-  $ PATH= ./example.sh 
-  /Users/ephemeraladmin/.nix-profile/bin:/nix/var/nix/profiles/default/bin:
-  ```
-  > Note: This strategy results in Nix's paths being present on `$PATH` and may have a minor impact on performance
+  <details>
+    <summary>This strategy has some behavioral caveats, namely, `$PATH` may have unexpected contents</summary>
+
+    For example, if `PATH` gets unset then a script invoked, `PATH` may not be as empty as expected:
+    ```bash
+    $ cat example.sh     
+    #! /bin/zsh
+    echo $PATH
+    $ PATH= ./example.sh 
+    /Users/ephemeraladmin/.nix-profile/bin:/nix/var/nix/profiles/default/bin:
+    ```
+    **Note:** This strategy results in Nix's paths being present on `$PATH` twice and may have a minor impact on performance
+
+  </details>
 
 ## Diagnostics
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ There are two possible workarounds for this:
     $ PATH= ./example.sh 
     /Users/ephemeraladmin/.nix-profile/bin:/nix/var/nix/profiles/default/bin:
     ```
-    **Note:** This strategy results in Nix's paths being present on `$PATH` twice and may have a minor impact on performance
+    This strategy results in Nix's paths being present on `$PATH` twice and may have a minor impact on performance.
 
   </details>
 

--- a/README.md
+++ b/README.md
@@ -310,13 +310,13 @@ firefox result-doc/nix-installer/index.html
 
 ## Quirks
 
-While `nix-installer` tries to provide a complete and seamless experience, there are unfortunately some issues which may require manual intervention or operator choices.
+While `nix-installer` tries to provide a comprehensive and unquirky experience, there are unfortunately some issues which may require manual intervention or operator choices.
 
 ### Using MacOS remote SSH builders, Nix binaries are not on `$PATH`
 
 When connecting to a Mac remote SSH builder users may sometimes see this error:
 
-```
+```bash
 $ nix store ping --store "ssh://$USER@$HOST"
 Store URL: ssh://$USER@$HOST
 zsh:1: command not found: nix-store

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ zsh:1: command not found: nix-store
 error: cannot connect to '$USER@$HOST'
 ```
 
-The way MacOS populates the `PATH` environment differs from other environments. ([Some background](https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2)).
+The way MacOS populates the `PATH` environment differs from other environments. ([Some background](https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2).)
 
 There are two possible workarounds for this:
 

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -34,8 +34,11 @@ const PROFILE_FISH_CONFD_PREFIXES: &[&str] = &[
 const PROFILE_TARGETS: &[&str] = &[
     "/etc/bashrc",
     "/etc/profile.d/nix.sh",
-    "/etc/zshenv",
     "/etc/bash.bashrc",
+    // https://zsh.sourceforge.io/Intro/intro_3.html
+    "/etc/zshrc",
+    "/etc/zsh/zshrc",
+    "/etc/zshenv",
     "/etc/zsh/zshenv",
 ];
 const PROFILE_NIX_FILE_SHELL: &str = "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh";

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -38,8 +38,6 @@ const PROFILE_TARGETS: &[&str] = &[
     // https://zsh.sourceforge.io/Intro/intro_3.html
     "/etc/zshrc",
     "/etc/zsh/zshrc",
-    "/etc/zshenv",
-    "/etc/zsh/zshenv",
 ];
 const PROFILE_NIX_FILE_SHELL: &str = "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh";
 const PROFILE_NIX_FILE_FISH: &str = "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.fish";


### PR DESCRIPTION
##### Description

This PR attempts to find some consistently desired behavior for users in the case of:

* [x] Running `nix store ping --store ssh://$USER@$HOST -vvv` on Macs and Linux remotes
* [x] Opening a terminal on Mac (which is login and interactive)
* [x] Opening a terminal on Linux (which is interactive)

This should workaround https://github.com/DeterminateSystems/nix-installer/issues/327.

It's not an ideal solution, but it's the most obvious workaround for the time being.

Also adds some documentation for users.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
