### PR TITLE
Proxy envs need to get elevated

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -107,6 +107,8 @@ pub fn ensure_root() -> eyre::Result<()> {
                 "GITHUB_PATH" => true,
                 // Used for detecting what command to suggest for sourcing Nix
                 "SHELL" => true,
+                // Proxy settings (automatically picked up by Reqwest)
+                "HTTP_PROXY" | "http_proxy" | "HTTPS_PROXY" | "https_proxy" => true,
                 // Our own environments
                 key if key.starts_with("NIX_INSTALLER") => true,
                 _ => false,


### PR DESCRIPTION
##### Description

Elevate with the proxy envs that are commonly used and documented both https://docs.rs/reqwest/latest/reqwest/index.html#proxies and https://nixos.org/manual/nix/stable/installation/env-variables.html#proxy-environment-variables so that they "Just work"

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
