### PR TITLE
Use retry strategy after diskutil create

### DIFF
--- a/src/action/macos/create_fstab_entry.rs
+++ b/src/action/macos/create_fstab_entry.rs
@@ -6,7 +6,7 @@ use crate::{
     execute_command,
 };
 use serde::Deserialize;
-use std::{io::SeekFrom, path::Path};
+use std::{io::SeekFrom, path::Path, time::Duration};
 use tokio::{
     fs::OpenOptions,
     io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -218,6 +218,29 @@ impl Action for CreateNixVolume {
             .try_execute()
             .await
             .map_err(|e| ActionError::Child(self.create_volume.action_tag(), Box::new(e)))?;
+
+        let mut retry_tokens: usize = 50;
+        loop {
+            let mut command = Command::new("/usr/sbin/diskutil");
+            command.args(["info", "-plist"]);
+            command.arg(&self.name);
+            command.stderr(std::process::Stdio::null());
+            command.stdout(std::process::Stdio::null());
+            tracing::trace!(%retry_tokens, command = ?command.as_std(), "Checking for Nix Store volume existence");
+            let output = command
+                .output()
+                .await
+                .map_err(|e| ActionError::command(&command, e))?;
+            if output.status.success() {
+                break;
+            } else if retry_tokens == 0 {
+                return Err(ActionError::command_output(&command, output));
+            } else {
+                retry_tokens = retry_tokens.saturating_sub(1);
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
         self.create_fstab_entry
             .try_execute()
             .await
@@ -246,17 +269,19 @@ impl Action for CreateNixVolume {
 
         let mut retry_tokens: usize = 50;
         loop {
-            tracing::trace!(%retry_tokens, "Checking for Nix Store existence");
             let mut command = Command::new("/usr/sbin/diskutil");
             command.args(["info", "/nix"]);
             command.stderr(std::process::Stdio::null());
             command.stdout(std::process::Stdio::null());
-            let status = command
-                .status()
+            tracing::trace!(%retry_tokens, command = ?command.as_std(), "Checking for Nix Store mount path existence");
+            let output = command
+                .output()
                 .await
                 .map_err(|e| ActionError::command(&command, e))?;
-            if status.success() || retry_tokens == 0 {
+            if output.status.success() {
                 break;
+            } else if retry_tokens == 0 {
+                return Err(ActionError::command_output(&command, output));
             } else {
                 retry_tokens = retry_tokens.saturating_sub(1);
             }


### PR DESCRIPTION
##### Description

In https://github.com/DeterminateSystems/nix-installer/issues/369 and https://github.com/DeterminateSystems/nix-installer/issues/371 users experienced an issue where MacOS was creating the volume, but it wasn't showing up in `diskutil` after.

What I suspect is happening is akin to how you can write to a file then read from it and not see the data you wrote because an fsync needed to happen. This adds a retry mechanic similar to what we do before `enableOwnership`.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
