### PR TITLE
Update the install differences in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ The `nix-installer` tool is ready to use in a number of environments:
 
 Differing from the current official [Nix](https://github.com/NixOS/nix) installer scripts:
 
-* Nix is installed with the `nix-command` and `flakes` features enabled in the `nix.conf`
-* `nix-installer` stores an installation receipt (for uninstalling) at `/nix/receipt.json` as well as a copy of the install binary at `/nix/nix-installer`
+* In `nix.conf`:
+  + the `nix-command` and `flakes` features are enabled
+  + `bash-prompt-prefix` is set
+  + `auto-optimise-store` is set to `true`
+  * `extra-nix-path` is set to `nixpkgs=flake:nixpkgs`
+* an installation receipt (for uninstalling) is stored at `/nix/receipt.json` as well as a copy of the install binary at `/nix/nix-installer`
+* `nix-channel --update` is not run, `~/.nix-channels` is not provisioned
 
 ## Motivations
 


### PR DESCRIPTION
##### Description

We have some more differences now. :)

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
