### PR TITLE
Add ssl-cert-file option

### DIFF
--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -29,9 +29,13 @@ impl ConfigureNix {
             .map_err(|e| ActionError::Child(SetupDefaultProfile::action_tag(), Box::new(e)))?;
 
         let configure_shell_profile = if settings.modify_profile {
-            Some(ConfigureShellProfile::plan().await.map_err(|e| {
-                ActionError::Child(ConfigureShellProfile::action_tag(), Box::new(e))
-            })?)
+            Some(
+                ConfigureShellProfile::plan(settings.ssl_cert_file.clone())
+                    .await
+                    .map_err(|e| {
+                        ActionError::Child(ConfigureShellProfile::action_tag(), Box::new(e))
+                    })?,
+            )
         } else {
             None
         };

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 /*! Configurable knobs and their related errors
 */
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 #[cfg(feature = "cli")]
 use clap::ArgAction;
@@ -176,6 +176,10 @@ pub struct CommonSettings {
     #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_PROXY"))]
     pub(crate) proxy: Option<Url>,
 
+    /// An SSL cert to use (if any), used for fetching Nix and sets `NIX_SSL_CERT_FILE` for Nix
+    #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_SSL_CERT_FILE"))]
+    pub(crate) ssl_cert_file: Option<PathBuf>,
+
     /// Extra configuration lines for `/etc/nix.conf`
     #[cfg_attr(feature = "cli", clap(long, action = ArgAction::Set, num_args = 0.., value_delimiter = ',', env = "NIX_INSTALLER_EXTRA_CONF", global = true))]
     pub extra_conf: Vec<String>,
@@ -279,6 +283,7 @@ impl CommonSettings {
             proxy: Default::default(),
             extra_conf: Default::default(),
             force: false,
+            ssl_cert_file: Default::default(),
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint: Some(
                 "https://install.determinate.systems/nix/diagnostic".try_into()?,
@@ -299,6 +304,7 @@ impl CommonSettings {
             proxy,
             extra_conf,
             force,
+            ssl_cert_file,
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint,
         } = self;
@@ -333,6 +339,7 @@ impl CommonSettings {
             serde_json::to_value(nix_package_url)?,
         );
         map.insert("proxy".into(), serde_json::to_value(proxy)?);
+        map.insert("ssl_cert_file".into(), serde_json::to_value(ssl_cert_file)?);
         map.insert("extra_conf".into(), serde_json::to_value(extra_conf)?);
         map.insert("force".into(), serde_json::to_value(force)?);
 


### PR DESCRIPTION
##### Description

Add an explicit `ssl-cert-file` option which is reflected in the created shell profiles, and influences the CA certs used for fetching Nix.

In #332 we taught the installer to use the system provided CA certs, but did not address anything to do with Nix. This lead to problems in #289.

On Linux systems, users of popular distros can expect that Nix would pick up their system `ca-certificates` and "just work", even if they have a custom CA required for various MITM configurations. This was done here: https://github.com/NixOS/nix/blob/1b8c13cbbaf26aabf2facd339bb1da479a88113c/scripts/nix-profile-daemon.sh.in#L34-L61

However, on Mac it's hardcoded: https://github.com/NixOS/nix/blob/master/misc/launchd/org.nixos.nix-daemon.plist.in#L8. A way to configure it is documented at https://nixos.org/manual/nix/stable/installation/env-variables.html#nix_ssl_cert_file-with-macos-and-the-nix-daemon, however that's not necessary. Setting the environment in the shell appears to be sufficient.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
