### PR TITLE
Fixup diagnostic_endpoint setting to be more flexible

### DIFF
--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -163,7 +163,7 @@ impl Planner for MyPlanner {
                 .into_keys()
                 .collect::<Vec<_>>(),
             self.common.ssl_cert_file.clone(),
-        ))
+        )?)
     }
 }
 

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -135,7 +135,7 @@ impl Planner for Linux {
                 .into_keys()
                 .collect::<Vec<_>>(),
             self.settings.ssl_cert_file.clone(),
-        ))
+        )?)
     }
 }
 

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -211,7 +211,7 @@ impl Planner for Macos {
                 .into_keys()
                 .collect::<Vec<_>>(),
             self.settings.ssl_cert_file.clone(),
-        ))
+        )?)
     }
 }
 

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -317,6 +317,9 @@ pub enum PlannerError {
     NixExists,
     #[error("WSL1 is not supported, please upgrade to WSL2: https://learn.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2")]
     Wsl1,
+    #[cfg(feature = "diagnostics")]
+    #[error(transparent)]
+    Diagnostic(#[from] crate::diagnostics::DiagnosticError),
 }
 
 impl HasExpectedErrors for PlannerError {
@@ -334,6 +337,8 @@ impl HasExpectedErrors for PlannerError {
             this @ PlannerError::NixOs => Some(Box::new(this)),
             this @ PlannerError::NixExists => Some(Box::new(this)),
             this @ PlannerError::Wsl1 => Some(Box::new(this)),
+            #[cfg(feature = "diagnostics")]
+            PlannerError::Diagnostic(diagnostic_error) => Some(Box::new(diagnostic_error)),
         }
     }
 }

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -79,7 +79,7 @@ impl Planner for MyPlanner {
                 .into_keys()
                 .collect::<Vec<_>>(),
             self.common.ssl_cert_file.clone(),
-        ))
+        )?)
     }
 }
 

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -287,7 +287,7 @@ impl Planner for SteamDeck {
                 .into_keys()
                 .collect::<Vec<_>>(),
             self.settings.ssl_cert_file.clone(),
-        ))
+        )?)
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -214,14 +214,16 @@ pub struct CommonSettings {
     ///     "status": "Success"
     /// }
     ///
-    /// To disable diagnostic reporting, unset the default with `--diagnostic-endpoint=`
+    /// To disable diagnostic reporting, unset the default with `--diagnostic-endpoint ""`, or `NIX_INSTALLER_DIAGNOSTIC_ENDPOINT=""`
     #[clap(
         long,
         env = "NIX_INSTALLER_DIAGNOSTIC_ENDPOINT",
         global = true,
-        default_value = "https://install.determinate.systems/nix/diagnostic"
+        value_parser = crate::diagnostics::diagnostic_endpoint_validator,
+        num_args = 0..=1, // Required to allow `--diagnostic-endpoint` or `NIX_INSTALLER_DIAGNOSTIC_ENDPOINT=""`
+        default_missing_value = "https://install.determinate.systems/nix/diagnostic"
     )]
-    pub diagnostic_endpoint: Option<Url>,
+    pub diagnostic_endpoint: Option<String>,
 }
 
 impl CommonSettings {
@@ -285,9 +287,7 @@ impl CommonSettings {
             force: false,
             ssl_cert_file: Default::default(),
             #[cfg(feature = "diagnostics")]
-            diagnostic_endpoint: Some(
-                "https://install.determinate.systems/nix/diagnostic".try_into()?,
-            ),
+            diagnostic_endpoint: Some("https://install.determinate.systems/nix/diagnostic".into()),
         })
     }
 


### PR DESCRIPTION
##### Description

In https://github.com/DeterminateSystems/nix-installer/issues/366 we found setting the `diagnostic-endpoint` to `None` was quite difficult (or even impossible) in some situations.

This makes us considerably more flexible as it reduces the type of the setting down to a String, primarily for `clap` related reasons.

Unfortunately creating a `TypedValueParser` which is shaped like this:

```rust
pub fn diagnostic_endpoint_parser(input: &str) -> Result<Option<Url>, DiagnosticError> {
    match Url::parse(input) {
        Ok(v) => match v.scheme() {
            "https" | "http" | "file" => Ok(Some(v)),
            _ => Err(DiagnosticError::UnknownUrlScheme),
        },
        Err(url_error) if url_error == url::ParseError::RelativeUrlWithoutBase => {
            match Url::parse(&format!("file://{input}")) {
                Ok(v) => Ok(Some(v)),
                Err(file_error) => Err(file_error)?,
            }
        },
        Err(url_error) => Err(url_error)?,
    }
}
```

Then used like this:

```rust
    #[clap(
        long,
        env = "NIX_INSTALLER_DIAGNOSTIC_ENDPOINT",
        global = true,
        value_parser = crate::diagnostics::diagnostic_endpoint_parser,
        num_args = 0..=1, // Required to allow `--diagnostic-endpoint` or `NIX_INSTALLER_DIAGNOSTIC_ENDPOINT=""`
        default_missing_value = "https://install.determinate.systems/nix/diagnostic"
    )]
    pub diagnostic_endpoint: Option<String>,
```

Creates an error like this:

![image](https://user-images.githubusercontent.com/130903/228021718-f34a51c9-4b16-4791-a82b-dfaa648e8320.png)

So instead we store a string, validate it at arg parse, then later parse it again when building the diagnostic data.

Fixes #366.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
