### PR TITLE
Revert `default_missing_value` to `default_value`

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -221,7 +221,7 @@ pub struct CommonSettings {
         global = true,
         value_parser = crate::diagnostics::diagnostic_endpoint_validator,
         num_args = 0..=1, // Required to allow `--diagnostic-endpoint` or `NIX_INSTALLER_DIAGNOSTIC_ENDPOINT=""`
-        default_missing_value = "https://install.determinate.systems/nix/diagnostic"
+        default_value = "https://install.determinate.systems/nix/diagnostic"
     )]
     pub diagnostic_endpoint: Option<String>,
 }


### PR DESCRIPTION


##### Description

We don't need to do this anymore. It was some change I was testing that didn't work, and I forgot to remove it.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
