### PR TITLE
Set NIX_SSL_CERT_FILE in the daemon

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -1,5 +1,6 @@
-use std::path::{Path, PathBuf};
-
+#[cfg(target_os = "linux")]
+use std::path::Path;
+use std::path::PathBuf;
 use tokio::process::Command;
 use tracing::{span, Span};
 

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -162,6 +162,7 @@ impl Planner for MyPlanner {
                 .await?
                 .into_keys()
                 .collect::<Vec<_>>(),
+            self.common.ssl_cert_file.clone(),
         ))
     }
 }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -197,7 +197,7 @@ use std::{error::Error, process::Output};
 use tokio::task::JoinError;
 use tracing::Span;
 
-use crate::error::HasExpectedErrors;
+use crate::{error::HasExpectedErrors, CertificateError};
 
 /// An action which can be reverted or completed, with an action state
 ///
@@ -305,6 +305,9 @@ pub enum ActionError {
     /// A custom error
     #[error(transparent)]
     Custom(Box<dyn std::error::Error + Send + Sync>),
+    /// An error to do with certificates
+    #[error(transparent)]
+    Certificate(#[from] CertificateError),
     /// A child error
     #[error("Child action `{0}`")]
     Child(ActionTag, #[source] Box<ActionError>),

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -84,10 +84,14 @@ impl Planner for Linux {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            ConfigureInitService::plan(self.init.init, self.init.start_daemon)
-                .await
-                .map_err(PlannerError::Action)?
-                .boxed(),
+            ConfigureInitService::plan(
+                self.init.init,
+                self.init.start_daemon,
+                self.settings.ssl_cert_file.clone(),
+            )
+            .await
+            .map_err(PlannerError::Action)?
+            .boxed(),
             RemoveDirectory::plan(crate::settings::SCRATCH_DIR)
                 .await
                 .map_err(PlannerError::Action)?
@@ -130,6 +134,7 @@ impl Planner for Linux {
                 .await?
                 .into_keys()
                 .collect::<Vec<_>>(),
+            self.settings.ssl_cert_file.clone(),
         ))
     }
 }

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -142,10 +142,14 @@ impl Planner for Macos {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            ConfigureInitService::plan(InitSystem::Launchd, true)
-                .await
-                .map_err(PlannerError::Action)?
-                .boxed(),
+            ConfigureInitService::plan(
+                InitSystem::Launchd,
+                true,
+                self.settings.ssl_cert_file.clone(),
+            )
+            .await
+            .map_err(PlannerError::Action)?
+            .boxed(),
             RemoveDirectory::plan(crate::settings::SCRATCH_DIR)
                 .await
                 .map_err(PlannerError::Action)?
@@ -200,6 +204,7 @@ impl Planner for Macos {
                 .await?
                 .into_keys()
                 .collect::<Vec<_>>(),
+            self.settings.ssl_cert_file.clone(),
         ))
     }
 }

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -78,6 +78,7 @@ impl Planner for MyPlanner {
                 .await?
                 .into_keys()
                 .collect::<Vec<_>>(),
+            self.common.ssl_cert_file.clone(),
         ))
     }
 }

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -226,10 +226,14 @@ impl Planner for SteamDeck {
                 .map_err(PlannerError::Action)?
                 .boxed(),
             // Init is required for the steam-deck archetype to make the `/nix` mount
-            ConfigureInitService::plan(InitSystem::Systemd, true)
-                .await
-                .map_err(PlannerError::Action)?
-                .boxed(),
+            ConfigureInitService::plan(
+                InitSystem::Systemd,
+                true,
+                self.settings.ssl_cert_file.clone(),
+            )
+            .await
+            .map_err(PlannerError::Action)?
+            .boxed(),
             StartSystemdUnit::plan("ensure-symlinked-units-resolve.service".to_string(), true)
                 .await
                 .map_err(PlannerError::Action)?
@@ -282,6 +286,7 @@ impl Planner for SteamDeck {
                 .await?
                 .into_keys()
                 .collect::<Vec<_>>(),
+            self.settings.ssl_cert_file.clone(),
         ))
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -68,7 +68,7 @@ pub struct CommonSettings {
             long = "no-modify-profile"
         )
     )]
-    pub(crate) modify_profile: bool,
+    pub modify_profile: bool,
 
     /// Number of build users to create
     #[cfg_attr(
@@ -81,7 +81,7 @@ pub struct CommonSettings {
             global = true
         )
     )]
-    pub(crate) nix_build_user_count: u32,
+    pub nix_build_user_count: u32,
 
     /// The Nix build group name
     #[cfg_attr(
@@ -93,7 +93,7 @@ pub struct CommonSettings {
             global = true
         )
     )]
-    pub(crate) nix_build_group_name: String,
+    pub nix_build_group_name: String,
 
     /// The Nix build group GID
     #[cfg_attr(
@@ -105,7 +105,7 @@ pub struct CommonSettings {
             global = true
         )
     )]
-    pub(crate) nix_build_group_id: u32,
+    pub nix_build_group_id: u32,
 
     /// The Nix build user prefix (user numbers will be postfixed)
     #[cfg_attr(
@@ -120,7 +120,7 @@ pub struct CommonSettings {
         all(target_os = "linux", feature = "cli"),
         clap(default_value = "nixbld")
     )]
-    pub(crate) nix_build_user_prefix: String,
+    pub nix_build_user_prefix: String,
 
     /// The Nix build user base UID (ascending)
     #[cfg_attr(
@@ -133,7 +133,7 @@ pub struct CommonSettings {
         all(target_os = "linux", feature = "cli"),
         clap(default_value_t = 30_000)
     )]
-    pub(crate) nix_build_user_id_base: u32,
+    pub nix_build_user_id_base: u32,
 
     /// The Nix package URL
     #[cfg_attr(
@@ -170,15 +170,15 @@ pub struct CommonSettings {
             default_value = NIX_AARCH64_LINUX_URL,
         )
     )]
-    pub(crate) nix_package_url: Url,
+    pub nix_package_url: Url,
 
     /// The proxy to use (if any), valid proxy bases are `https://$URL`, `http://$URL` and `socks5://$URL`
     #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_PROXY"))]
-    pub(crate) proxy: Option<Url>,
+    pub proxy: Option<Url>,
 
     /// An SSL cert to use (if any), used for fetching Nix and sets `NIX_SSL_CERT_FILE` for Nix
     #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_SSL_CERT_FILE"))]
-    pub(crate) ssl_cert_file: Option<PathBuf>,
+    pub ssl_cert_file: Option<PathBuf>,
 
     /// Extra configuration lines for `/etc/nix.conf`
     #[cfg_attr(feature = "cli", clap(long, action = ArgAction::Set, num_args = 0.., value_delimiter = ',', env = "NIX_INSTALLER_EXTRA_CONF", global = true))]
@@ -195,7 +195,7 @@ pub struct CommonSettings {
             env = "NIX_INSTALLER_FORCE"
         )
     )]
-    pub(crate) force: bool,
+    pub force: bool,
 
     #[cfg(feature = "diagnostics")]
     /// The URL or file path for an installation diagnostic to be sent
@@ -379,69 +379,6 @@ async fn linux_detect_systemd_started() -> bool {
     started
 }
 
-// Builder Pattern
-impl CommonSettings {
-    /// Number of build users to create
-    pub fn nix_build_user_count(&mut self, count: u32) -> &mut Self {
-        self.nix_build_user_count = count;
-        self
-    }
-
-    /// Modify the user profile to automatically load nix
-    pub fn modify_profile(&mut self, toggle: bool) -> &mut Self {
-        self.modify_profile = toggle;
-        self
-    }
-
-    /// The Nix build group name
-    pub fn nix_build_group_name(&mut self, val: String) -> &mut Self {
-        self.nix_build_group_name = val;
-        self
-    }
-
-    /// The Nix build group GID
-    pub fn nix_build_group_id(&mut self, count: u32) -> &mut Self {
-        self.nix_build_group_id = count;
-        self
-    }
-
-    /// The Nix build user prefix (user numbers will be postfixed)
-    pub fn nix_build_user_prefix(&mut self, val: String) -> &mut Self {
-        self.nix_build_user_prefix = val;
-        self
-    }
-
-    /// The Nix build user base UID (ascending)
-    pub fn nix_build_user_id_base(&mut self, count: u32) -> &mut Self {
-        self.nix_build_user_id_base = count;
-        self
-    }
-
-    /// The Nix package URL
-    pub fn nix_package_url(&mut self, url: Url) -> &mut Self {
-        self.nix_package_url = url;
-        self
-    }
-    /// Extra configuration lines for `/etc/nix.conf`
-    pub fn extra_conf(&mut self, extra_conf: Vec<String>) -> &mut Self {
-        self.extra_conf = extra_conf;
-        self
-    }
-
-    /// If `nix-installer` should forcibly recreate files it finds existing
-    pub fn force(&mut self, force: bool) -> &mut Self {
-        self.force = force;
-        self
-    }
-
-    #[cfg(feature = "diagnostics")]
-    /// The URL or file path for an [`DiagnosticReport`][crate::diagnostics::DiagnosticReport] to be sent
-    pub fn diagnostic_endpoint(&mut self, diagnostic_endpoint: Option<Url>) -> &mut Self {
-        self.diagnostic_endpoint = diagnostic_endpoint;
-        self
-    }
-}
-
 #[serde_with::serde_as]
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 #[cfg_attr(feature = "cli", derive(clap::Parser))]
@@ -456,7 +393,7 @@ pub struct InitSettings {
         all(target_os = "linux", feature = "cli"),
         clap(default_value_t = InitSystem::Systemd)
     )]
-    pub(crate) init: InitSystem,
+    pub init: InitSystem,
 
     /// Start the daemon (if not `--init none`)
     #[cfg_attr(
@@ -470,7 +407,7 @@ pub struct InitSettings {
             long = "no-start-daemon"
         )
     )]
-    pub(crate) start_daemon: bool,
+    pub start_daemon: bool,
 }
 
 impl InitSettings {


### PR DESCRIPTION
##### Description

Investigating #289 more, I asked @edolstra for some guidance around when to set `NIX_SSL_CERT_FILE`. Resulting from that discussion, this PR adds the necessary environment settings into the init services of both Mac and Linux.

A side note: It would be good to split up `configure_init_service.rs` more...

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
