### PR TITLE
Detect fdesetup properly

### DIFF
--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -105,17 +105,21 @@ impl Planner for Macos {
         };
 
         let encrypt = if self.encrypt == None {
-            Command::new("/usr/bin/fdesetup")
+            let output = Command::new("/usr/bin/fdesetup")
                 .arg("isactive")
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .process_group(0)
-                .status()
+                .output()
                 .await
-                .map_err(|e| PlannerError::Custom(Box::new(e)))?
-                .code()
-                .map(|v| if v == 0 { false } else { true })
-                .unwrap_or(false)
+                .map_err(|e| PlannerError::Custom(Box::new(e)))?;
+
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout == "true" {
+                true
+            } else {
+                false
+            }
         } else {
             false
         };


### PR DESCRIPTION
##### Description

It seems we were not detecting Full Disk Encryption correctly. 

```bash
ephemeraladmin@mac-epic-turducken ~ % /usr/bin/fdesetup isactive            
false
ephemeraladmin@mac-epic-turducken ~ % echo $?
1
```

This appeared to cause some issues on Macs which already had Nix installed, as we assumed they were using FDE when they were not (and then couldn't find their passwords).

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
