### PR TITLE
Use nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -112,16 +112,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1672580127,
-        "narHash": "sha256-3lW3xZslREhJogoOkjeZtlBtvFMyxHku7I/9IVehhT8=",
+        "lastModified": 1678875422,
+        "narHash": "sha256-T3o6NcQPwXjxJMn2shz86Chch4ljXgZn746c2caGxd8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0874168639713f547c05947c76124f78441ea46c",
+        "rev": "126f49a01de5b7e35a43fd43f891ecf6d3a51459",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "The Determinate Nix Installer";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     fenix = {
       url = "github:nix-community/fenix";
@@ -58,7 +58,7 @@
     {
       overlays.default = final: prev:
         let
-          toolchain = fenixToolchain final.hostPlatform.system;
+          toolchain = fenixToolchain final.stdenv.system;
           naerskLib = final.callPackage naersk {
             cargo = toolchain;
             rustc = toolchain;
@@ -95,19 +95,19 @@
         in
         rec {
           nix-installer = naerskLib.buildPackage sharedAttrs;
-        } // nixpkgs.lib.optionalAttrs (prev.hostPlatform.system == "x86_64-linux") rec {
+        } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "x86_64-linux") rec {
           default = nix-installer-static;
           nix-installer-static = naerskLib.buildPackage
             (sharedAttrs // {
               CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
             });
-        } // nixpkgs.lib.optionalAttrs (prev.hostPlatform.system == "i686-linux") rec {
+        } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "i686-linux") rec {
           default = nix-installer-static;
           nix-installer-static = naerskLib.buildPackage
             (sharedAttrs // {
               CARGO_BUILD_TARGET = "i686-unknown-linux-musl";
             });
-        } // nixpkgs.lib.optionalAttrs (prev.hostPlatform.system == "aarch64-linux") rec {
+        } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "aarch64-linux") rec {
           default = nix-installer-static;
           nix-installer-static = naerskLib.buildPackage
             (sharedAttrs // {

--- a/src/action/macos/create_synthetic_objects.rs
+++ b/src/action/macos/create_synthetic_objects.rs
@@ -5,7 +5,7 @@ use crate::execute_command;
 
 use crate::action::{Action, ActionDescription, ActionError, ActionTag, StatefulAction};
 
-/// Create the synthetic objects defined in `/etc/syntethic.conf`
+/// Create the synthetic objects defined in `/etc/synthetic.conf`
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct CreateSyntheticObjects;
 

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,4 +1,4 @@
-/*! An executable or revertable step, possibly orcestrating sub-[`Action`]s using things like
+/*! An executable or revertable step, possibly orchestrating sub-[`Action`]s using things like
     [`JoinSet`](tokio::task::JoinSet)s
 
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ pub enum NixInstallerError {
         #[source]
         serde_json::Error,
     ),
-    /// An error ocurring when a signal is issued along [`InstallPlan::install`](crate::InstallPlan::install)'s `cancel_channel` argument
+    /// An error occurring when a signal is issued along [`InstallPlan::install`](crate::InstallPlan::install)'s `cancel_channel` argument
     #[error("Cancelled by user")]
     Cancelled,
     /// Semver error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 `nix-installer` breaks down into three main concepts:
 
-* [`Action`]: An executable or revertable step, possibly orcestrating sub-[`Action`]s using things
+* [`Action`]: An executable or revertable step, possibly orchestrating sub-[`Action`]s using things
   like [`JoinSet`](tokio::task::JoinSet)s.
 * [`InstallPlan`]: A set of [`Action`]s, along with some metadata, which can be carried out to
   drive an install or revert.


### PR DESCRIPTION
##### Description

So it sounds like there is no unified channel for Linux and Mac for nixpkgs in any stable form, only unstable.

If you're on Mac you have to pick `nixpkgs-22.05-darwin`  (which is undocumented https://nixos.wiki/wiki/Nix_channels) and on Linux you have to pick `nixos-22.05` since `nixpkgs-22.05` does not exist.

Opting to use `nixpkgs-unstable` means we may see some breakage, but we can always opt not to update our lock and keep our dependencies unchanged.

This creates a better experience for Mac users trying to build `nix-installer` as they don't need to build the whole world.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
