### PR TITLE
Make shell profile locations chosen by planner

### DIFF
--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -12,6 +12,8 @@ use crate::{
 use std::{collections::HashMap, path::Path};
 use tokio::process::Command;
 
+use super::ShellProfileLocations;
+
 /// A planner for Linux installs
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "cli", derive(clap::Parser))]
@@ -80,7 +82,7 @@ impl Planner for Linux {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            ConfigureNix::plan(&self.settings)
+            ConfigureNix::plan(ShellProfileLocations::default(), &self.settings)
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -144,7 +144,7 @@ impl Planner for Macos {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            ConfigureNix::plan(&self.settings)
+            ConfigureNix::plan(ShellProfileLocations::default(), &self.settings)
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -4,6 +4,8 @@ use std::{collections::HashMap, io::Cursor};
 use clap::ArgAction;
 use tokio::process::Command;
 
+use super::ShellProfileLocations;
+
 use crate::{
     action::{
         base::RemoveDirectory,

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -808,6 +808,31 @@
         },
         "configure_shell_profile": {
           "action": {
+            "locations": {
+              "fish": {
+                "confd_suffix": "conf.d/nix.fish",
+                "confd_prefixes": [
+                  "/etc/fish",
+                  "/usr/local/etc/fish",
+                  "/opt/homebrew/etc/fish",
+                  "/opt/local/etc/fish"
+                ],
+                "vendor_confd_suffix": "vendor_conf.d/nix.fish",
+                "vendor_confd_prefixes": [
+                  "/usr/share/fish/",
+                  "/usr/local/share/fish/"
+                ]
+              },
+              "bash": [
+                "/etc/bashrc",
+                "/etc/profile.d/nix.sh",
+                "/etc/bash.bashrc"
+              ],
+              "zsh": [
+                "/etc/zshrc",
+                "/etc/zsh/zshrc"
+              ]
+            },
             "create_directories": [],
             "create_or_insert_into_files": [
               {

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -863,7 +863,6 @@
                 ],
                 "vendor_confd_suffix": "vendor_conf.d/nix.fish",
                 "vendor_confd_prefixes": [
-                  "/usr/share/fish/",
                   "/usr/local/share/fish/"
                 ]
               },

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -852,6 +852,31 @@
         },
         "configure_shell_profile": {
           "action": {
+            "locations": {
+              "fish": {
+                "confd_suffix": "conf.d/nix.fish",
+                "confd_prefixes": [
+                  "/etc/fish",
+                  "/usr/local/etc/fish",
+                  "/opt/homebrew/etc/fish",
+                  "/opt/local/etc/fish"
+                ],
+                "vendor_confd_suffix": "vendor_conf.d/nix.fish",
+                "vendor_confd_prefixes": [
+                  "/usr/share/fish/",
+                  "/usr/local/share/fish/"
+                ]
+              },
+              "bash": [
+                "/etc/bashrc",
+                "/etc/profile.d/nix.sh",
+                "/etc/bash.bashrc"
+              ],
+              "zsh": [
+                "/etc/zshrc",
+                "/etc/zsh/zshrc"
+              ]
+            },
             "create_directories": [],
             "create_or_insert_into_files": [
               {

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -889,6 +889,31 @@
         },
         "configure_shell_profile": {
           "action": {
+            "locations": {
+              "fish": {
+                "confd_suffix": "conf.d/nix.fish",
+                "confd_prefixes": [
+                  "/etc/fish",
+                  "/usr/local/etc/fish",
+                  "/opt/homebrew/etc/fish",
+                  "/opt/local/etc/fish"
+                ],
+                "vendor_confd_suffix": "vendor_conf.d/nix.fish",
+                "vendor_confd_prefixes": [
+                  "/usr/share/fish/",
+                  "/usr/local/share/fish/"
+                ]
+              },
+              "bash": [
+                "/etc/bashrc",
+                "/etc/profile.d/nix.sh",
+                "/etc/bash.bashrc"
+              ],
+              "zsh": [
+                "/etc/zshrc",
+                "/etc/zsh/zshrc"
+              ]
+            },
             "create_directories": [],
             "create_or_insert_into_files": [
               {


### PR DESCRIPTION
##### Description

In https://github.com/DeterminateSystems/nix-installer/issues/367 users experienced issues installing on the Steam Deck with the new version!

The problem was that the `/usr/share` path was read-only.

This was caused by us expanding our fish support to include the `/usr/share/vendor_conf.d` support. Our steam-deck-analog tests were insufficient to catch this.

This change makes the shell profile locations customizable by the planner.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
