### PR TITLE
Add Rosetta check for Mac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "erased-serde"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +997,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "strum",
+ "sysctl",
  "tar",
  "target-lexicon",
  "tempfile",
@@ -1412,6 +1425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1647,6 +1669,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sysctl"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed66d6a2ccbd656659289bc90767895b7abbdec897a0fc6031aca3ed1cb51d3e"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]
@@ -2024,6 +2060,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ is_ci = { version = "1.1.1", default-features = false, optional = true }
 strum = { version = "0.24.1", features = ["derive"] }
 nix-config-parser = { version = "0.1.2", features = ["serde"] }
 which = "4.4.0"
+sysctl = "0.5.4"
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Cursor};
+use std::{collections::HashMap, io::Cursor, process::Stdio};
 
 #[cfg(feature = "cli")]
 use clap::ArgAction;
@@ -9,7 +9,7 @@ use crate::{
         base::RemoveDirectory,
         common::{ConfigureInitService, ConfigureNix, ProvisionNix},
         macos::CreateNixVolume,
-        StatefulAction,
+        ActionError, StatefulAction,
     },
     execute_command,
     os::darwin::DiskUtilInfoOutput,
@@ -87,6 +87,8 @@ impl Planner for Macos {
     }
 
     async fn plan(&self) -> Result<Vec<StatefulAction<Box<dyn Action>>>, PlannerError> {
+        ensure_not_running_in_rosetta().await?;
+
         let root_disk = match &self.root_disk {
             root_disk @ Some(_) => root_disk.clone(),
             None => {
@@ -213,4 +215,33 @@ impl Into<BuiltinPlanner> for Macos {
     fn into(self) -> BuiltinPlanner {
         BuiltinPlanner::Macos(self)
     }
+}
+
+async fn ensure_not_running_in_rosetta() -> Result<(), PlannerError> {
+    let mut command = Command::new("fuser");
+    command.process_group(0);
+    command.arg("/usr/libexec/rosetta/runtime");
+    command.stderr(Stdio::null());
+    command.stdout(Stdio::piped());
+    command.stdin(Stdio::null());
+    tracing::trace!("Executing `{:?}`", command.as_std());
+
+    let output = command
+        .output()
+        .await
+        .map_err(|e| PlannerError::Action(ActionError::command(&command, e)))?;
+
+    let stdout = String::from_utf8(output.stdout)?;
+
+    let own_pid = std::process::id();
+    let own_pid_using_rosetta = stdout
+        .split(" ")
+        .flat_map(|v| v.parse::<u32>().ok())
+        .any(|v| v == own_pid);
+
+    if own_pid_using_rosetta {
+        return Err(PlannerError::RosettaDetected);
+    }
+
+    Ok(())
 }

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -297,13 +297,10 @@ pub enum PlannerError {
     InstallSettings(#[from] InstallSettingsError),
     /// A MacOS (Darwin) plist related error
     #[error(transparent)]
-    #[cfg(target_os = "macos")]
     Plist(#[from] plist::Error),
-    #[error("Detected that this process is running under Rosetta, using Nix in Rosetta is not recommended")]
-    #[cfg(target_os = "macos")]
+    #[error("Detected that this process is running under Rosetta, using Nix in Rosetta is not supported (Please open an issue with your use case)")]
     RosettaDetected,
     /// A Linux SELinux related error
-    #[cfg(target_os = "linux")]
     #[error("This installer doesn't yet support SELinux in `Enforcing` mode. If SELinux is important to you, please see https://github.com/DeterminateSystems/nix-installer/issues/124. You can also try again after setting SELinux to `Permissive` mode with `setenforce Permissive`")]
     SelinuxEnforcing,
     /// A UTF-8 related error
@@ -326,12 +323,9 @@ impl HasExpectedErrors for PlannerError {
             this @ PlannerError::UnsupportedArchitecture(_) => Some(Box::new(this)),
             PlannerError::Action(_) => None,
             PlannerError::InstallSettings(_) => None,
-            #[cfg(target_os = "macos")]
             PlannerError::Plist(_) => None,
-            #[cfg(target_os = "macos")]
             this @ PlannerError::RosettaDetected => Some(Box::new(this)),
             PlannerError::Utf8(_) => None,
-            #[cfg(target_os = "linux")]
             PlannerError::SelinuxEnforcing => Some(Box::new(self)),
             PlannerError::Custom(_) => None,
             this @ PlannerError::NixOs => Some(Box::new(this)),

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -298,6 +298,8 @@ pub enum PlannerError {
     /// A MacOS (Darwin) plist related error
     #[error(transparent)]
     Plist(#[from] plist::Error),
+    #[error(transparent)]
+    Sysctl(#[from] sysctl::SysctlError),
     #[error("Detected that this process is running under Rosetta, using Nix in Rosetta is not supported (Please open an issue with your use case)")]
     RosettaDetected,
     /// A Linux SELinux related error
@@ -324,6 +326,7 @@ impl HasExpectedErrors for PlannerError {
             PlannerError::Action(_) => None,
             PlannerError::InstallSettings(_) => None,
             PlannerError::Plist(_) => None,
+            PlannerError::Sysctl(_) => None,
             this @ PlannerError::RosettaDetected => Some(Box::new(this)),
             PlannerError::Utf8(_) => None,
             PlannerError::SelinuxEnforcing => Some(Box::new(self)),

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -297,8 +297,13 @@ pub enum PlannerError {
     InstallSettings(#[from] InstallSettingsError),
     /// A MacOS (Darwin) plist related error
     #[error(transparent)]
+    #[cfg(target_os = "macos")]
     Plist(#[from] plist::Error),
+    #[error("Detected that this process is running under Rosetta, using Nix in Rosetta is not recommended")]
+    #[cfg(target_os = "macos")]
+    RosettaDetected,
     /// A Linux SELinux related error
+    #[cfg(target_os = "linux")]
     #[error("This installer doesn't yet support SELinux in `Enforcing` mode. If SELinux is important to you, please see https://github.com/DeterminateSystems/nix-installer/issues/124. You can also try again after setting SELinux to `Permissive` mode with `setenforce Permissive`")]
     SelinuxEnforcing,
     /// A UTF-8 related error
@@ -321,8 +326,12 @@ impl HasExpectedErrors for PlannerError {
             this @ PlannerError::UnsupportedArchitecture(_) => Some(Box::new(this)),
             PlannerError::Action(_) => None,
             PlannerError::InstallSettings(_) => None,
+            #[cfg(target_os = "macos")]
             PlannerError::Plist(_) => None,
+            #[cfg(target_os = "macos")]
+            this @ PlannerError::RosettaDetected => Some(Box::new(this)),
             PlannerError::Utf8(_) => None,
+            #[cfg(target_os = "linux")]
             PlannerError::SelinuxEnforcing => Some(Box::new(self)),
             PlannerError::Custom(_) => None,
             this @ PlannerError::NixOs => Some(Box::new(this)),


### PR DESCRIPTION
##### Description

Fixes #344, we now check for Rosetta.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
