### PR TITLE
Be less grumpy about existing file permissions.

### DIFF
--- a/src/action/base/create_or_insert_into_file.rs
+++ b/src/action/base/create_or_insert_into_file.rs
@@ -79,11 +79,12 @@ impl CreateOrInsertIntoFile {
                 let discovered_mode = discovered_mode & 0o777;
 
                 if discovered_mode != mode {
-                    return Err(ActionError::PathModeMismatch(
-                        this.path.clone(),
+                    tracing::debug!(
+                        "`{}` has mode `{}`, a mode of `{}` was expected",
+                        this.path.display(),
                         discovered_mode,
                         mode,
-                    ));
+                    );
                 }
             }
 

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -93,7 +93,7 @@ impl ConfigureShellProfile {
                         profile_target_path,
                         None,
                         None,
-                        None,
+                        0o644,
                         shell_buf.to_string(),
                         create_or_insert_into_file::Position::Beginning,
                     )

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -3,7 +3,6 @@ use crate::action::{Action, ActionDescription, ActionError, ActionTag, StatefulA
 
 use nix::unistd::User;
 use std::path::{Path, PathBuf};
-use target_lexicon::OperatingSystem;
 use tokio::task::JoinSet;
 use tracing::{span, Instrument, Span};
 

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -88,22 +88,12 @@ impl ConfigureShellProfile {
                     );
                     continue;
                 }
-                // Macs require a different mode on certain files...
-                let required_mode = match target_lexicon::OperatingSystem::host() {
-                    OperatingSystem::MacOSX {
-                        major: _,
-                        minor: _,
-                        patch: _,
-                    }
-                    | OperatingSystem::Darwin => 0o444,
-                    _ => 0o644,
-                };
                 create_or_insert_files.push(
                     CreateOrInsertIntoFile::plan(
                         profile_target_path,
                         None,
                         None,
-                        required_mode,
+                        None,
                         shell_buf.to_string(),
                         create_or_insert_into_file::Position::Beginning,
                     )


### PR DESCRIPTION
##### Description

This should address https://github.com/DeterminateSystems/nix-installer/issues/358 and hopefully prefer some future permission issues as well.

Alters our behavior to no longer error if the user has a file with a different mode than what we'd create.

There is some risk that we may need to make something executable manually or some such, we may want to rethink our approach to permissions in the future in general. Perhaps an option to `ensure` the mode is correct, or to not bother.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
