### PR TITLE
Uninstall shouldn't fail fast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.7.0"
+version = "0.7.1-unreleased"
 dependencies = [
  "async-trait",
  "atty",

--- a/flake.nix
+++ b/flake.nix
@@ -194,6 +194,7 @@
         vm-test = import ./nix/tests/vm-test {
           inherit forSystem;
           inherit (nix.hydraJobs) binaryTarball;
+          inherit (nixpkgs) lib;
         };
         container-test = import ./nix/tests/container-test {
           inherit forSystem;

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -86,7 +86,7 @@ let
             exit 1
           fi
         done
-        if grep "^nixbld:" /etc/groups; then
+        if grep "^nixbld:" /etc/group; then
           echo "Group nixbld exists after uninstall"
           exit 1
         fi

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -241,7 +241,7 @@ impl Action for AddUserToGroup {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             name,
             uid: _,

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -5,7 +5,7 @@ use target_lexicon::OperatingSystem;
 use tokio::process::Command;
 use tracing::{span, Span};
 
-use crate::action::ActionError;
+use crate::action::{ActionError, ActionErrorKind};
 use crate::execute_command;
 
 use crate::action::{Action, ActionDescription, StatefulAction};
@@ -37,22 +37,23 @@ impl AddUserToGroup {
         };
         // Ensure user does not exists
         if let Some(user) = User::from_name(name.as_str())
-            .map_err(|e| ActionError::GettingUserId(name.clone(), e))?
+            .map_err(|e| ActionErrorKind::GettingUserId(name.clone(), e))
+            .map_err(Self::error)?
         {
             if user.uid.as_raw() != uid {
-                return Err(ActionError::UserUidMismatch(
+                return Err(Self::error(ActionErrorKind::UserUidMismatch(
                     name.clone(),
                     user.uid.as_raw(),
                     uid,
-                ));
+                )));
             }
 
             if user.gid.as_raw() != gid {
-                return Err(ActionError::UserGidMismatch(
+                return Err(Self::error(ActionErrorKind::UserGidMismatch(
                     name.clone(),
                     user.gid.as_raw(),
                     gid,
-                ));
+                )));
             }
 
             // See if group membership needs to be done
@@ -74,7 +75,8 @@ impl AddUserToGroup {
                     let output = command
                         .output()
                         .await
-                        .map_err(|e| ActionError::command(&command, e))?;
+                        .map_err(|e| ActionErrorKind::command(&command, e))
+                        .map_err(Self::error)?;
                     match output.status.code() {
                         Some(0) => {
                             // yes {user} is a member of {groupname}
@@ -98,7 +100,9 @@ impl AddUserToGroup {
                         },
                         _ => {
                             // Some other issue
-                            return Err(ActionError::command_output(&command, output));
+                            return Err(Self::error(ActionErrorKind::command_output(
+                                &command, output,
+                            )));
                         },
                     };
                 },
@@ -109,8 +113,9 @@ impl AddUserToGroup {
                             .arg(&this.name)
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
-                    let output_str = String::from_utf8(output.stdout)?;
+                    .await
+                    .map_err(Self::error)?;
+                    let output_str = String::from_utf8(output.stdout).map_err(Self::error)?;
                     let user_in_group = output_str.split(" ").any(|v| v == &this.groupname);
 
                     if user_in_group {
@@ -187,7 +192,8 @@ impl Action for AddUserToGroup {
                         .arg(&name)
                         .stdin(std::process::Stdio::null()),
                 )
-                .await?;
+                .await
+                .map_err(Self::error)?;
                 execute_command(
                     Command::new("/usr/sbin/dseditgroup")
                         .process_group(0)
@@ -199,7 +205,8 @@ impl Action for AddUserToGroup {
                         .arg(groupname)
                         .stdin(std::process::Stdio::null()),
                 )
-                .await?;
+                .await
+                .map_err(Self::error)?;
             },
             _ => {
                 if which::which("gpasswd").is_ok() {
@@ -210,7 +217,8 @@ impl Action for AddUserToGroup {
                             .args([name, groupname])
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
+                    .await
+                    .map_err(Self::error)?;
                 } else if which::which("addgroup").is_ok() {
                     execute_command(
                         Command::new("addgroup")
@@ -218,9 +226,12 @@ impl Action for AddUserToGroup {
                             .args([name, groupname])
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
+                    .await
+                    .map_err(Self::error)?;
                 } else {
-                    return Err(ActionError::MissingAddUserToGroupCommand);
+                    return Err(Self::error(Self::error(
+                        ActionErrorKind::MissingAddUserToGroupCommand,
+                    )));
                 }
             },
         }
@@ -241,7 +252,7 @@ impl Action for AddUserToGroup {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             name,
             uid: _,
@@ -265,7 +276,7 @@ impl Action for AddUserToGroup {
                         .stdin(std::process::Stdio::null()),
                 )
                 .await
-                .map_err(|e| vec![e])?;
+                .map_err(Self::error)?;
             },
             _ => {
                 if which::which("gpasswd").is_ok() {
@@ -277,7 +288,7 @@ impl Action for AddUserToGroup {
                             .stdin(std::process::Stdio::null()),
                     )
                     .await
-                    .map_err(|e| vec![e])?;
+                    .map_err(Self::error)?;
                 } else if which::which("delgroup").is_ok() {
                     execute_command(
                         Command::new("delgroup")
@@ -286,9 +297,11 @@ impl Action for AddUserToGroup {
                             .stdin(std::process::Stdio::null()),
                     )
                     .await
-                    .map_err(|e| vec![e])?;
+                    .map_err(Self::error)?;
                 } else {
-                    return Err(vec![ActionError::MissingRemoveUserFromGroupCommand]);
+                    return Err(Self::error(
+                        ActionErrorKind::MissingRemoveUserFromGroupCommand,
+                    ));
                 }
             },
         };

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -264,7 +264,8 @@ impl Action for AddUserToGroup {
                         .arg(&name)
                         .stdin(std::process::Stdio::null()),
                 )
-                .await?;
+                .await
+                .map_err(|e| vec![e])?;
             },
             _ => {
                 if which::which("gpasswd").is_ok() {
@@ -275,7 +276,8 @@ impl Action for AddUserToGroup {
                             .args([&name.to_string(), &groupname.to_string()])
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
+                    .await
+                    .map_err(|e| vec![e])?;
                 } else if which::which("delgroup").is_ok() {
                     execute_command(
                         Command::new("delgroup")
@@ -283,9 +285,10 @@ impl Action for AddUserToGroup {
                             .args([name, groupname])
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
+                    .await
+                    .map_err(|e| vec![e])?;
                 } else {
-                    return Err(ActionError::MissingRemoveUserFromGroupCommand);
+                    return Err(vec![ActionError::MissingRemoveUserFromGroupCommand]);
                 }
             },
         };

--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -191,7 +191,7 @@ impl Action for CreateDirectory {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             path,
             user: _,

--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -6,7 +6,7 @@ use nix::unistd::{chown, Group, User};
 use tokio::fs::{create_dir, remove_dir_all};
 use tracing::{span, Span};
 
-use crate::action::{Action, ActionDescription, ActionState};
+use crate::action::{Action, ActionDescription, ActionErrorKind, ActionState};
 use crate::action::{ActionError, StatefulAction};
 
 /** Create a directory at the given location, optionally with an owning user, group, and mode.
@@ -40,40 +40,47 @@ impl CreateDirectory {
         let action_state = if path.exists() {
             let metadata = tokio::fs::metadata(&path)
                 .await
-                .map_err(|e| ActionError::GettingMetadata(path.clone(), e))?;
+                .map_err(|e| ActionErrorKind::GettingMetadata(path.clone(), e))
+                .map_err(Self::error)?;
             if !metadata.is_dir() {
-                return Err(ActionError::PathWasNotDirectory(path.to_owned()));
+                return Err(Self::error(ActionErrorKind::PathWasNotDirectory(
+                    path.to_owned(),
+                )));
             }
 
             // Does it have the right user/group?
             if let Some(user) = &user {
                 // If the file exists, the user must also exist to be correct.
                 let expected_uid = User::from_name(user.as_str())
-                    .map_err(|e| ActionError::GettingUserId(user.clone(), e))?
-                    .ok_or_else(|| ActionError::NoUser(user.clone()))?
+                    .map_err(|e| ActionErrorKind::GettingUserId(user.clone(), e))
+                    .map_err(Self::error)?
+                    .ok_or_else(|| ActionErrorKind::NoUser(user.clone()))
+                    .map_err(Self::error)?
                     .uid;
                 let found_uid = metadata.uid();
                 if found_uid != expected_uid.as_raw() {
-                    return Err(ActionError::PathUserMismatch(
+                    return Err(Self::error(ActionErrorKind::PathUserMismatch(
                         path.clone(),
                         found_uid,
                         expected_uid.as_raw(),
-                    ));
+                    )));
                 }
             }
             if let Some(group) = &group {
                 // If the file exists, the group must also exist to be correct.
                 let expected_gid = Group::from_name(group.as_str())
-                    .map_err(|e| ActionError::GettingGroupId(group.clone(), e))?
-                    .ok_or_else(|| ActionError::NoUser(group.clone()))?
+                    .map_err(|e| ActionErrorKind::GettingGroupId(group.clone(), e))
+                    .map_err(Self::error)?
+                    .ok_or_else(|| ActionErrorKind::NoUser(group.clone()))
+                    .map_err(Self::error)?
                     .gid;
                 let found_gid = metadata.gid();
                 if found_gid != expected_gid.as_raw() {
-                    return Err(ActionError::PathGroupMismatch(
+                    return Err(Self::error(ActionErrorKind::PathGroupMismatch(
                         path.clone(),
                         found_gid,
                         expected_gid.as_raw(),
-                    ));
+                    )));
                 }
             }
 
@@ -136,8 +143,10 @@ impl Action for CreateDirectory {
         let gid = if let Some(group) = group {
             Some(
                 Group::from_name(group.as_str())
-                    .map_err(|e| ActionError::GettingGroupId(group.clone(), e))?
-                    .ok_or(ActionError::NoGroup(group.clone()))?
+                    .map_err(|e| ActionErrorKind::GettingGroupId(group.clone(), e))
+                    .map_err(Self::error)?
+                    .ok_or(ActionErrorKind::NoGroup(group.clone()))
+                    .map_err(Self::error)?
                     .gid,
             )
         } else {
@@ -146,8 +155,10 @@ impl Action for CreateDirectory {
         let uid = if let Some(user) = user {
             Some(
                 User::from_name(user.as_str())
-                    .map_err(|e| ActionError::GettingUserId(user.clone(), e))?
-                    .ok_or(ActionError::NoUser(user.clone()))?
+                    .map_err(|e| ActionErrorKind::GettingUserId(user.clone(), e))
+                    .map_err(Self::error)?
+                    .ok_or(ActionErrorKind::NoUser(user.clone()))
+                    .map_err(Self::error)?
                     .uid,
             )
         } else {
@@ -156,13 +167,17 @@ impl Action for CreateDirectory {
 
         create_dir(path.clone())
             .await
-            .map_err(|e| ActionError::CreateDirectory(path.clone(), e))?;
-        chown(path, uid, gid).map_err(|e| ActionError::Chown(path.clone(), e))?;
+            .map_err(|e| ActionErrorKind::CreateDirectory(path.clone(), e))
+            .map_err(Self::error)?;
+        chown(path, uid, gid)
+            .map_err(|e| ActionErrorKind::Chown(path.clone(), e))
+            .map_err(Self::error)?;
 
         if let Some(mode) = mode {
             tokio::fs::set_permissions(&path, PermissionsExt::from_mode(*mode))
                 .await
-                .map_err(|e| ActionError::SetPermissions(*mode, path.to_owned(), e))?;
+                .map_err(|e| ActionErrorKind::SetPermissions(*mode, path.to_owned(), e))
+                .map_err(Self::error)?;
         }
 
         Ok(())
@@ -191,7 +206,7 @@ impl Action for CreateDirectory {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             path,
             user: _,
@@ -202,14 +217,16 @@ impl Action for CreateDirectory {
 
         let is_empty = path
             .read_dir()
-            .map_err(|e| vec![ActionError::Read(path.clone(), e)])?
+            .map_err(|e| ActionErrorKind::Read(path.clone(), e))
+            .map_err(Self::error)?
             .next()
             .is_none();
 
         match (is_empty, force_prune_on_revert) {
             (true, _) | (false, true) => remove_dir_all(path.clone())
                 .await
-                .map_err(|e| vec![ActionError::Remove(path.clone(), e)])?,
+                .map_err(|e| ActionErrorKind::Remove(path.clone(), e))
+                .map_err(Self::error)?,
             (false, false) => {
                 tracing::debug!("Not removing `{}`, the folder is not empty", path.display());
             },
@@ -222,7 +239,6 @@ impl Action for CreateDirectory {
 #[cfg(test)]
 mod test {
     use super::*;
-    use color_eyre::{eyre::eyre, Section};
 
     #[tokio::test]
     async fn creates_and_deletes_empty_directory() -> eyre::Result<()> {
@@ -232,12 +248,7 @@ mod test {
 
         action.try_execute().await?;
 
-        if let Err(errs) = action.try_revert().await {
-            let mut report = eyre!("Errors");
-            for err in errs {
-                report = report.error(err);
-            }
-        }
+        action.try_revert().await?;
 
         assert!(!test_dir.exists(), "Folder should have been deleted");
 
@@ -257,12 +268,7 @@ mod test {
         let stub_file = test_dir.as_path().join("stub");
         tokio::fs::write(stub_file, "More content").await?;
 
-        if let Err(errs) = action.try_revert().await {
-            let mut report = eyre!("Errors");
-            for err in errs {
-                report = report.error(err);
-            }
-        }
+        action.try_revert().await?;
 
         assert!(!test_dir.exists(), "Folder should have been deleted");
 
@@ -282,12 +288,7 @@ mod test {
         let stub_file = test_dir.as_path().join("stub");
         tokio::fs::write(&stub_file, "More content").await?;
 
-        if let Err(errs) = action.try_revert().await {
-            let mut report = eyre!("Errors");
-            for err in errs {
-                report = report.error(err);
-            }
-        }
+        action.try_revert().await?;
 
         assert!(test_dir.exists(), "Folder should not have been deleted");
         assert!(stub_file.exists(), "Folder should not have been deleted");

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -238,7 +238,7 @@ impl Action for CreateFile {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             path,
             user: _,

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -368,9 +368,17 @@ mod test {
         {
             Err(error) => match error.kind() {
                 ActionErrorKind::DifferentContent(path) => assert_eq!(path, test_file.as_path()),
-                _ => return Err(eyre!("Should have returned an ActionError::Exists error")),
+                _ => {
+                    return Err(eyre!(
+                        "Should have returned an ActionErrorKind::Exists error"
+                    ))
+                },
             },
-            _ => return Err(eyre!("Should have returned an ActionError::Exists error")),
+            _ => {
+                return Err(eyre!(
+                    "Should have returned an ActionErrorKind::Exists error"
+                ))
+            },
         };
 
         assert!(test_file.exists(), "File should have not been deleted");
@@ -407,13 +415,13 @@ mod test {
                 },
                 _ => {
                     return Err(eyre!(
-                        "Should have returned an ActionError::PathModeMismatch error"
+                        "Should have returned an ActionErrorKind::PathModeMismatch error"
                     ))
                 },
             },
             _ => {
                 return Err(eyre!(
-                    "Should have returned an ActionError::PathModeMismatch error"
+                    "Should have returned an ActionErrorKind::PathModeMismatch error"
                 ))
             },
         }
@@ -470,13 +478,13 @@ mod test {
                 ActionErrorKind::PathWasNotFile(path) => assert_eq!(path, temp_dir.path()),
                 _ => {
                     return Err(eyre!(
-                        "Should have returned an ActionError::PathWasNotFile error"
+                        "Should have returned an ActionErrorKind::PathWasNotFile error"
                     ))
                 },
             },
             _ => {
                 return Err(eyre!(
-                    "Should have returned an ActionError::PathWasNotFile error"
+                    "Should have returned an ActionErrorKind::PathWasNotFile error"
                 ))
             },
         }

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -10,7 +10,9 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
 };
 
-use crate::action::{Action, ActionDescription, ActionError, ActionTag, StatefulAction};
+use crate::action::{
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
 
 /** Create a file at the given location with the provided `buf`,
 optionally with an owning user, group, and mode.
@@ -55,15 +57,17 @@ impl CreateFile {
             // If the path exists, perhaps we can just skip this
             let mut file = File::open(&this.path)
                 .await
-                .map_err(|e| ActionError::Open(this.path.clone(), e))?;
+                .map_err(|e| ActionErrorKind::Open(this.path.clone(), e))
+                .map_err(Self::error)?;
 
             let metadata = file
                 .metadata()
                 .await
-                .map_err(|e| ActionError::GettingMetadata(this.path.clone(), e))?;
+                .map_err(|e| ActionErrorKind::GettingMetadata(this.path.clone(), e))
+                .map_err(Self::error)?;
 
             if !metadata.is_file() {
-                return Err(ActionError::PathWasNotFile(this.path));
+                return Err(Self::error(ActionErrorKind::PathWasNotFile(this.path)));
             }
 
             if let Some(mode) = mode {
@@ -73,11 +77,11 @@ impl CreateFile {
                 let discovered_mode = discovered_mode & 0o777;
 
                 if discovered_mode != mode {
-                    return Err(ActionError::PathModeMismatch(
+                    return Err(Self::error(ActionErrorKind::PathModeMismatch(
                         this.path.clone(),
                         discovered_mode,
                         mode,
-                    ));
+                    )));
                 }
             }
 
@@ -85,31 +89,35 @@ impl CreateFile {
             if let Some(user) = &this.user {
                 // If the file exists, the user must also exist to be correct.
                 let expected_uid = User::from_name(user.as_str())
-                    .map_err(|e| ActionError::GettingUserId(user.clone(), e))?
-                    .ok_or_else(|| ActionError::NoUser(user.clone()))?
+                    .map_err(|e| ActionErrorKind::GettingUserId(user.clone(), e))
+                    .map_err(Self::error)?
+                    .ok_or_else(|| ActionErrorKind::NoUser(user.clone()))
+                    .map_err(Self::error)?
                     .uid;
                 let found_uid = metadata.uid();
                 if found_uid != expected_uid.as_raw() {
-                    return Err(ActionError::PathUserMismatch(
+                    return Err(Self::error(ActionErrorKind::PathUserMismatch(
                         this.path.clone(),
                         found_uid,
                         expected_uid.as_raw(),
-                    ));
+                    )));
                 }
             }
             if let Some(group) = &this.group {
                 // If the file exists, the group must also exist to be correct.
                 let expected_gid = Group::from_name(group.as_str())
-                    .map_err(|e| ActionError::GettingGroupId(group.clone(), e))?
-                    .ok_or_else(|| ActionError::NoUser(group.clone()))?
+                    .map_err(|e| ActionErrorKind::GettingGroupId(group.clone(), e))
+                    .map_err(Self::error)?
+                    .ok_or_else(|| ActionErrorKind::NoUser(group.clone()))
+                    .map_err(Self::error)?
                     .gid;
                 let found_gid = metadata.gid();
                 if found_gid != expected_gid.as_raw() {
-                    return Err(ActionError::PathGroupMismatch(
+                    return Err(Self::error(ActionErrorKind::PathGroupMismatch(
                         this.path.clone(),
                         found_gid,
                         expected_gid.as_raw(),
-                    ));
+                    )));
                 }
             }
 
@@ -117,10 +125,13 @@ impl CreateFile {
             let mut discovered_buf = String::new();
             file.read_to_string(&mut discovered_buf)
                 .await
-                .map_err(|e| ActionError::Read(this.path.clone(), e))?;
+                .map_err(|e| ActionErrorKind::Read(this.path.clone(), e))
+                .map_err(Self::error)?;
 
             if discovered_buf != this.buf {
-                return Err(ActionError::DifferentContent(this.path.clone()));
+                return Err(Self::error(ActionErrorKind::DifferentContent(
+                    this.path.clone(),
+                )));
             }
 
             tracing::debug!("Creating file `{}` already complete", this.path.display());
@@ -190,17 +201,21 @@ impl Action for CreateFile {
         let mut file = options
             .open(&path)
             .await
-            .map_err(|e| ActionError::Open(path.to_owned(), e))?;
+            .map_err(|e| ActionErrorKind::Open(path.to_owned(), e))
+            .map_err(Self::error)?;
 
         file.write_all(buf.as_bytes())
             .await
-            .map_err(|e| ActionError::Write(path.to_owned(), e))?;
+            .map_err(|e| ActionErrorKind::Write(path.to_owned(), e))
+            .map_err(Self::error)?;
 
         let gid = if let Some(group) = group {
             Some(
                 Group::from_name(group.as_str())
-                    .map_err(|e| ActionError::GettingGroupId(group.clone(), e))?
-                    .ok_or(ActionError::NoGroup(group.clone()))?
+                    .map_err(|e| ActionErrorKind::GettingGroupId(group.clone(), e))
+                    .map_err(Self::error)?
+                    .ok_or(ActionErrorKind::NoGroup(group.clone()))
+                    .map_err(Self::error)?
                     .gid,
             )
         } else {
@@ -209,14 +224,18 @@ impl Action for CreateFile {
         let uid = if let Some(user) = user {
             Some(
                 User::from_name(user.as_str())
-                    .map_err(|e| ActionError::GettingUserId(user.clone(), e))?
-                    .ok_or(ActionError::NoUser(user.clone()))?
+                    .map_err(|e| ActionErrorKind::GettingUserId(user.clone(), e))
+                    .map_err(Self::error)?
+                    .ok_or(ActionErrorKind::NoUser(user.clone()))
+                    .map_err(Self::error)?
                     .uid,
             )
         } else {
             None
         };
-        chown(path, uid, gid).map_err(|e| ActionError::Chown(path.clone(), e))?;
+        chown(path, uid, gid)
+            .map_err(|e| ActionErrorKind::Chown(path.clone(), e))
+            .map_err(Self::error)?;
 
         Ok(())
     }
@@ -238,7 +257,7 @@ impl Action for CreateFile {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let Self {
             path,
             user: _,
@@ -250,7 +269,8 @@ impl Action for CreateFile {
 
         remove_file(&path)
             .await
-            .map_err(|e| vec![ActionError::Remove(path.to_owned(), e)])?;
+            .map_err(|e| ActionErrorKind::Remove(path.to_owned(), e))
+            .map_err(Self::error)?;
 
         Ok(())
     }
@@ -259,7 +279,7 @@ impl Action for CreateFile {
 #[cfg(test)]
 mod test {
     use super::*;
-    use color_eyre::{eyre::eyre, Section};
+    use color_eyre::eyre::eyre;
     use tokio::fs::write;
 
     #[tokio::test]
@@ -271,12 +291,7 @@ mod test {
 
         action.try_execute().await?;
 
-        if let Err(errs) = action.try_revert().await {
-            let mut report = eyre!("Errors");
-            for err in errs {
-                report = report.error(err);
-            }
-        }
+        action.try_revert().await?;
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -296,12 +311,7 @@ mod test {
 
         write(test_file.as_path(), "More content").await?;
 
-        if let Err(errs) = action.try_revert().await {
-            let mut report = eyre!("Errors");
-            for err in errs {
-                report = report.error(err);
-            }
-        }
+        action.try_revert().await?;
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -330,12 +340,7 @@ mod test {
 
         action.try_execute().await?;
 
-        if let Err(errs) = action.try_revert().await {
-            let mut report = eyre!("Errors");
-            for err in errs {
-                report = report.error(err);
-            }
-        }
+        action.try_revert().await?;
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -361,9 +366,12 @@ mod test {
         )
         .await
         {
-            Err(ActionError::DifferentContent(path)) => assert_eq!(path, test_file.as_path()),
+            Err(error) => match error.kind() {
+                ActionErrorKind::DifferentContent(path) => assert_eq!(path, test_file.as_path()),
+                _ => return Err(eyre!("Should have returned an ActionError::Exists error")),
+            },
             _ => return Err(eyre!("Should have returned an ActionError::Exists error")),
-        }
+        };
 
         assert!(test_file.exists(), "File should have not been deleted");
 
@@ -391,10 +399,17 @@ mod test {
         )
         .await
         {
-            Err(ActionError::PathModeMismatch(path, got, expected)) => {
-                assert_eq!(path, test_file.as_path());
-                assert_eq!(expected, expected_mode);
-                assert_eq!(got, initial_mode);
+            Err(err) => match err.kind() {
+                ActionErrorKind::PathModeMismatch(path, got, expected) => {
+                    assert_eq!(path, test_file.as_path());
+                    assert_eq!(*expected, expected_mode);
+                    assert_eq!(*got, initial_mode);
+                },
+                _ => {
+                    return Err(eyre!(
+                        "Should have returned an ActionError::PathModeMismatch error"
+                    ))
+                },
             },
             _ => {
                 return Err(eyre!(
@@ -430,12 +445,7 @@ mod test {
 
         action.try_execute().await?;
 
-        if let Err(errs) = action.try_revert().await {
-            let mut report = eyre!("Errors");
-            for err in errs {
-                report = report.error(err);
-            }
-        }
+        action.try_revert().await?;
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -456,7 +466,14 @@ mod test {
         )
         .await
         {
-            Err(ActionError::PathWasNotFile(path)) => assert_eq!(path, temp_dir.path()),
+            Err(err) => match err.kind() {
+                ActionErrorKind::PathWasNotFile(path) => assert_eq!(path, temp_dir.path()),
+                _ => {
+                    return Err(eyre!(
+                        "Should have returned an ActionError::PathWasNotFile error"
+                    ))
+                },
+            },
             _ => {
                 return Err(eyre!(
                     "Should have returned an ActionError::PathWasNotFile error"

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -238,7 +238,7 @@ impl Action for CreateFile {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             path,
             user: _,
@@ -250,7 +250,7 @@ impl Action for CreateFile {
 
         remove_file(&path)
             .await
-            .map_err(|e| ActionError::Remove(path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Remove(path.to_owned(), e)])?;
 
         Ok(())
     }
@@ -259,7 +259,7 @@ impl Action for CreateFile {
 #[cfg(test)]
 mod test {
     use super::*;
-    use eyre::eyre;
+    use color_eyre::{eyre::eyre, Section};
     use tokio::fs::write;
 
     #[tokio::test]
@@ -271,7 +271,12 @@ mod test {
 
         action.try_execute().await?;
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -291,7 +296,12 @@ mod test {
 
         write(test_file.as_path(), "More content").await?;
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -320,7 +330,12 @@ mod test {
 
         action.try_execute().await?;
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -415,7 +430,12 @@ mod test {
 
         action.try_execute().await?;
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -135,7 +135,7 @@ impl Action for CreateGroup {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self { name, gid: _ } = self;
 
         use target_lexicon::OperatingSystem;

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -2,7 +2,7 @@ use nix::unistd::Group;
 use tokio::process::Command;
 use tracing::{span, Span};
 
-use crate::action::{ActionError, ActionTag};
+use crate::action::{ActionError, ActionErrorKind, ActionTag};
 use crate::execute_command;
 
 use crate::action::{Action, ActionDescription, StatefulAction};
@@ -25,14 +25,15 @@ impl CreateGroup {
         };
         // Ensure group does not exists
         if let Some(group) = Group::from_name(name.as_str())
-            .map_err(|e| ActionError::GettingGroupId(name.clone(), e))?
+            .map_err(|e| ActionErrorKind::GettingGroupId(name.clone(), e))
+            .map_err(Self::error)?
         {
             if group.gid.as_raw() != gid {
-                return Err(ActionError::GroupGidMismatch(
+                return Err(Self::error(ActionErrorKind::GroupGidMismatch(
                     name.clone(),
                     group.gid.as_raw(),
                     gid,
-                ));
+                )));
             }
 
             tracing::debug!("Creating group `{}` already complete", this.name);
@@ -96,7 +97,8 @@ impl Action for CreateGroup {
                         ])
                         .stdin(std::process::Stdio::null()),
                 )
-                .await?;
+                .await
+                .map_err(Self::error)?;
             },
             _ => {
                 if which::which("groupadd").is_ok() {
@@ -106,7 +108,8 @@ impl Action for CreateGroup {
                             .args(["-g", &gid.to_string(), "--system", name])
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
+                    .await
+                    .map_err(Self::error)?;
                 } else if which::which("addgroup").is_ok() {
                     execute_command(
                         Command::new("addgroup")
@@ -114,9 +117,10 @@ impl Action for CreateGroup {
                             .args(["-g", &gid.to_string(), "--system", name])
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
+                    .await
+                    .map_err(Self::error)?;
                 } else {
-                    return Err(ActionError::MissingGroupCreationCommand);
+                    return Err(Self::error(ActionErrorKind::MissingGroupCreationCommand));
                 }
             },
         };
@@ -135,7 +139,7 @@ impl Action for CreateGroup {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let Self { name, gid: _ } = self;
 
         use target_lexicon::OperatingSystem;
@@ -152,7 +156,7 @@ impl Action for CreateGroup {
                         .stdin(std::process::Stdio::null()),
                 )
                 .await
-                .map_err(|e| vec![e])?;
+                .map_err(Self::error)?;
                 if !output.status.success() {}
             },
             _ => {
@@ -164,7 +168,7 @@ impl Action for CreateGroup {
                             .stdin(std::process::Stdio::null()),
                     )
                     .await
-                    .map_err(|e| vec![e])?;
+                    .map_err(Self::error)?;
                 } else if which::which("delgroup").is_ok() {
                     execute_command(
                         Command::new("delgroup")
@@ -173,9 +177,9 @@ impl Action for CreateGroup {
                             .stdin(std::process::Stdio::null()),
                     )
                     .await
-                    .map_err(|e| vec![e])?;
+                    .map_err(Self::error)?;
                 } else {
-                    return Err(vec![ActionError::MissingGroupDeletionCommand]);
+                    return Err(Self::error(ActionErrorKind::MissingGroupDeletionCommand));
                 }
             },
         };

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -151,7 +151,8 @@ impl Action for CreateGroup {
                         .args([".", "-delete", &format!("/Groups/{name}")])
                         .stdin(std::process::Stdio::null()),
                 )
-                .await?;
+                .await
+                .map_err(|e| vec![e])?;
                 if !output.status.success() {}
             },
             _ => {
@@ -162,7 +163,8 @@ impl Action for CreateGroup {
                             .arg(name)
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
+                    .await
+                    .map_err(|e| vec![e])?;
                 } else if which::which("delgroup").is_ok() {
                     execute_command(
                         Command::new("delgroup")
@@ -170,9 +172,10 @@ impl Action for CreateGroup {
                             .arg(name)
                             .stdin(std::process::Stdio::null()),
                     )
-                    .await?;
+                    .await
+                    .map_err(|e| vec![e])?;
                 } else {
-                    return Err(ActionError::MissingGroupDeletionCommand);
+                    return Err(vec![ActionError::MissingGroupDeletionCommand]);
                 }
             },
         };

--- a/src/action/base/create_or_insert_into_file.rs
+++ b/src/action/base/create_or_insert_into_file.rs
@@ -567,13 +567,13 @@ mod test {
                 ActionErrorKind::PathWasNotFile(path) => assert_eq!(path, temp_dir.path()),
                 _ => {
                     return Err(eyre!(
-                        "Should have returned an ActionError::PathWasNotFile error"
+                        "Should have returned an ActionErrorKind::PathWasNotFile error"
                     ))
                 },
             },
             _ => {
                 return Err(eyre!(
-                    "Should have returned an ActionError::PathWasNotFile error"
+                    "Should have returned an ActionErrorKind::PathWasNotFile error"
                 ))
             },
         }

--- a/src/action/base/create_or_insert_into_file.rs
+++ b/src/action/base/create_or_insert_into_file.rs
@@ -308,7 +308,7 @@ impl Action for CreateOrInsertIntoFile {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             path,
             user: _,

--- a/src/action/base/create_or_merge_nix_config.rs
+++ b/src/action/base/create_or_merge_nix_config.rs
@@ -440,7 +440,7 @@ impl Action for CreateOrMergeNixConfig {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             path,
             pending_nix_config: _,

--- a/src/action/base/create_or_merge_nix_config.rs
+++ b/src/action/base/create_or_merge_nix_config.rs
@@ -448,7 +448,7 @@ impl Action for CreateOrMergeNixConfig {
 
         remove_file(&path)
             .await
-            .map_err(|e| ActionError::Remove(path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Remove(path.to_owned(), e)])?;
 
         Ok(())
     }
@@ -457,7 +457,7 @@ impl Action for CreateOrMergeNixConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use eyre::eyre;
+    use color_eyre::{eyre::eyre, Section};
     use tokio::fs::write;
 
     #[tokio::test]
@@ -477,7 +477,12 @@ mod test {
         assert!(s.contains("ca-references"));
         assert!(NixConfig::parse_file(&test_file).is_ok());
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -500,7 +505,12 @@ mod test {
 
         write(test_file.as_path(), "More content").await?;
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -526,7 +536,12 @@ mod test {
 
         action.try_execute().await?;
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -571,7 +586,12 @@ mod test {
         assert!(s.contains("warn-dirty = true"));
         assert!(NixConfig::parse_file(&test_file).is_ok());
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -651,7 +671,12 @@ mod test {
         assert!(s.contains("ca-references"));
         assert!(NixConfig::parse_file(&test_file).is_ok());
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 
@@ -679,7 +704,12 @@ mod test {
         assert_eq!(s.matches("a = b").count(), 1);
         assert!(NixConfig::parse_file(&test_file).is_ok());
 
-        action.try_revert().await?;
+        if let Err(errs) = action.try_revert().await {
+            let mut report = eyre!("Errors");
+            for err in errs {
+                report = report.error(err);
+            }
+        }
 
         assert!(!test_file.exists(), "File should have been deleted");
 

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -252,7 +252,7 @@ impl Action for CreateUser {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             name,
             uid: _,

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -161,7 +161,7 @@ impl Action for FetchAndUnpackNix {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         Ok(())
     }
 }

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -5,7 +5,7 @@ use reqwest::Url;
 use tracing::{span, Span};
 
 use crate::{
-    action::{Action, ActionDescription, ActionError, ActionTag, StatefulAction},
+    action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
     parse_ssl_cert,
 };
 
@@ -33,26 +33,18 @@ impl FetchAndUnpackNix {
 
         match url.scheme() {
             "https" | "http" | "file" => (),
-            _ => {
-                return Err(ActionError::Custom(Box::new(
-                    FetchUrlError::UnknownUrlScheme,
-                )))
-            },
+            _ => return Err(Self::error(FetchUrlError::UnknownUrlScheme)),
         };
 
         if let Some(proxy) = &proxy {
             match proxy.scheme() {
                 "https" | "http" | "socks5" => (),
-                _ => {
-                    return Err(ActionError::Custom(Box::new(
-                        FetchUrlError::UnknownProxyScheme,
-                    )))
-                },
+                _ => return Err(Self::error(FetchUrlError::UnknownProxyScheme)),
             };
         }
 
         if let Some(ssl_cert_file) = &ssl_cert_file {
-            parse_ssl_cert(&ssl_cert_file).await?;
+            parse_ssl_cert(&ssl_cert_file).await.map_err(Self::error)?;
         }
 
         Ok(Self {
@@ -106,41 +98,43 @@ impl Action for FetchAndUnpackNix {
             "https" | "http" => {
                 let mut buildable_client = reqwest::Client::builder();
                 if let Some(proxy) = &self.proxy {
-                    buildable_client =
-                        buildable_client.proxy(reqwest::Proxy::all(proxy.clone()).map_err(|e| {
-                            ActionError::Custom(Box::new(FetchUrlError::Reqwest(e)))
-                        })?)
+                    buildable_client = buildable_client.proxy(
+                        reqwest::Proxy::all(proxy.clone())
+                            .map_err(FetchUrlError::Reqwest)
+                            .map_err(Self::error)?,
+                    )
                 }
                 if let Some(ssl_cert_file) = &self.ssl_cert_file {
-                    let ssl_cert = parse_ssl_cert(&ssl_cert_file).await?;
+                    let ssl_cert = parse_ssl_cert(&ssl_cert_file).await.map_err(Self::error)?;
                     buildable_client = buildable_client.add_root_certificate(ssl_cert);
                 }
                 let client = buildable_client
                     .build()
-                    .map_err(|e| ActionError::Custom(Box::new(FetchUrlError::Reqwest(e))))?;
+                    .map_err(FetchUrlError::Reqwest)
+                    .map_err(Self::error)?;
                 let req = client
                     .get(self.url.clone())
                     .build()
-                    .map_err(|e| ActionError::Custom(Box::new(FetchUrlError::Reqwest(e))))?;
+                    .map_err(FetchUrlError::Reqwest)
+                    .map_err(Self::error)?;
                 let res = client
                     .execute(req)
                     .await
-                    .map_err(|e| ActionError::Custom(Box::new(FetchUrlError::Reqwest(e))))?;
+                    .map_err(FetchUrlError::Reqwest)
+                    .map_err(Self::error)?;
                 res.bytes()
                     .await
-                    .map_err(|e| ActionError::Custom(Box::new(FetchUrlError::Reqwest(e))))?
+                    .map_err(FetchUrlError::Reqwest)
+                    .map_err(Self::error)?
             },
             "file" => {
                 let buf = tokio::fs::read(self.url.path())
                     .await
-                    .map_err(|e| ActionError::Read(PathBuf::from(self.url.path()), e))?;
+                    .map_err(|e| ActionErrorKind::Read(PathBuf::from(self.url.path()), e))
+                    .map_err(Self::error)?;
                 Bytes::from(buf)
             },
-            _ => {
-                return Err(ActionError::Custom(Box::new(
-                    FetchUrlError::UnknownUrlScheme,
-                )))
-            },
+            _ => return Err(Self::error(FetchUrlError::UnknownUrlScheme)),
         };
 
         // TODO(@Hoverbear): Pick directory
@@ -151,7 +145,8 @@ impl Action for FetchAndUnpackNix {
         let mut archive = tar::Archive::new(decoder);
         archive
             .unpack(&dest_clone)
-            .map_err(|e| ActionError::Custom(Box::new(FetchUrlError::Unarchive(e))))?;
+            .map_err(FetchUrlError::Unarchive)
+            .map_err(Self::error)?;
 
         Ok(())
     }
@@ -161,7 +156,7 @@ impl Action for FetchAndUnpackNix {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         Ok(())
     }
 }
@@ -181,4 +176,10 @@ pub enum FetchUrlError {
     UnknownUrlScheme,
     #[error("Unknown proxy scheme, `https://`, `socks5://`, and `http://` supported")]
     UnknownProxyScheme,
+}
+
+impl Into<ActionErrorKind> for FetchUrlError {
+    fn into(self) -> ActionErrorKind {
+        ActionErrorKind::Custom(Box::new(self))
+    }
 }

--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -105,7 +105,7 @@ impl Action for MoveUnpackedNix {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         // Noop
         Ok(())
     }

--- a/src/action/base/remove_directory.rs
+++ b/src/action/base/remove_directory.rs
@@ -70,7 +70,7 @@ impl Action for RemoveDirectory {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         Ok(())
     }
 }

--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -205,7 +205,7 @@ impl Action for SetupDefaultProfile {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         std::env::remove_var("NIX_SSL_CERT_FILE");
 
         Ok(())

--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::{
-    action::{ActionError, ActionTag, StatefulAction},
+    action::{ActionError, ActionErrorKind, ActionTag, StatefulAction},
     execute_command, set_env,
 };
 
@@ -50,9 +50,9 @@ impl Action for SetupDefaultProfile {
         // Find an `nix` package
         let nix_pkg_glob = "/nix/store/*-nix-*";
         let mut found_nix_pkg = None;
-        for entry in glob(nix_pkg_glob).map_err(|e| {
-            ActionError::Custom(Box::new(SetupDefaultProfileError::GlobPatternError(e)))
-        })? {
+        for entry in glob(nix_pkg_glob)
+            .map_err(|e| Self::error(SetupDefaultProfileError::GlobPatternError(e)))?
+        {
             match entry {
                 Ok(path) => {
                     // TODO(@Hoverbear): Should probably ensure is unique
@@ -65,17 +65,15 @@ impl Action for SetupDefaultProfile {
         let nix_pkg = if let Some(nix_pkg) = found_nix_pkg {
             nix_pkg
         } else {
-            return Err(ActionError::Custom(Box::new(
-                SetupDefaultProfileError::NoNix,
-            )));
+            return Err(Self::error(SetupDefaultProfileError::NoNix));
         };
 
         // Find an `nss-cacert` package, add it too.
         let nss_ca_cert_pkg_glob = "/nix/store/*-nss-cacert-*";
         let mut found_nss_ca_cert_pkg = None;
-        for entry in glob(nss_ca_cert_pkg_glob).map_err(|e| {
-            ActionError::Custom(Box::new(SetupDefaultProfileError::GlobPatternError(e)))
-        })? {
+        for entry in glob(nss_ca_cert_pkg_glob)
+            .map_err(|e| Self::error(SetupDefaultProfileError::GlobPatternError(e)))?
+        {
             match entry {
                 Ok(path) => {
                     // TODO(@Hoverbear): Should probably ensure is unique
@@ -88,23 +86,22 @@ impl Action for SetupDefaultProfile {
         let nss_ca_cert_pkg = if let Some(nss_ca_cert_pkg) = found_nss_ca_cert_pkg {
             nss_ca_cert_pkg
         } else {
-            return Err(ActionError::Custom(Box::new(
-                SetupDefaultProfileError::NoNssCacert,
-            )));
+            return Err(Self::error(SetupDefaultProfileError::NoNssCacert));
         };
 
         let found_nix_paths = glob::glob(&format!("{}/nix-*", self.unpacked_path.display()))
-            .map_err(|e| ActionError::Custom(Box::new(e)))?
+            .map_err(|e| Self::error(SetupDefaultProfileError::from(e)))?
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| ActionError::Custom(Box::new(e)))?;
+            .map_err(|e| Self::error(SetupDefaultProfileError::from(e)))?;
         if found_nix_paths.len() != 1 {
-            return Err(ActionError::MalformedBinaryTarball);
+            return Err(Self::error(ActionErrorKind::MalformedBinaryTarball));
         }
         let found_nix_path = found_nix_paths.into_iter().next().unwrap();
         let reginfo_path = PathBuf::from(found_nix_path).join(".reginfo");
         let reginfo = tokio::fs::read(&reginfo_path)
             .await
-            .map_err(|e| ActionError::Read(reginfo_path.to_path_buf(), e))?;
+            .map_err(|e| ActionErrorKind::Read(reginfo_path.to_path_buf(), e))
+            .map_err(Self::error)?;
         let mut load_db_command = Command::new(nix_pkg.join("bin/nix-store"));
         load_db_command.process_group(0);
         load_db_command.arg("--load-db");
@@ -113,9 +110,7 @@ impl Action for SetupDefaultProfile {
         load_db_command.stderr(std::process::Stdio::piped());
         load_db_command.env(
             "HOME",
-            dirs::home_dir().ok_or_else(|| {
-                ActionError::Custom(Box::new(SetupDefaultProfileError::NoRootHome))
-            })?,
+            dirs::home_dir().ok_or_else(|| Self::error(SetupDefaultProfileError::NoRootHome))?,
         );
         tracing::trace!(
             "Executing `{:?}` with stdin from `{}`",
@@ -124,17 +119,20 @@ impl Action for SetupDefaultProfile {
         );
         let mut handle = load_db_command
             .spawn()
-            .map_err(|e| ActionError::command(&load_db_command, e))?;
+            .map_err(|e| ActionErrorKind::command(&load_db_command, e))
+            .map_err(Self::error)?;
 
         let mut stdin = handle.stdin.take().unwrap();
         stdin
             .write_all(&reginfo)
             .await
-            .map_err(|e| ActionError::Write(PathBuf::from("/dev/stdin"), e))?;
+            .map_err(|e| ActionErrorKind::Write(PathBuf::from("/dev/stdin"), e))
+            .map_err(Self::error)?;
         stdin
             .flush()
             .await
-            .map_err(|e| ActionError::Write(PathBuf::from("/dev/stdin"), e))?;
+            .map_err(|e| ActionErrorKind::Write(PathBuf::from("/dev/stdin"), e))
+            .map_err(Self::error)?;
         drop(stdin);
         tracing::trace!(
             "Wrote `{}` to stdin of `nix-store --load-db`",
@@ -144,9 +142,13 @@ impl Action for SetupDefaultProfile {
         let output = handle
             .wait_with_output()
             .await
-            .map_err(|e| ActionError::command(&load_db_command, e))?;
+            .map_err(|e| ActionErrorKind::command(&load_db_command, e))
+            .map_err(Self::error)?;
         if !output.status.success() {
-            return Err(ActionError::command_output(&load_db_command, output));
+            return Err(Self::error(ActionErrorKind::command_output(
+                &load_db_command,
+                output,
+            )));
         };
 
         // Install `nix` itself into the store
@@ -158,16 +160,16 @@ impl Action for SetupDefaultProfile {
                 .stdin(std::process::Stdio::null())
                 .env(
                     "HOME",
-                    dirs::home_dir().ok_or_else(|| {
-                        ActionError::Custom(Box::new(SetupDefaultProfileError::NoRootHome))
-                    })?,
+                    dirs::home_dir()
+                        .ok_or_else(|| Self::error(SetupDefaultProfileError::NoRootHome))?,
                 )
                 .env(
                     "NIX_SSL_CERT_FILE",
                     nss_ca_cert_pkg.join("etc/ssl/certs/ca-bundle.crt"),
                 ), /* This is apparently load bearing... */
         )
-        .await?;
+        .await
+        .map_err(Self::error)?;
 
         // Install `nix` itself into the store
         execute_command(
@@ -178,16 +180,16 @@ impl Action for SetupDefaultProfile {
                 .stdin(std::process::Stdio::null())
                 .env(
                     "HOME",
-                    dirs::home_dir().ok_or_else(|| {
-                        ActionError::Custom(Box::new(SetupDefaultProfileError::NoRootHome))
-                    })?,
+                    dirs::home_dir()
+                        .ok_or_else(|| Self::error(SetupDefaultProfileError::NoRootHome))?,
                 )
                 .env(
                     "NIX_SSL_CERT_FILE",
                     nss_ca_cert_pkg.join("etc/ssl/certs/ca-bundle.crt"),
                 ), /* This is apparently load bearing... */
         )
-        .await?;
+        .await
+        .map_err(Self::error)?;
 
         set_env(
             "NIX_SSL_CERT_FILE",
@@ -205,7 +207,7 @@ impl Action for SetupDefaultProfile {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         std::env::remove_var("NIX_SSL_CERT_FILE");
 
         Ok(())
@@ -233,4 +235,10 @@ pub enum SetupDefaultProfileError {
     NoNix,
     #[error("No root home found to place channel configuration in")]
     NoRootHome,
+}
+
+impl Into<ActionErrorKind> for SetupDefaultProfileError {
+    fn into(self) -> ActionErrorKind {
+        ActionErrorKind::Custom(Box::new(self))
+    }
 }

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -534,6 +534,13 @@ impl Action for ConfigureInitService {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(Self::error(
+                errors
+                    .into_iter()
+                    .next()
+                    .expect("Expected 1 len Vec to have at least 1 item"),
+            ))
         } else {
             Err(Self::error(ActionErrorKind::Multiple(errors)))
         }

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -190,7 +190,7 @@ impl Action for ConfigureInitService {
                 tokio::fs::copy(src.clone(), DARWIN_NIX_DAEMON_DEST)
                     .await
                     .map_err(|e| {
-                        Self::error(ActionError::Copy(
+                        Self::error(ActionErrorKind::Copy(
                             src.to_path_buf(),
                             PathBuf::from(DARWIN_NIX_DAEMON_DEST),
                             e,

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -372,7 +372,7 @@ impl Action for ConfigureInitService {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         match self.init {
             #[cfg(target_os = "macos")]
             InitSystem::Launchd => {

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -414,7 +414,8 @@ impl Action for ConfigureInitService {
                         .arg("unload")
                         .arg(DARWIN_NIX_DAEMON_DEST),
                 )
-                .await?;
+                .await
+                .map_err(|e| Self::error(e))?;
             },
             #[cfg(target_os = "linux")]
             InitSystem::Systemd => {

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -4,7 +4,7 @@ use crate::{
     action::{
         base::SetupDefaultProfile,
         common::{ConfigureShellProfile, PlaceNixConfiguration},
-        Action, ActionDescription, ActionError, ActionTag, StatefulAction,
+        Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
     },
     planner::ShellProfileLocations,
     settings::{CommonSettings, SCRATCH_DIR},
@@ -30,7 +30,7 @@ impl ConfigureNix {
     ) -> Result<StatefulAction<Self>, ActionError> {
         let setup_default_profile = SetupDefaultProfile::plan(PathBuf::from(SCRATCH_DIR))
             .await
-            .map_err(|e| ActionError::Child(SetupDefaultProfile::action_tag(), Box::new(e)))?;
+            .map_err(Self::error)?;
 
         let configure_shell_profile = if settings.modify_profile {
             Some(
@@ -39,9 +39,7 @@ impl ConfigureNix {
                     settings.ssl_cert_file.clone(),
                 )
                 .await
-                .map_err(|e| {
-                    ActionError::Child(ConfigureShellProfile::action_tag(), Box::new(e))
-                })?,
+                .map_err(Self::error)?,
             )
         } else {
             None
@@ -52,7 +50,7 @@ impl ConfigureNix {
             settings.force,
         )
         .await
-        .map_err(|e| ActionError::Child(PlaceNixConfiguration::action_tag(), Box::new(e)))?;
+        .map_err(Self::error)?;
 
         Ok(Self {
             place_nix_configuration,
@@ -112,27 +110,21 @@ impl Action for ConfigureNix {
                         .try_execute()
                         .instrument(setup_default_profile_span)
                         .await
-                        .map_err(|e| {
-                            ActionError::Child(setup_default_profile.action_tag(), Box::new(e))
-                        })
+                        .map_err(Self::error)
                 },
                 async move {
                     place_nix_configuration
                         .try_execute()
                         .instrument(place_nix_configuration_span)
                         .await
-                        .map_err(|e| {
-                            ActionError::Child(place_nix_configuration.action_tag(), Box::new(e))
-                        })
+                        .map_err(Self::error)
                 },
                 async move {
                     configure_shell_profile
                         .try_execute()
                         .instrument(configure_shell_profile_span)
                         .await
-                        .map_err(|e| {
-                            ActionError::Child(configure_shell_profile.action_tag(), Box::new(e))
-                        })
+                        .map_err(Self::error)
                 },
             )?;
         } else {
@@ -144,18 +136,14 @@ impl Action for ConfigureNix {
                         .try_execute()
                         .instrument(setup_default_profile_span)
                         .await
-                        .map_err(|e| {
-                            ActionError::Child(setup_default_profile.action_tag(), Box::new(e))
-                        })
+                        .map_err(Self::error)
                 },
                 async move {
                     place_nix_configuration
                         .try_execute()
                         .instrument(place_nix_configuration_span)
                         .await
-                        .map_err(|e| {
-                            ActionError::Child(place_nix_configuration.action_tag(), Box::new(e))
-                        })
+                        .map_err(Self::error)
                 },
             )?;
         };
@@ -181,38 +169,24 @@ impl Action for ConfigureNix {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let mut errors = vec![];
         if let Some(configure_shell_profile) = &mut self.configure_shell_profile {
-            if let Err(err) = configure_shell_profile.try_revert().await.map_err(|errs| {
-                ActionError::ChildRevert(configure_shell_profile.action_tag(), errs)
-            }) {
+            if let Err(err) = configure_shell_profile.try_revert().await {
                 errors.push(err);
             }
         }
-        if let Err(err) = self
-            .place_nix_configuration
-            .try_revert()
-            .await
-            .map_err(|errs| {
-                ActionError::ChildRevert(self.place_nix_configuration.action_tag(), errs)
-            })
-        {
+        if let Err(err) = self.place_nix_configuration.try_revert().await {
             errors.push(err);
         }
-        if let Err(err) = self
-            .setup_default_profile
-            .try_revert()
-            .await
-            .map_err(|errs| ActionError::ChildRevert(self.setup_default_profile.action_tag(), errs))
-        {
+        if let Err(err) = self.setup_default_profile.try_revert().await {
             errors.push(err);
         }
 
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(errors)
+            Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }
     }
 }

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -181,7 +181,7 @@ impl Action for ConfigureNix {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         if let Some(configure_shell_profile) = &mut self.configure_shell_profile {
             configure_shell_profile.try_revert().await.map_err(|e| {
                 ActionError::Child(configure_shell_profile.action_tag(), Box::new(e))

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -185,6 +185,11 @@ impl Action for ConfigureNix {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
         } else {
             Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -207,7 +207,7 @@ impl Action for ConfigureShellProfile {
         }
 
         let mut set = JoinSet::new();
-        let mut errors = Vec::default();
+        let mut errors = vec![];
 
         for (idx, create_or_insert_into_file) in
             self.create_or_insert_into_files.iter_mut().enumerate()
@@ -262,14 +262,19 @@ impl Action for ConfigureShellProfile {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let mut set = JoinSet::new();
-        let mut errors: Vec<ActionError> = Vec::default();
+        let mut errors = vec![];
 
         for (idx, create_or_insert_into_file) in
             self.create_or_insert_into_files.iter_mut().enumerate()
         {
             let mut create_or_insert_file_clone = create_or_insert_into_file.clone();
             let _abort_handle = set.spawn(async move {
-                create_or_insert_file_clone.try_revert().await?;
+                create_or_insert_file_clone
+                    .try_revert()
+                    .await
+                    .map_err(|errs| {
+                        ActionError::ChildRevert(create_or_insert_file_clone.action_tag(), errs)
+                    })?;
                 Result::<_, _>::Ok((idx, create_or_insert_file_clone))
             });
         }
@@ -280,27 +285,24 @@ impl Action for ConfigureShellProfile {
                     self.create_or_insert_into_files[idx] = create_or_insert_into_file
                 },
                 Ok(Err(e)) => errors.push(e),
-                Err(e) => return Err(e)?,
+                Err(e) => return Err(e).map_err(|e| vec![ActionError::from(e)])?,
             };
         }
 
         for create_directory in self.create_directories.iter_mut() {
-            create_directory
+            if let Err(err) = create_directory
                 .try_revert()
                 .await
-                .map_err(|e| ActionError::Child(create_directory.action_tag(), Box::new(e)))?;
-        }
-
-        if !errors.is_empty() {
-            if errors.len() == 1 {
-                return Err(errors.into_iter().next().unwrap())?;
-            } else {
-                return Err(ActionError::Children(
-                    errors.into_iter().map(|v| Box::new(v)).collect(),
-                ));
+                .map_err(|errs| ActionError::ChildRevert(create_directory.action_tag(), errs))
+            {
+                errors.push(err);
             }
         }
 
-        Ok(())
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -260,7 +260,7 @@ impl Action for ConfigureShellProfile {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let mut set = JoinSet::new();
         let mut errors: Vec<ActionError> = Vec::default();
 

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -1,5 +1,7 @@
 use crate::action::base::{create_or_insert_into_file, CreateDirectory, CreateOrInsertIntoFile};
-use crate::action::{Action, ActionDescription, ActionError, ActionTag, StatefulAction};
+use crate::action::{
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
 use crate::planner::ShellProfileLocations;
 
 use nix::unistd::User;
@@ -32,9 +34,9 @@ impl ConfigureShellProfile {
         let maybe_ssl_cert_file_setting = if let Some(ssl_cert_file) = ssl_cert_file {
             format!(
                 "export NIX_SSL_CERT_FILE={:?}\n",
-                ssl_cert_file
-                    .canonicalize()
-                    .map_err(|e| { ActionError::Canonicalize(ssl_cert_file, e) })?
+                ssl_cert_file.canonicalize().map_err(|e| {
+                    Self::error(ActionErrorKind::Canonicalize(ssl_cert_file, e))
+                })?
             )
         } else {
             "".to_string()
@@ -219,12 +221,7 @@ impl Action for ConfigureShellProfile {
                     .try_execute()
                     .instrument(span)
                     .await
-                    .map_err(|e| {
-                        ActionError::Child(
-                            create_or_insert_into_file_clone.action_tag(),
-                            Box::new(e),
-                        )
-                    })?;
+                    .map_err(Self::error)?;
                 Result::<_, ActionError>::Ok((idx, create_or_insert_into_file_clone))
             });
         }
@@ -235,17 +232,17 @@ impl Action for ConfigureShellProfile {
                     self.create_or_insert_into_files[idx] = create_or_insert_into_file
                 },
                 Ok(Err(e)) => errors.push(e),
-                Err(e) => return Err(e)?,
+                Err(e) => return Err(Self::error(e))?,
             };
         }
 
         if !errors.is_empty() {
             if errors.len() == 1 {
-                return Err(errors.into_iter().next().unwrap())?;
+                return Err(Self::error(errors.into_iter().next().unwrap()))?;
             } else {
-                return Err(ActionError::Children(
-                    errors.into_iter().map(|v| Box::new(v)).collect(),
-                ));
+                return Err(Self::error(ActionErrorKind::MultipleChildren(
+                    errors.into_iter().collect(),
+                )));
             }
         }
 
@@ -260,7 +257,7 @@ impl Action for ConfigureShellProfile {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let mut set = JoinSet::new();
         let mut errors = vec![];
 
@@ -269,12 +266,7 @@ impl Action for ConfigureShellProfile {
         {
             let mut create_or_insert_file_clone = create_or_insert_into_file.clone();
             let _abort_handle = set.spawn(async move {
-                create_or_insert_file_clone
-                    .try_revert()
-                    .await
-                    .map_err(|errs| {
-                        ActionError::ChildRevert(create_or_insert_file_clone.action_tag(), errs)
-                    })?;
+                create_or_insert_file_clone.try_revert().await?;
                 Result::<_, _>::Ok((idx, create_or_insert_file_clone))
             });
         }
@@ -285,16 +277,13 @@ impl Action for ConfigureShellProfile {
                     self.create_or_insert_into_files[idx] = create_or_insert_into_file
                 },
                 Ok(Err(e)) => errors.push(e),
-                Err(e) => return Err(e).map_err(|e| vec![ActionError::from(e)])?,
+                // This is quite rare and generally a very bad sign.
+                Err(e) => return Err(e).map_err(|e| Self::error(ActionErrorKind::from(e)))?,
             };
         }
 
         for create_directory in self.create_directories.iter_mut() {
-            if let Err(err) = create_directory
-                .try_revert()
-                .await
-                .map_err(|errs| ActionError::ChildRevert(create_directory.action_tag(), errs))
-            {
+            if let Err(err) = create_directory.try_revert().await {
                 errors.push(err);
             }
         }
@@ -302,7 +291,7 @@ impl Action for ConfigureShellProfile {
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(errors)
+            Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }
     }
 }

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -290,6 +290,11 @@ impl Action for ConfigureShellProfile {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
         } else {
             Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }

--- a/src/action/common/create_nix_tree.rs
+++ b/src/action/common/create_nix_tree.rs
@@ -117,6 +117,11 @@ impl Action for CreateNixTree {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
         } else {
             Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }

--- a/src/action/common/create_nix_tree.rs
+++ b/src/action/common/create_nix_tree.rs
@@ -107,7 +107,7 @@ impl Action for CreateNixTree {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         // Just do sequential since parallelizing this will have little benefit
         for create_directory in self.create_directories.iter_mut().rev() {
             create_directory

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -266,6 +266,11 @@ impl Action for CreateUsersAndGroups {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
         } else {
             Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -184,7 +184,7 @@ impl Action for CreateUsersAndGroups {
                 //     match result {
                 //         Ok(Ok((idx, success))) => create_users[idx] = success,
                 //         Ok(Err(e)) => errors.push(Box::new(e)),
-                //         Err(e) => return Err(ActionError::Join(e))?,
+                //         Err(e) => return Err(ActionErrorKind::Join(e))?,
                 //     };
                 // }
 
@@ -192,7 +192,7 @@ impl Action for CreateUsersAndGroups {
                 //     if errors.len() == 1 {
                 //         return Err(errors.into_iter().next().unwrap().into());
                 //     } else {
-                //         return Err(ActionError::Children(errors));
+                //         return Err(ActionErrorKind::Children(errors));
                 //     }
                 // }
             },

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -255,7 +255,7 @@ impl Action for CreateUsersAndGroups {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             create_users,
             create_group,

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -131,6 +131,11 @@ impl Action for PlaceNixConfiguration {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
         } else {
             Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -2,7 +2,9 @@ use tracing::{span, Span};
 
 use crate::action::base::create_or_merge_nix_config::CreateOrMergeNixConfigError;
 use crate::action::base::{CreateDirectory, CreateOrMergeNixConfig};
-use crate::action::{Action, ActionDescription, ActionError, ActionTag, StatefulAction};
+use crate::action::{
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
 
 const NIX_CONF_FOLDER: &str = "/etc/nix";
 const NIX_CONF: &str = "/etc/nix/nix.conf";
@@ -26,7 +28,7 @@ impl PlaceNixConfiguration {
         let extra_conf = extra_conf.join("\n");
         let mut nix_config = nix_config_parser::NixConfig::parse_string(extra_conf, None)
             .map_err(CreateOrMergeNixConfigError::ParseNixConfig)
-            .map_err(|e| ActionError::Custom(Box::new(e)))?;
+            .map_err(Self::error)?;
         let settings = nix_config.settings_mut();
 
         settings.insert("build-users-group".to_string(), nix_build_group_name);
@@ -46,12 +48,10 @@ impl PlaceNixConfiguration {
 
         let create_directory = CreateDirectory::plan(NIX_CONF_FOLDER, None, None, 0o0755, force)
             .await
-            .map_err(|e| ActionError::Child(CreateDirectory::action_tag(), Box::new(e)))?;
+            .map_err(Self::error)?;
         let create_or_merge_nix_config = CreateOrMergeNixConfig::plan(NIX_CONF, nix_config)
             .await
-            .map_err(|e| {
-            ActionError::Child(CreateOrMergeNixConfig::action_tag(), Box::new(e))
-        })?;
+            .map_err(Self::error)?;
         Ok(Self {
             create_directory,
             create_or_merge_nix_config,
@@ -100,13 +100,11 @@ impl Action for PlaceNixConfiguration {
         self.create_directory
             .try_execute()
             .await
-            .map_err(|e| ActionError::Child(self.create_directory.action_tag(), Box::new(e)))?;
+            .map_err(Self::error)?;
         self.create_or_merge_nix_config
             .try_execute()
             .await
-            .map_err(|e| {
-                ActionError::Child(self.create_or_merge_nix_config.action_tag(), Box::new(e))
-            })?;
+            .map_err(Self::error)?;
 
         Ok(())
     }
@@ -122,31 +120,19 @@ impl Action for PlaceNixConfiguration {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let mut errors = vec![];
-        if let Err(err) = self
-            .create_or_merge_nix_config
-            .try_revert()
-            .await
-            .map_err(|errs| {
-                ActionError::ChildRevert(self.create_or_merge_nix_config.action_tag(), errs)
-            })
-        {
+        if let Err(err) = self.create_or_merge_nix_config.try_revert().await {
             errors.push(err);
         }
-        if let Err(err) = self
-            .create_directory
-            .try_revert()
-            .await
-            .map_err(|errs| ActionError::ChildRevert(self.create_directory.action_tag(), errs))
-        {
+        if let Err(err) = self.create_directory.try_revert().await {
             errors.push(err);
         }
 
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(errors)
+            Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }
     }
 }

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -122,7 +122,7 @@ impl Action for PlaceNixConfiguration {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         self.create_or_merge_nix_config
             .try_revert()
             .await

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -130,7 +130,7 @@ impl Action for ProvisionNix {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         // We fetch nix while doing the rest, then move it over.
         let mut fetch_nix_clone = self.fetch_nix.clone();
         let fetch_nix_handle = tokio::task::spawn(async {

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -4,7 +4,7 @@ use super::{CreateNixTree, CreateUsersAndGroups};
 use crate::{
     action::{
         base::{FetchAndUnpackNix, MoveUnpackedNix},
-        Action, ActionDescription, ActionError, ActionTag, StatefulAction,
+        Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
     },
     settings::{CommonSettings, SCRATCH_DIR},
 };
@@ -33,13 +33,11 @@ impl ProvisionNix {
         .await?;
         let create_users_and_group = CreateUsersAndGroups::plan(settings.clone())
             .await
-            .map_err(|e| ActionError::Child(CreateUsersAndGroups::action_tag(), Box::new(e)))?;
-        let create_nix_tree = CreateNixTree::plan()
-            .await
-            .map_err(|e| ActionError::Child(CreateNixTree::action_tag(), Box::new(e)))?;
+            .map_err(Self::error)?;
+        let create_nix_tree = CreateNixTree::plan().await.map_err(Self::error)?;
         let move_unpacked_nix = MoveUnpackedNix::plan(PathBuf::from(SCRATCH_DIR))
             .await
-            .map_err(|e| ActionError::Child(MoveUnpackedNix::action_tag(), Box::new(e)))?;
+            .map_err(Self::error)?;
         Ok(Self {
             fetch_nix,
             create_users_and_group,
@@ -86,29 +84,27 @@ impl Action for ProvisionNix {
         // We fetch nix while doing the rest, then move it over.
         let mut fetch_nix_clone = self.fetch_nix.clone();
         let fetch_nix_handle = tokio::task::spawn(async {
-            fetch_nix_clone
-                .try_execute()
-                .await
-                .map_err(|e| ActionError::Child(fetch_nix_clone.action_tag(), Box::new(e)))?;
+            fetch_nix_clone.try_execute().await.map_err(Self::error)?;
             Result::<_, ActionError>::Ok(fetch_nix_clone)
         });
 
         self.create_users_and_group
             .try_execute()
             .await
-            .map_err(|e| {
-                ActionError::Child(self.create_users_and_group.action_tag(), Box::new(e))
-            })?;
+            .map_err(Self::error)?;
         self.create_nix_tree
             .try_execute()
             .await
-            .map_err(|e| ActionError::Child(self.create_nix_tree.action_tag(), Box::new(e)))?;
+            .map_err(Self::error)?;
 
-        self.fetch_nix = fetch_nix_handle.await.map_err(ActionError::Join)??;
+        self.fetch_nix = fetch_nix_handle
+            .await
+            .map_err(ActionErrorKind::Join)
+            .map_err(Self::error)??;
         self.move_unpacked_nix
             .try_execute()
             .await
-            .map_err(|e| ActionError::Child(self.move_unpacked_nix.action_tag(), Box::new(e)))?;
+            .map_err(Self::error)?;
 
         Ok(())
     }
@@ -130,47 +126,28 @@ impl Action for ProvisionNix {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let mut errors = vec![];
 
-        if let Err(err) = self
-            .fetch_nix
-            .try_revert()
-            .await
-            .map_err(|errs| ActionError::ChildRevert(self.fetch_nix.action_tag(), errs))
-        {
+        if let Err(err) = self.fetch_nix.try_revert().await {
             errors.push(err)
         }
 
-        if let Err(err) = self
-            .create_users_and_group
-            .try_revert()
-            .await
-            .map_err(|errs| {
-                ActionError::ChildRevert(self.create_users_and_group.action_tag(), errs)
-            })
-        {
+        if let Err(err) = self.create_users_and_group.try_revert().await {
             errors.push(err)
         }
-        if let Err(err) = self.create_nix_tree.try_revert().await.map_err(|errs| {
-            ActionError::ChildRevert(self.create_users_and_group.action_tag(), errs)
-        }) {
+        if let Err(err) = self.create_nix_tree.try_revert().await {
             errors.push(err)
         }
 
-        if let Err(err) = self
-            .move_unpacked_nix
-            .try_revert()
-            .await
-            .map_err(|e| ActionError::ChildRevert(self.move_unpacked_nix.action_tag(), e))
-        {
+        if let Err(err) = self.move_unpacked_nix.try_revert().await {
             errors.push(err)
         }
 
         if errors.is_empty() {
             Ok(())
         } else {
-            Err(errors)
+            Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }
     }
 }

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -146,6 +146,11 @@ impl Action for ProvisionNix {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
         } else {
             Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -110,7 +110,7 @@ impl Action for StartSystemdUnit {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self { unit, enable } = self;
 
         if *enable {

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -146,6 +146,11 @@ impl Action for StartSystemdUnit {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
         } else {
             Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -120,21 +120,16 @@ impl Action for BootstrapLaunchctlService {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
-        let Self {
-            path,
-            service: _,
-            domain,
-        } = self;
-
         execute_command(
             Command::new("launchctl")
                 .process_group(0)
                 .arg("bootout")
-                .arg(domain)
-                .arg(path)
+                .arg(&self.domain)
+                .arg(&self.path)
                 .stdin(std::process::Stdio::null()),
         )
-        .await?;
+        .await
+        .map_err(|e| vec![e])?;
 
         Ok(())
     }

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -119,7 +119,7 @@ impl Action for BootstrapLaunchctlService {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             path,
             service: _,

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::{span, Span};
 
-use crate::action::{ActionError, ActionTag, StatefulAction};
+use crate::action::{ActionError, ActionErrorKind, ActionTag, StatefulAction};
 use crate::execute_command;
 
 use crate::action::{Action, ActionDescription};
@@ -40,7 +40,7 @@ impl BootstrapLaunchctlService {
         let output = command
             .output()
             .await
-            .map_err(|e| ActionError::command(&command, e))?;
+            .map_err(|e| Self::error(ActionErrorKind::command(&command, e)))?;
         if output.status.success() || output.status.code() == Some(37) {
             // We presume that success means it's found
             return Ok(StatefulAction::completed(Self {
@@ -102,7 +102,8 @@ impl Action for BootstrapLaunchctlService {
                 .arg(path)
                 .stdin(std::process::Stdio::null()),
         )
-        .await?;
+        .await
+        .map_err(Self::error)?;
 
         Ok(())
     }
@@ -119,7 +120,7 @@ impl Action for BootstrapLaunchctlService {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         execute_command(
             Command::new("launchctl")
                 .process_group(0)
@@ -129,7 +130,7 @@ impl Action for BootstrapLaunchctlService {
                 .stdin(std::process::Stdio::null()),
         )
         .await
-        .map_err(|e| vec![e])?;
+        .map_err(Self::error)?;
 
         Ok(())
     }

--- a/src/action/macos/create_apfs_volume.rs
+++ b/src/action/macos/create_apfs_volume.rs
@@ -119,19 +119,14 @@ impl Action for CreateApfsVolume {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
-        let Self {
-            disk: _,
-            name,
-            case_sensitive: _,
-        } = self;
-
         execute_command(
             Command::new("/usr/sbin/diskutil")
                 .process_group(0)
-                .args(["apfs", "deleteVolume", name])
+                .args(["apfs", "deleteVolume", &self.name])
                 .stdin(std::process::Stdio::null()),
         )
-        .await?;
+        .await
+        .map_err(|v| vec![v])?;
 
         Ok(())
     }

--- a/src/action/macos/create_apfs_volume.rs
+++ b/src/action/macos/create_apfs_volume.rs
@@ -118,7 +118,7 @@ impl Action for CreateApfsVolume {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             disk: _,
             name,

--- a/src/action/macos/create_fstab_entry.rs
+++ b/src/action/macos/create_fstab_entry.rs
@@ -2,7 +2,7 @@ use uuid::Uuid;
 
 use super::{get_uuid_for_label, CreateApfsVolume};
 use crate::action::{
-    Action, ActionDescription, ActionError, ActionState, ActionTag, StatefulAction,
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionState, ActionTag, StatefulAction,
 };
 use std::{io::SeekFrom, path::Path};
 use tokio::{
@@ -46,7 +46,7 @@ impl CreateFstabEntry {
         if fstab_path.exists() {
             let fstab_buf = tokio::fs::read_to_string(&fstab_path)
                 .await
-                .map_err(|e| ActionError::Read(fstab_path.to_path_buf(), e))?;
+                .map_err(|e| Self::error(ActionErrorKind::Read(fstab_path.to_path_buf(), e)))?;
             let prelude_comment = fstab_prelude_comment(&apfs_volume_label);
 
             // See if a previous install from this crate exists, if so, invite the user to remove it (we may need to change it)
@@ -122,7 +122,9 @@ impl Action for CreateFstabEntry {
             existing_entry,
         } = self;
         let fstab_path = Path::new(FSTAB_PATH);
-        let uuid = get_uuid_for_label(&apfs_volume_label).await?;
+        let uuid = get_uuid_for_label(&apfs_volume_label)
+            .await
+            .map_err(Self::error)?;
 
         let mut fstab = tokio::fs::OpenOptions::new()
             .create(true)
@@ -130,14 +132,14 @@ impl Action for CreateFstabEntry {
             .read(true)
             .open(fstab_path)
             .await
-            .map_err(|e| ActionError::Open(fstab_path.to_path_buf(), e))?;
+            .map_err(|e| Self::error(ActionErrorKind::Open(fstab_path.to_path_buf(), e)))?;
 
         // Make sure it doesn't already exist before we write to it.
         let mut fstab_buf = String::new();
         fstab
             .read_to_string(&mut fstab_buf)
             .await
-            .map_err(|e| ActionError::Read(fstab_path.to_owned(), e))?;
+            .map_err(|e| Self::error(ActionErrorKind::Read(fstab_path.to_owned(), e)))?;
 
         let updated_buf = match existing_entry {
             ExistingFstabEntry::NixInstallerEntry => {
@@ -161,9 +163,9 @@ impl Action for CreateFstabEntry {
                     }
                 }
                 if !(saw_prelude && updated_line) {
-                    return Err(ActionError::Custom(Box::new(
+                    return Err(Self::error(
                         CreateFstabEntryError::ExistingNixInstallerEntryDisappeared,
-                    )));
+                    ));
                 }
                 current_fstab_lines.join("\n")
             },
@@ -182,9 +184,9 @@ impl Action for CreateFstabEntry {
                     }
                 }
                 if !updated_line {
-                    return Err(ActionError::Custom(Box::new(
+                    return Err(Self::error(
                         CreateFstabEntryError::ExistingForeignEntryDisappeared,
-                    )));
+                    ));
                 }
                 current_fstab_lines.join("\n")
             },
@@ -194,15 +196,15 @@ impl Action for CreateFstabEntry {
         fstab
             .seek(SeekFrom::Start(0))
             .await
-            .map_err(|e| ActionError::Seek(fstab_path.to_owned(), e))?;
+            .map_err(|e| Self::error(ActionErrorKind::Seek(fstab_path.to_owned(), e)))?;
         fstab
             .set_len(0)
             .await
-            .map_err(|e| ActionError::Truncate(fstab_path.to_owned(), e))?;
+            .map_err(|e| Self::error(ActionErrorKind::Truncate(fstab_path.to_owned(), e)))?;
         fstab
             .write_all(updated_buf.as_bytes())
             .await
-            .map_err(|e| ActionError::Write(fstab_path.to_owned(), e))?;
+            .map_err(|e| Self::error(ActionErrorKind::Write(fstab_path.to_owned(), e)))?;
 
         Ok(())
     }
@@ -222,12 +224,12 @@ impl Action for CreateFstabEntry {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let fstab_path = Path::new(FSTAB_PATH);
 
         let uuid = get_uuid_for_label(&self.apfs_volume_label)
             .await
-            .map_err(|v| vec![v])?;
+            .map_err(Self::error)?;
 
         let fstab_entry = fstab_lines(&uuid, &self.apfs_volume_label);
 
@@ -237,12 +239,12 @@ impl Action for CreateFstabEntry {
             .read(true)
             .open(&fstab_path)
             .await
-            .map_err(|e| vec![ActionError::Open(fstab_path.to_owned(), e)])?;
+            .map_err(|e| Self::error(ActionErrorKind::Open(fstab_path.to_owned(), e)))?;
 
         let mut file_contents = String::default();
         file.read_to_string(&mut file_contents)
             .await
-            .map_err(|e| vec![ActionError::Read(fstab_path.to_owned(), e)])?;
+            .map_err(|e| Self::error(ActionErrorKind::Read(fstab_path.to_owned(), e)))?;
 
         if let Some(start) = file_contents.rfind(fstab_entry.as_str()) {
             let end = start + fstab_entry.len();
@@ -251,16 +253,16 @@ impl Action for CreateFstabEntry {
 
         file.seek(SeekFrom::Start(0))
             .await
-            .map_err(|e| vec![ActionError::Seek(fstab_path.to_owned(), e)])?;
+            .map_err(|e| Self::error(ActionErrorKind::Seek(fstab_path.to_owned(), e)))?;
         file.set_len(0)
             .await
-            .map_err(|e| vec![ActionError::Truncate(fstab_path.to_owned(), e)])?;
+            .map_err(|e| Self::error(ActionErrorKind::Truncate(fstab_path.to_owned(), e)))?;
         file.write_all(file_contents.as_bytes())
             .await
-            .map_err(|e| vec![ActionError::Write(fstab_path.to_owned(), e)])?;
+            .map_err(|e| Self::error(ActionErrorKind::Write(fstab_path.to_owned(), e)))?;
         file.flush()
             .await
-            .map_err(|e| vec![ActionError::Flush(fstab_path.to_owned(), e)])?;
+            .map_err(|e| Self::error(ActionErrorKind::Flush(fstab_path.to_owned(), e)))?;
 
         Ok(())
     }
@@ -287,4 +289,10 @@ pub enum CreateFstabEntryError {
     ExistingNixInstallerEntryDisappeared,
     #[error("The `/etc/fstab` entry (previously created by the official install scripts) detected during planning disappeared between planning and executing. Cannot update `/etc/fstab` as planned")]
     ExistingForeignEntryDisappeared,
+}
+
+impl Into<ActionErrorKind> for CreateFstabEntryError {
+    fn into(self) -> ActionErrorKind {
+        ActionErrorKind::Custom(Box::new(self))
+    }
 }

--- a/src/action/macos/create_fstab_entry.rs
+++ b/src/action/macos/create_fstab_entry.rs
@@ -223,13 +223,13 @@ impl Action for CreateFstabEntry {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
-        let Self {
-            apfs_volume_label,
-            existing_entry: _,
-        } = self;
         let fstab_path = Path::new(FSTAB_PATH);
-        let uuid = get_uuid_for_label(&apfs_volume_label).await?;
-        let fstab_entry = fstab_lines(&uuid, apfs_volume_label);
+
+        let uuid = get_uuid_for_label(&self.apfs_volume_label)
+            .await
+            .map_err(|v| vec![v])?;
+
+        let fstab_entry = fstab_lines(&uuid, &self.apfs_volume_label);
 
         let mut file = OpenOptions::new()
             .create(false)
@@ -237,12 +237,12 @@ impl Action for CreateFstabEntry {
             .read(true)
             .open(&fstab_path)
             .await
-            .map_err(|e| ActionError::Open(fstab_path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Open(fstab_path.to_owned(), e)])?;
 
         let mut file_contents = String::default();
         file.read_to_string(&mut file_contents)
             .await
-            .map_err(|e| ActionError::Read(fstab_path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Read(fstab_path.to_owned(), e)])?;
 
         if let Some(start) = file_contents.rfind(fstab_entry.as_str()) {
             let end = start + fstab_entry.len();
@@ -251,16 +251,16 @@ impl Action for CreateFstabEntry {
 
         file.seek(SeekFrom::Start(0))
             .await
-            .map_err(|e| ActionError::Seek(fstab_path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Seek(fstab_path.to_owned(), e)])?;
         file.set_len(0)
             .await
-            .map_err(|e| ActionError::Truncate(fstab_path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Truncate(fstab_path.to_owned(), e)])?;
         file.write_all(file_contents.as_bytes())
             .await
-            .map_err(|e| ActionError::Write(fstab_path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Write(fstab_path.to_owned(), e)])?;
         file.flush()
             .await
-            .map_err(|e| ActionError::Flush(fstab_path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Flush(fstab_path.to_owned(), e)])?;
 
         Ok(())
     }

--- a/src/action/macos/create_fstab_entry.rs
+++ b/src/action/macos/create_fstab_entry.rs
@@ -222,7 +222,7 @@ impl Action for CreateFstabEntry {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self {
             apfs_volume_label,
             existing_entry: _,

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -270,7 +270,7 @@ impl Action for CreateNixVolume {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         self.enable_ownership.try_revert().await?;
         self.kickstart_launchctl_service.try_revert().await?;
         self.bootstrap_volume.try_revert().await?;

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -326,6 +326,11 @@ impl Action for CreateNixVolume {
 
         if errors.is_empty() {
             Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
         } else {
             Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
         }

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -271,6 +271,8 @@ impl Action for CreateNixVolume {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+        let mut errors = vec![];
+
         self.enable_ownership.try_revert().await?;
         self.kickstart_launchctl_service.try_revert().await?;
         self.bootstrap_volume.try_revert().await?;

--- a/src/action/macos/create_synthetic_objects.rs
+++ b/src/action/macos/create_synthetic_objects.rs
@@ -68,7 +68,7 @@ impl Action for CreateSyntheticObjects {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         // Yup we literally call both and ignore the error! Reasoning: https://github.com/NixOS/nix/blob/95331cb9c99151cbd790ceb6ddaf49fc1c0da4b3/scripts/create-darwin-volume.sh#L261
         execute_command(
             Command::new("/System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util")

--- a/src/action/macos/create_synthetic_objects.rs
+++ b/src/action/macos/create_synthetic_objects.rs
@@ -68,7 +68,7 @@ impl Action for CreateSyntheticObjects {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         // Yup we literally call both and ignore the error! Reasoning: https://github.com/NixOS/nix/blob/95331cb9c99151cbd790ceb6ddaf49fc1c0da4b3/scripts/create-darwin-volume.sh#L261
         execute_command(
             Command::new("/System/Library/Filesystems/apfs.fs/Contents/Resources/apfs.util")
@@ -89,11 +89,4 @@ impl Action for CreateSyntheticObjects {
 
         Ok(())
     }
-}
-
-#[non_exhaustive]
-#[derive(Debug, thiserror::Error)]
-pub enum CreateSyntheticObjectsError {
-    #[error("Failed to execute command")]
-    Command(#[source] std::io::Error),
 }

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -7,7 +7,9 @@ use tokio::{
     io::AsyncWriteExt,
 };
 
-use crate::action::{Action, ActionDescription, ActionError, ActionTag, StatefulAction};
+use crate::action::{
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
 
 use super::get_uuid_for_label;
 
@@ -43,27 +45,27 @@ impl CreateVolumeService {
         };
 
         if this.path.exists() {
-            let discovered_plist: LaunchctlMountPlist = plist::from_file(&this.path)?;
+            let discovered_plist: LaunchctlMountPlist =
+                plist::from_file(&this.path).map_err(Self::error)?;
             let expected_plist = generate_mount_plist(
                 &this.mount_service_label,
                 &this.apfs_volume_label,
                 &this.mount_point,
                 encrypt,
             )
-            .await?;
+            .await
+            .map_err(Self::error)?;
             if discovered_plist != expected_plist {
                 tracing::trace!(
                     ?discovered_plist,
                     ?expected_plist,
                     "Parsed plists not equal"
                 );
-                return Err(ActionError::Custom(Box::new(
-                    CreateVolumeServiceError::DifferentPlist {
-                        expected: expected_plist,
-                        discovered: discovered_plist,
-                        path: this.path.clone(),
-                    },
-                )));
+                return Err(Self::error(CreateVolumeServiceError::DifferentPlist {
+                    expected: expected_plist,
+                    discovered: discovered_plist,
+                    path: this.path.clone(),
+                }));
             }
 
             tracing::debug!("Creating file `{}` already complete", this.path.display());
@@ -121,7 +123,8 @@ impl Action for CreateVolumeService {
             mount_point,
             *encrypt,
         )
-        .await?;
+        .await
+        .map_err(Self::error)?;
 
         let mut options = OpenOptions::new();
         options.create_new(true).write(true).read(true);
@@ -129,13 +132,13 @@ impl Action for CreateVolumeService {
         let mut file = options
             .open(&path)
             .await
-            .map_err(|e| ActionError::Open(path.to_owned(), e))?;
+            .map_err(|e| Self::error(ActionErrorKind::Open(path.to_owned(), e)))?;
 
         let mut buf = Vec::new();
-        plist::to_writer_xml(&mut buf, &generated_plist)?;
+        plist::to_writer_xml(&mut buf, &generated_plist).map_err(Self::error)?;
         file.write_all(&buf)
             .await
-            .map_err(|e| ActionError::Write(path.to_owned(), e))?;
+            .map_err(|e| Self::error(ActionErrorKind::Write(path.to_owned(), e)))?;
 
         Ok(())
     }
@@ -148,10 +151,10 @@ impl Action for CreateVolumeService {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         remove_file(&self.path)
             .await
-            .map_err(|e| vec![ActionError::Remove(self.path.to_owned(), e)])?;
+            .map_err(|e| Self::error(ActionErrorKind::Remove(self.path.to_owned(), e)))?;
 
         Ok(())
     }
@@ -163,7 +166,7 @@ async fn generate_mount_plist(
     apfs_volume_label: &str,
     mount_point: &Path,
     encrypt: bool,
-) -> Result<LaunchctlMountPlist, ActionError> {
+) -> Result<LaunchctlMountPlist, ActionErrorKind> {
     let apfs_volume_label_with_quotes = format!("\"{apfs_volume_label}\"");
     let uuid = get_uuid_for_label(&apfs_volume_label).await?;
     // The official Nix scripts uppercase the UUID, so we do as well for compatibility.
@@ -207,4 +210,10 @@ pub enum CreateVolumeServiceError {
         discovered: LaunchctlMountPlist,
         path: PathBuf,
     },
+}
+
+impl Into<ActionErrorKind> for CreateVolumeServiceError {
+    fn into(self) -> ActionErrorKind {
+        ActionErrorKind::Custom(Box::new(self))
+    }
 }

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -148,10 +148,10 @@ impl Action for CreateVolumeService {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         remove_file(&self.path)
             .await
-            .map_err(|e| ActionError::Remove(self.path.to_owned(), e))?;
+            .map_err(|e| vec![ActionError::Remove(self.path.to_owned(), e)])?;
 
         Ok(())
     }

--- a/src/action/macos/enable_ownership.rs
+++ b/src/action/macos/enable_ownership.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::{span, Span};
 
-use crate::action::{ActionError, ActionTag, StatefulAction};
+use crate::action::{ActionError, ActionErrorKind, ActionTag, StatefulAction};
 use crate::execute_command;
 
 use crate::action::{Action, ActionDescription};
@@ -62,9 +62,11 @@ impl Action for EnableOwnership {
                     .arg(&path)
                     .stdin(std::process::Stdio::null()),
             )
-            .await?
+            .await
+            .map_err(Self::error)?
             .stdout;
-            let the_plist: DiskUtilInfoOutput = plist::from_reader(Cursor::new(buf))?;
+            let the_plist: DiskUtilInfoOutput =
+                plist::from_reader(Cursor::new(buf)).map_err(Self::error)?;
 
             the_plist.global_permissions_enabled
         };
@@ -77,7 +79,8 @@ impl Action for EnableOwnership {
                     .arg(path)
                     .stdin(std::process::Stdio::null()),
             )
-            .await?;
+            .await
+            .map_err(Self::error)?;
         }
 
         Ok(())
@@ -88,7 +91,7 @@ impl Action for EnableOwnership {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         // noop
         Ok(())
     }
@@ -99,4 +102,10 @@ impl Action for EnableOwnership {
 pub enum EnableOwnershipError {
     #[error("Failed to execute command")]
     Command(#[source] std::io::Error),
+}
+
+impl Into<ActionErrorKind> for EnableOwnershipError {
+    fn into(self) -> ActionErrorKind {
+        ActionErrorKind::Custom(Box::new(self))
+    }
 }

--- a/src/action/macos/enable_ownership.rs
+++ b/src/action/macos/enable_ownership.rs
@@ -88,7 +88,7 @@ impl Action for EnableOwnership {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         // noop
         Ok(())
     }

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -220,12 +220,10 @@ impl Action for EncryptApfsVolume {
         disk = %self.disk.display(),
     ))]
     async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
-        let mut errors = vec![];
-
         let disk_str = self.disk.to_str().expect("Could not turn disk into string"); /* Should not reasonably ever fail */
 
         // TODO: This seems very rough and unsafe
-        if let Err(e) = execute_command(
+        execute_command(
             Command::new("/usr/bin/security").process_group(0).args([
                 "delete-generic-password",
                 "-a",
@@ -244,15 +242,9 @@ impl Action for EncryptApfsVolume {
             ]),
         )
         .await
-        {
-            errors.push(e);
-        }
+        .map_err(|e| vec![e])?;
 
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
+        Ok(())
     }
 }
 

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -1,7 +1,7 @@
 use crate::{
     action::{
-        macos::NIX_VOLUME_MOUNTD_DEST, Action, ActionDescription, ActionError, ActionState,
-        ActionTag, StatefulAction,
+        macos::NIX_VOLUME_MOUNTD_DEST, Action, ActionDescription, ActionError, ActionErrorKind,
+        ActionState, ActionTag, StatefulAction,
     },
     execute_command,
     os::darwin::DiskUtilApfsListOutput,
@@ -51,7 +51,7 @@ impl EncryptApfsVolume {
         if command
             .status()
             .await
-            .map_err(|e| ActionError::command(&command, e))?
+            .map_err(|e| Self::error(ActionErrorKind::command(&command, e)))?
             .success()
         {
             // The user has a password matching what we would create.
@@ -61,24 +61,26 @@ impl EncryptApfsVolume {
             }
 
             // Ask the user to remove it
-            return Err(ActionError::Custom(Box::new(
-                EncryptApfsVolumeError::ExistingPasswordFound(name, disk),
+            return Err(Self::error(EncryptApfsVolumeError::ExistingPasswordFound(
+                name, disk,
             )));
         } else {
             if planned_create_apfs_volume.state == ActionState::Completed {
                 // The user has a volume already created, but a password not set. This means we probably can't decrypt the volume.
-                return Err(ActionError::Custom(Box::new(
+                return Err(Self::error(
                     EncryptApfsVolumeError::MissingPasswordForExistingVolume(name, disk),
-                )));
+                ));
             }
         }
 
         // Ensure if the disk already exists, that it's encrypted
         let output =
             execute_command(Command::new("/usr/sbin/diskutil").args(["apfs", "list", "-plist"]))
-                .await?;
+                .await
+                .map_err(Self::error)?;
 
-        let parsed: DiskUtilApfsListOutput = plist::from_bytes(&output.stdout)?;
+        let parsed: DiskUtilApfsListOutput =
+            plist::from_bytes(&output.stdout).map_err(Self::error)?;
         for container in parsed.containers {
             for volume in container.volumes {
                 if volume.name == name {
@@ -87,9 +89,9 @@ impl EncryptApfsVolume {
                             return Ok(StatefulAction::completed(Self { disk, name }));
                         },
                         false => {
-                            return Err(ActionError::Custom(Box::new(
+                            return Err(Self::error(
                                 EncryptApfsVolumeError::ExistingVolumeNotEncrypted(name, disk),
-                            )));
+                            ));
                         },
                     }
                 }
@@ -150,7 +152,9 @@ impl Action for EncryptApfsVolume {
 
         let disk_str = disk.to_str().expect("Could not turn disk into string"); /* Should not reasonably ever fail */
 
-        execute_command(Command::new("/usr/sbin/diskutil").arg("mount").arg(&name)).await?;
+        execute_command(Command::new("/usr/sbin/diskutil").arg("mount").arg(&name))
+            .await
+            .map_err(Self::error)?;
 
         // Add the password to the user keychain so they can unlock it later.
         execute_command(
@@ -180,7 +184,8 @@ impl Action for EncryptApfsVolume {
                 "/Library/Keychains/System.keychain",
             ]),
         )
-        .await?;
+        .await
+        .map_err(Self::error)?;
 
         // Encrypt the mounted volume
         execute_command(Command::new("/usr/sbin/diskutil").process_group(0).args([
@@ -192,7 +197,8 @@ impl Action for EncryptApfsVolume {
             "-passphrase",
             password.as_str(),
         ]))
-        .await?;
+        .await
+        .map_err(Self::error)?;
 
         execute_command(
             Command::new("/usr/sbin/diskutil")
@@ -201,7 +207,8 @@ impl Action for EncryptApfsVolume {
                 .arg("force")
                 .arg(&name),
         )
-        .await?;
+        .await
+        .map_err(Self::error)?;
 
         Ok(())
     }
@@ -219,7 +226,7 @@ impl Action for EncryptApfsVolume {
     #[tracing::instrument(level = "debug", skip_all, fields(
         disk = %self.disk.display(),
     ))]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         let disk_str = self.disk.to_str().expect("Could not turn disk into string"); /* Should not reasonably ever fail */
 
         // TODO: This seems very rough and unsafe
@@ -242,7 +249,7 @@ impl Action for EncryptApfsVolume {
             ]),
         )
         .await
-        .map_err(|e| vec![e])?;
+        .map_err(Self::error)?;
 
         Ok(())
     }
@@ -256,4 +263,10 @@ pub enum EncryptApfsVolumeError {
     MissingPasswordForExistingVolume(String, PathBuf),
     #[error("The existing APFS volume \"{0}\" on disk `{1}` is not encrypted but it should be, consider removing the volume with `diskutil apfs deleteVolume \"{0}\"` (if you receive error -69888, you may need to run `launchctl bootout system/org.nixos.darwin-store` and `launchctl bootout system/org.nixos.nix-daemon` first)")]
     ExistingVolumeNotEncrypted(String, PathBuf),
+}
+
+impl Into<ActionErrorKind> for EncryptApfsVolumeError {
+    fn into(self) -> ActionErrorKind {
+        ActionErrorKind::Custom(Box::new(self))
+    }
 }

--- a/src/action/macos/kickstart_launchctl_service.rs
+++ b/src/action/macos/kickstart_launchctl_service.rs
@@ -115,7 +115,7 @@ impl Action for KickstartLaunchctlService {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         let Self { domain, service } = self;
 
         // MacOs doesn't offer an "ensure-stopped" like they do with Kickstart

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod unmount_apfs_volume;
 pub use bootstrap_launchctl_service::BootstrapLaunchctlService;
 pub use create_apfs_volume::CreateApfsVolume;
 pub use create_nix_volume::{CreateNixVolume, NIX_VOLUME_MOUNTD_DEST};
-pub use create_synthetic_objects::{CreateSyntheticObjects, CreateSyntheticObjectsError};
+pub use create_synthetic_objects::CreateSyntheticObjects;
 pub use create_volume_service::CreateVolumeService;
 pub use enable_ownership::{EnableOwnership, EnableOwnershipError};
 pub use encrypt_apfs_volume::EncryptApfsVolume;
@@ -27,9 +27,9 @@ use uuid::Uuid;
 
 use crate::execute_command;
 
-use super::ActionError;
+use super::ActionErrorKind;
 
-async fn get_uuid_for_label(apfs_volume_label: &str) -> Result<Uuid, ActionError> {
+async fn get_uuid_for_label(apfs_volume_label: &str) -> Result<Uuid, ActionErrorKind> {
     let output = execute_command(
         Command::new("/usr/sbin/diskutil")
             .process_group(0)

--- a/src/action/macos/unmount_apfs_volume.rs
+++ b/src/action/macos/unmount_apfs_volume.rs
@@ -94,15 +94,13 @@ impl Action for UnmountApfsVolume {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
-        let Self { disk: _, name } = self;
-
         let mut errors = vec![];
 
         if let Err(err) = execute_command(
             Command::new("/usr/sbin/diskutil")
                 .process_group(0)
                 .args(["unmount", "force"])
-                .arg(name)
+                .arg(self.name)
                 .stdin(std::process::Stdio::null()),
         )
         .await

--- a/src/action/macos/unmount_apfs_volume.rs
+++ b/src/action/macos/unmount_apfs_volume.rs
@@ -65,9 +65,11 @@ impl Action for UnmountApfsVolume {
                     .arg(&name)
                     .stdin(std::process::Stdio::null()),
             )
-            .await?
+            .await
+            .map_err(Self::error)?
             .stdout;
-            let the_plist: DiskUtilInfoOutput = plist::from_reader(Cursor::new(buf))?;
+            let the_plist: DiskUtilInfoOutput =
+                plist::from_reader(Cursor::new(buf)).map_err(|e| Self::error(e))?;
 
             the_plist.mount_point.is_some()
         };
@@ -80,7 +82,8 @@ impl Action for UnmountApfsVolume {
                     .arg(name)
                     .stdin(std::process::Stdio::null()),
             )
-            .await?;
+            .await
+            .map_err(Self::error)?;
         } else {
             tracing::debug!("Volume was already unmounted, can skip unmounting")
         }
@@ -93,10 +96,8 @@ impl Action for UnmountApfsVolume {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
-        let mut errors = vec![];
-
-        if let Err(err) = execute_command(
+    async fn revert(&mut self) -> Result<(), ActionError> {
+        execute_command(
             Command::new("/usr/sbin/diskutil")
                 .process_group(0)
                 .args(["unmount", "force"])
@@ -104,14 +105,8 @@ impl Action for UnmountApfsVolume {
                 .stdin(std::process::Stdio::null()),
         )
         .await
-        {
-            errors.push(err);
-        };
+        .map_err(Self::error)?;
 
-        if errors.is_empty() {
-            Ok(())
-        } else {
-            Err(errors)
-        }
+        Ok(())
     }
 }

--- a/src/action/macos/unmount_apfs_volume.rs
+++ b/src/action/macos/unmount_apfs_volume.rs
@@ -100,7 +100,7 @@ impl Action for UnmountApfsVolume {
             Command::new("/usr/sbin/diskutil")
                 .process_group(0)
                 .args(["unmount", "force"])
-                .arg(self.name)
+                .arg(&self.name)
                 .stdin(std::process::Stdio::null()),
         )
         .await

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -98,7 +98,7 @@ impl Action for MyAction {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
+    async fn revert(&mut self) -> Result<(), ActionError> {
         // Revert steps...
         Ok(())
     }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -98,7 +98,7 @@ impl Action for MyAction {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn revert(&mut self) -> Result<(), ActionError> {
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>> {
         // Revert steps...
         Ok(())
     }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -575,7 +575,8 @@ impl crate::diagnostics::ErrorDiagnostic for ActionErrorKind {
             | Self::SetPermissions(_, path, _)
             | Self::GettingMetadata(path, _)
             | Self::CreateDirectory(path, _)
-            | Self::PathWasNotFile(path) => {
+            | Self::PathWasNotFile(path)
+            | Self::Remove(path, _) => {
                 vec![path.to_string_lossy().to_string()]
             },
             Self::Rename(first_path, second_path, _)

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -362,20 +362,20 @@ pub enum ActionErrorKind {
     #[error(transparent)]
     Child(Box<ActionError>),
     /// Several errors
-    #[error("Multiple child errors:\n{}", .0.iter().map(|err| {
+    #[error("Multiple child errors\n{}", .0.iter().map(|err| {
         if let Some(source) = err.source() {
-            format!("{err}\n{source}")
+            format!("{err}\n{source}\n")
         } else {
-            format!("{err}") 
+            format!("{err}\n") 
         }
     }).collect::<Vec<_>>().join("\n"))]
     MultipleChildren(Vec<ActionError>),
     /// Several errors
-    #[error("Multiple errors:\n{}", .0.iter().map(|err| {
+    #[error("Multiple errors\n{}", .0.iter().map(|err| {
         if let Some(source) = err.source() {
-            format!("{err} ({source})")
+            format!("{err} ({source})\n")
         } else {
-            format!("{err}") 
+            format!("{err}\n") 
         }
     }).collect::<Vec<_>>().join("\n"))]
     Multiple(Vec<ActionErrorKind>),

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -244,7 +244,7 @@ pub trait Action: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
     /// If this action calls sub-[`Action`]s, care should be taken to call [`try_revert`][StatefulAction::try_revert], not [`revert`][Action::revert], so that [`ActionState`] is handled correctly and tracing is done.
     ///
     /// /// This is called by [`InstallPlan::uninstall`](crate::InstallPlan::uninstall) through [`StatefulAction::try_revert`] which handles tracing as well as if the action needs to revert based on its `action_state`.
-    async fn revert(&mut self) -> Result<(), Vec<ActionError>>;
+    async fn revert(&mut self) -> Result<(), ActionError>;
 
     fn stateful(self) -> StatefulAction<Self>
     where
@@ -255,6 +255,14 @@ pub trait Action: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
             state: ActionState::Uncompleted,
         }
     }
+
+    fn error(kind: impl Into<ActionErrorKind>) -> ActionError
+    where
+        Self: Sized,
+    {
+        ActionError::new(Self::action_tag(), kind)
+    }
+
     // They should also have an `async fn plan(args...) -> Result<StatefulAction<Self>, ActionError>;`
 }
 
@@ -299,10 +307,51 @@ impl From<&'static str> for ActionTag {
     }
 }
 
+#[derive(Debug)]
+pub struct ActionError {
+    action_tag: ActionTag,
+    kind: ActionErrorKind,
+}
+
+impl ActionError {
+    pub fn new(action_tag: ActionTag, kind: impl Into<ActionErrorKind>) -> Self {
+        Self {
+            action_tag,
+            kind: kind.into(),
+        }
+    }
+
+    pub fn kind(&self) -> &ActionErrorKind {
+        &self.kind
+    }
+
+    pub fn action_tag(&self) -> &ActionTag {
+        &self.action_tag
+    }
+}
+
+impl std::fmt::Display for ActionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("Action `{}` errored", self.action_tag))
+    }
+}
+
+impl std::error::Error for ActionError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.kind)
+    }
+}
+
+impl From<ActionError> for ActionErrorKind {
+    fn from(value: ActionError) -> Self {
+        Self::Child(Box::new(value))
+    }
+}
+
 /// An error occurring during an action
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
-pub enum ActionError {
+pub enum ActionErrorKind {
     /// A custom error
     #[error(transparent)]
     Custom(Box<dyn std::error::Error + Send + Sync>),
@@ -310,26 +359,26 @@ pub enum ActionError {
     #[error(transparent)]
     Certificate(#[from] CertificateError),
     /// A child error
-    #[error("Child action `{0}`")]
-    Child(ActionTag, #[source] Box<ActionError>),
-    /// Several child errors
-    #[error("Reverting child action `{0}` errors:\n{}", .1.iter().map(|err| {
+    #[error(transparent)]
+    Child(Box<ActionError>),
+    /// Several errors
+    #[error("Multiple child errors:\n{}", .0.iter().map(|err| {
+        if let Some(source) = err.source() {
+            format!("{err}\n{source}")
+        } else {
+            format!("{err}") 
+        }
+    }).collect::<Vec<_>>().join("\n"))]
+    MultipleChildren(Vec<ActionError>),
+    /// Several errors
+    #[error("Multiple errors:\n{}", .0.iter().map(|err| {
         if let Some(source) = err.source() {
             format!("{err} ({source})")
         } else {
             format!("{err}") 
         }
     }).collect::<Vec<_>>().join("\n"))]
-    ChildRevert(ActionTag, Vec<ActionError>),
-    /// Several child errors
-    #[error("Child action errors:\n{}", .0.iter().map(|err| {
-        if let Some(source) = err.source() {
-            format!("{err} ({source})")
-        } else {
-            format!("{err}") 
-        }
-    }).collect::<Vec<_>>().join("\n"))]
-    Children(Vec<Box<ActionError>>),
+    Multiple(Vec<ActionErrorKind>),
     /// The path already exists with different content that expected
     #[error(
         "`{0}` exists with different content than planned, consider removing it with `rm {0}`"
@@ -484,7 +533,7 @@ pub enum ActionError {
     SystemdMissing,
 }
 
-impl ActionError {
+impl ActionErrorKind {
     pub fn command(command: &tokio::process::Command, error: std::io::Error) -> Self {
         Self::Command {
             #[cfg(feature = "diagnostics")]
@@ -503,7 +552,7 @@ impl ActionError {
     }
 }
 
-impl HasExpectedErrors for ActionError {
+impl HasExpectedErrors for ActionErrorKind {
     fn expected<'a>(&'a self) -> Option<Box<dyn std::error::Error + 'a>> {
         match self {
             Self::PathUserMismatch(_, _, _)
@@ -515,11 +564,10 @@ impl HasExpectedErrors for ActionError {
 }
 
 #[cfg(feature = "diagnostics")]
-impl crate::diagnostics::ErrorDiagnostic for ActionError {
+impl crate::diagnostics::ErrorDiagnostic for ActionErrorKind {
     fn diagnostic(&self) -> String {
         let static_str: &'static str = (self).into();
         let context = match self {
-            Self::Child(action, _) => vec![action.to_string()],
             Self::Read(path, _)
             | Self::Open(path, _)
             | Self::Write(path, _)

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -313,14 +313,23 @@ pub enum ActionError {
     #[error("Child action `{0}`")]
     Child(ActionTag, #[source] Box<ActionError>),
     /// Several child errors
-    #[error("Child action errors:\n{}", .0.iter().map(|(tag, err)| {
+    #[error("Reverting child action `{0}` errors:\n{}", .1.iter().map(|err| {
         if let Some(source) = err.source() {
-            format!("`{tag}` {err} ({source})")
+            format!("{err} ({source})")
         } else {
-            format!("`{tag}` {err}") 
+            format!("{err}") 
         }
     }).collect::<Vec<_>>().join("\n"))]
-    Children(Vec<(ActionTag, Box<ActionError>)>),
+    ChildRevert(ActionTag, Vec<ActionError>),
+    /// Several child errors
+    #[error("Child action errors:\n{}", .0.iter().map(|err| {
+        if let Some(source) = err.source() {
+            format!("{err} ({source})")
+        } else {
+            format!("{err}") 
+        }
+    }).collect::<Vec<_>>().join("\n"))]
+    Children(Vec<Box<ActionError>>),
     /// The path already exists with different content that expected
     #[error(
         "`{0}` exists with different content than planned, consider removing it with `rm {0}`"

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -362,7 +362,7 @@ pub enum ActionErrorKind {
     #[error(transparent)]
     Child(Box<ActionError>),
     /// Several errors
-    #[error("Multiple child errors\n{}", .0.iter().map(|err| {
+    #[error("Multiple child errors\n\n{}", .0.iter().map(|err| {
         if let Some(source) = err.source() {
             format!("{err}\n{source}\n")
         } else {
@@ -371,11 +371,11 @@ pub enum ActionErrorKind {
     }).collect::<Vec<_>>().join("\n"))]
     MultipleChildren(Vec<ActionError>),
     /// Several errors
-    #[error("Multiple errors\n{}", .0.iter().map(|err| {
+    #[error("Multiple errors\n\n{}", .0.iter().map(|err| {
         if let Some(source) = err.source() {
-            format!("{err} ({source})\n")
+            format!("{err}\n{source}")
         } else {
-            format!("{err}\n") 
+            format!("{err}\n")
         }
     }).collect::<Vec<_>>().join("\n"))]
     Multiple(Vec<ActionErrorKind>),

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -313,14 +313,14 @@ pub enum ActionError {
     #[error("Child action `{0}`")]
     Child(ActionTag, #[source] Box<ActionError>),
     /// Several child errors
-    #[error("Child action errors: {}", .0.iter().map(|v| {
-        if let Some(source) = v.source() {
-            format!("{v} ({source})")
+    #[error("Child action errors:\n{}", .0.iter().map(|(tag, err)| {
+        if let Some(source) = err.source() {
+            format!("`{tag}` {err} ({source})")
         } else {
-            format!("{v}") 
+            format!("`{tag}` {err}") 
         }
-    }).collect::<Vec<_>>().join(" & "))]
-    Children(Vec<Box<ActionError>>),
+    }).collect::<Vec<_>>().join("\n"))]
+    Children(Vec<(ActionTag, Box<ActionError>)>),
     /// The path already exists with different content that expected
     #[error(
         "`{0}` exists with different content than planned, consider removing it with `rm {0}`"

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -244,7 +244,7 @@ pub trait Action: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
     /// If this action calls sub-[`Action`]s, care should be taken to call [`try_revert`][StatefulAction::try_revert], not [`revert`][Action::revert], so that [`ActionState`] is handled correctly and tracing is done.
     ///
     /// /// This is called by [`InstallPlan::uninstall`](crate::InstallPlan::uninstall) through [`StatefulAction::try_revert`] which handles tracing as well as if the action needs to revert based on its `action_state`.
-    async fn revert(&mut self) -> Result<(), ActionError>;
+    async fn revert(&mut self) -> Result<(), Vec<ActionError>>;
 
     fn stateful(self) -> StatefulAction<Self>
     where

--- a/src/action/stateful.rs
+++ b/src/action/stateful.rs
@@ -83,7 +83,7 @@ impl StatefulAction<Box<dyn Action>> {
     ///
     /// You should prefer this ([`try_revert`][StatefulAction::try_revert]) over [`revert`][Action::revert] as it handles [`ActionState`] and does tracing
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn try_revert(&mut self) -> Result<(), Vec<ActionError>> {
+    pub async fn try_revert(&mut self) -> Result<(), ActionError> {
         match self.state {
             ActionState::Uncompleted => {
                 tracing::trace!(
@@ -193,7 +193,7 @@ where
     /// Perform any revert steps
     ///
     /// You should prefer this ([`try_revert`][StatefulAction::try_revert]) over [`revert`][Action::revert] as it handles [`ActionState`] and does tracing
-    pub async fn try_revert(&mut self) -> Result<(), Vec<ActionError>> {
+    pub async fn try_revert(&mut self) -> Result<(), ActionError> {
         let span = self.action.tracing_span();
         match self.state {
             ActionState::Uncompleted => {

--- a/src/action/stateful.rs
+++ b/src/action/stateful.rs
@@ -83,7 +83,7 @@ impl StatefulAction<Box<dyn Action>> {
     ///
     /// You should prefer this ([`try_revert`][StatefulAction::try_revert]) over [`revert`][Action::revert] as it handles [`ActionState`] and does tracing
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn try_revert(&mut self) -> Result<(), ActionError> {
+    pub async fn try_revert(&mut self) -> Result<(), Vec<ActionError>> {
         match self.state {
             ActionState::Uncompleted => {
                 tracing::trace!(
@@ -193,7 +193,7 @@ where
     /// Perform any revert steps
     ///
     /// You should prefer this ([`try_revert`][StatefulAction::try_revert]) over [`revert`][Action::revert] as it handles [`ActionState`] and does tracing
-    pub async fn try_revert(&mut self) -> Result<(), ActionError> {
+    pub async fn try_revert(&mut self) -> Result<(), Vec<ActionError>> {
         let span = self.action.tracing_span();
         match self.state {
             ActionState::Uncompleted => {

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -146,9 +146,6 @@ impl CommandExecute for Uninstall {
             _ => (),
         }
 
-        // TODO(@hoverbear): It would be so nice to catch errors and offer the user a way to keep going...
-        //                   However that will require being able to link error -> step and manually setting that step as `Uncompleted`.
-
         println!(
             "\
             {success}\n\

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -129,12 +129,9 @@ impl CommandExecute for Uninstall {
 
         let res = plan.uninstall(rx).await;
         match res {
-            Err(NixInstallerError::ActionRevert(errs)) => {
-                let mut report = eyre!("Multiple errors");
-                for err in errs {
-                    report = report.error(err);
-                }
-                return Err(report)?;
+            Err(err @ NixInstallerError::ActionRevert(_)) => {
+                tracing::info!("Uninstallation complete, some errors encountered");
+                return Err(err)?;
             },
             Err(err) => {
                 if let Some(expected) = err.expected() {

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -127,7 +127,7 @@ impl CommandExecute for Uninstall {
         let res = plan.uninstall(rx).await;
         match res {
             Err(err @ NixInstallerError::ActionRevert(_)) => {
-                tracing::info!("Uninstallation complete, some errors encountered");
+                tracing::error!("Uninstallation complete, some errors encountered");
                 return Err(err)?;
             },
             Err(err) => {

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -11,10 +11,7 @@ use crate::{
     InstallPlan, NixInstallerError,
 };
 use clap::{ArgAction, Parser};
-use color_eyre::{
-    eyre::{eyre, WrapErr},
-    Section,
-};
+use color_eyre::eyre::{eyre, WrapErr};
 use owo_colors::OwoColorize;
 use rand::Rng;
 

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -102,11 +102,11 @@ impl DiagnosticData {
         let mut walker: &dyn std::error::Error = &err;
         while let Some(source) = walker.source() {
             if let Some(downcasted) = source.downcast_ref::<ActionError>() {
-                let downcasted_diagnostic = downcasted.diagnostic();
+                let downcasted_diagnostic = downcasted.kind().diagnostic();
                 failure_chain.push(downcasted_diagnostic);
             }
             if let Some(downcasted) = source.downcast_ref::<Box<ActionError>>() {
-                let downcasted_diagnostic = downcasted.diagnostic();
+                let downcasted_diagnostic = downcasted.kind().diagnostic();
                 failure_chain.push(downcasted_diagnostic);
             }
             if let Some(downcasted) = source.downcast_ref::<PlannerError>() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,18 +1,14 @@
 use std::path::PathBuf;
 
-use crate::{
-    action::{ActionError, ActionTag},
-    planner::PlannerError,
-    settings::InstallSettingsError,
-};
+use crate::{action::ActionError, planner::PlannerError, settings::InstallSettingsError};
 
 /// An error occurring during a call defined in this crate
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug, strum::IntoStaticStr)]
 pub enum NixInstallerError {
     /// An error originating from an [`Action`](crate::action::Action)
-    #[error("Error executing action `{0}`")]
-    Action(ActionTag, #[source] ActionError),
+    #[error("Error executing action")]
+    Action(#[source] ActionError),
     /// An error originating from an [`Action`](crate::action::Action) while reverting
     #[error("Error reverting")]
     ActionRevert(Vec<ActionError>),
@@ -75,7 +71,7 @@ pub(crate) trait HasExpectedErrors: std::error::Error + Sized + Send + Sync {
 impl HasExpectedErrors for NixInstallerError {
     fn expected<'a>(&'a self) -> Option<Box<dyn std::error::Error + 'a>> {
         match self {
-            NixInstallerError::Action(_, action_error) => action_error.expected(),
+            NixInstallerError::Action(action_error) => action_error.kind().expected(),
             NixInstallerError::ActionRevert(_) => None,
             NixInstallerError::RecordingReceipt(_, _) => None,
             NixInstallerError::CopyingSelf(_) => None,
@@ -95,7 +91,7 @@ impl crate::diagnostics::ErrorDiagnostic for NixInstallerError {
     fn diagnostic(&self) -> String {
         let static_str: &'static str = (self).into();
         let context = match self {
-            Self::Action(action, _) => vec![action.to_string()],
+            Self::Action(action_error) => vec![action_error.action_tag().to_string()],
             _ => vec![],
         };
         return format!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,9 @@ pub enum NixInstallerError {
     /// An error originating from an [`Action`](crate::action::Action)
     #[error("Error executing action `{0}`")]
     Action(ActionTag, #[source] ActionError),
+    /// An error originating from an [`Action`](crate::action::Action) while reverting
+    #[error("Error reverting")]
+    ActionRevert(Vec<ActionError>),
     /// An error while writing the [`InstallPlan`](crate::InstallPlan)
     #[error("Recording install receipt")]
     RecordingReceipt(PathBuf, #[source] std::io::Error),
@@ -73,6 +76,7 @@ impl HasExpectedErrors for NixInstallerError {
     fn expected<'a>(&'a self) -> Option<Box<dyn std::error::Error + 'a>> {
         match self {
             NixInstallerError::Action(_, action_error) => action_error.expected(),
+            NixInstallerError::ActionRevert(_) => None,
             NixInstallerError::RecordingReceipt(_, _) => None,
             NixInstallerError::CopyingSelf(_) => None,
             NixInstallerError::SerializingReceipt(_) => None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{error::Error, path::PathBuf};
 
 use crate::{action::ActionError, planner::PlannerError, settings::InstallSettingsError};
 
@@ -10,7 +10,13 @@ pub enum NixInstallerError {
     #[error("Error executing action")]
     Action(#[source] ActionError),
     /// An error originating from an [`Action`](crate::action::Action) while reverting
-    #[error("Error reverting")]
+    #[error("Error reverting\n{}", .0.iter().map(|err| {
+        if let Some(source) = err.source() {
+            format!("{err}\n{source}\n")
+        } else {
+            format!("{err}\n") 
+        }
+    }).collect::<Vec<_>>().join("\n"))]
     ActionRevert(Vec<ActionError>),
     /// An error while writing the [`InstallPlan`](crate::InstallPlan)
     #[error("Recording install receipt")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,6 @@ pub mod settings;
 
 use std::{ffi::OsStr, path::Path, process::Output};
 
-use action::{Action, ActionError};
-
 pub use error::NixInstallerError;
 pub use plan::InstallPlan;
 use planner::BuiltinPlanner;
@@ -91,16 +89,18 @@ use planner::BuiltinPlanner;
 use reqwest::Certificate;
 use tokio::process::Command;
 
+use crate::action::{Action, ActionErrorKind};
+
 #[tracing::instrument(level = "debug", skip_all, fields(command = %format!("{:?}", command.as_std())))]
-async fn execute_command(command: &mut Command) -> Result<Output, ActionError> {
+async fn execute_command(command: &mut Command) -> Result<Output, ActionErrorKind> {
     tracing::trace!("Executing");
     let output = command
         .output()
         .await
-        .map_err(|e| ActionError::command(command, e))?;
+        .map_err(|e| ActionErrorKind::command(command, e))?;
     match output.status.success() {
         true => Ok(output),
-        false => Err(ActionError::command_output(command, output)),
+        false => Err(ActionErrorKind::command_output(command, output)),
     }
 }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -175,12 +175,11 @@ impl InstallPlan {
             }
 
             tracing::info!("Step: {}", action.tracing_synopsis());
-            let typetag_name = action.inner_typetag_name();
             if let Err(err) = action.try_execute().await {
                 if let Err(err) = write_receipt(self.clone()).await {
                     tracing::error!("Error saving receipt: {:?}", err);
                 }
-                let err = NixInstallerError::Action(typetag_name.into(), err);
+                let err = NixInstallerError::Action(err);
                 #[cfg(feature = "diagnostics")]
                 if let Some(diagnostic_data) = &self.diagnostic_data {
                     diagnostic_data
@@ -326,7 +325,7 @@ impl InstallPlan {
 
             tracing::info!("Revert: {}", action.tracing_synopsis());
             if let Err(errs) = action.try_revert().await {
-                errors.extend(errs);
+                errors.push(errs);
             }
         }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -329,10 +329,6 @@ impl InstallPlan {
             }
         }
 
-        if let Err(err) = write_receipt(self.clone()).await {
-            tracing::error!("Error saving receipt: {:?}", err);
-        }
-
         if errors.is_empty() {
             #[cfg(feature = "diagnostics")]
             if let Some(diagnostic_data) = &self.diagnostic_data {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -296,6 +296,7 @@ impl InstallPlan {
     ) -> Result<(), NixInstallerError> {
         let Self { actions, .. } = self;
         let mut cancel_channel = cancel_channel.into();
+        let mut errors = vec![];
 
         // This is **deliberately sequential**.
         // Actions which are parallelizable are represented by "group actions" like CreateUsers
@@ -324,39 +325,44 @@ impl InstallPlan {
             }
 
             tracing::info!("Revert: {}", action.tracing_synopsis());
-            let typetag_name = action.inner_typetag_name();
-            if let Err(err) = action.try_revert().await {
-                if let Err(err) = write_receipt(self.clone()).await {
-                    tracing::error!("Error saving receipt: {:?}", err);
-                }
-                let err = NixInstallerError::Action(typetag_name.into(), err);
-                #[cfg(feature = "diagnostics")]
-                if let Some(diagnostic_data) = &self.diagnostic_data {
-                    diagnostic_data
-                        .clone()
-                        .failure(&err)
-                        .send(
-                            crate::diagnostics::DiagnosticAction::Uninstall,
-                            crate::diagnostics::DiagnosticStatus::Failure,
-                        )
-                        .await?;
-                }
-                return Err(err);
+            if let Err(errs) = action.try_revert().await {
+                errors.extend(errs);
             }
         }
 
-        #[cfg(feature = "diagnostics")]
-        if let Some(diagnostic_data) = &self.diagnostic_data {
-            diagnostic_data
-                .clone()
-                .send(
-                    crate::diagnostics::DiagnosticAction::Uninstall,
-                    crate::diagnostics::DiagnosticStatus::Success,
-                )
-                .await?;
+        if let Err(err) = write_receipt(self.clone()).await {
+            tracing::error!("Error saving receipt: {:?}", err);
         }
 
-        Ok(())
+        if errors.is_empty() {
+            #[cfg(feature = "diagnostics")]
+            if let Some(diagnostic_data) = &self.diagnostic_data {
+                diagnostic_data
+                    .clone()
+                    .send(
+                        crate::diagnostics::DiagnosticAction::Uninstall,
+                        crate::diagnostics::DiagnosticStatus::Success,
+                    )
+                    .await?;
+            }
+
+            Ok(())
+        } else {
+            let error = NixInstallerError::ActionRevert(errors);
+            #[cfg(feature = "diagnostics")]
+            if let Some(diagnostic_data) = &self.diagnostic_data {
+                diagnostic_data
+                    .clone()
+                    .failure(&error)
+                    .send(
+                        crate::diagnostics::DiagnosticAction::Uninstall,
+                        crate::diagnostics::DiagnosticStatus::Failure,
+                    )
+                    .await?;
+            }
+
+            return Err(error);
+        }
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -178,10 +178,6 @@ pub struct CommonSettings {
 
     /// An SSL cert to use (if any), used for fetching Nix and sets `NIX_SSL_CERT_FILE` for Nix
     #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_SSL_CERT_FILE"))]
-    #[cfg_attr(
-        all(target_os = "macos", feature = "cli"),
-        clap(default_value = "/etc/ssl/certs/ca-certificates.crt")
-    )]
     pub ssl_cert_file: Option<PathBuf>,
 
     /// Extra configuration lines for `/etc/nix.conf`

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -178,6 +178,10 @@ pub struct CommonSettings {
 
     /// An SSL cert to use (if any), used for fetching Nix and sets `NIX_SSL_CERT_FILE` for Nix
     #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_SSL_CERT_FILE"))]
+    #[cfg_attr(
+        all(target_os = "macos", feature = "cli"),
+        clap(default_value = "/etc/ssl/certs/ca-certificates.crt")
+    )]
     pub ssl_cert_file: Option<PathBuf>,
 
     /// Extra configuration lines for `/etc/nix.conf`
@@ -232,6 +236,7 @@ impl CommonSettings {
         let url;
         let nix_build_user_prefix;
         let nix_build_user_id_base;
+        let ssl_cert_file;
 
         use target_lexicon::{Architecture, OperatingSystem};
         match (Architecture::host(), OperatingSystem::host()) {
@@ -240,18 +245,21 @@ impl CommonSettings {
                 url = NIX_X64_64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
+                ssl_cert_file = None;
             },
             #[cfg(target_os = "linux")]
             (Architecture::X86_32(_), OperatingSystem::Linux) => {
                 url = NIX_I686_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
+                ssl_cert_file = None;
             },
             #[cfg(target_os = "linux")]
             (Architecture::Aarch64(_), OperatingSystem::Linux) => {
                 url = NIX_AARCH64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
+                ssl_cert_file = None;
             },
             #[cfg(target_os = "macos")]
             (Architecture::X86_64, OperatingSystem::MacOSX { .. })
@@ -259,6 +267,7 @@ impl CommonSettings {
                 url = NIX_X64_64_DARWIN_URL;
                 nix_build_user_prefix = "_nixbld";
                 nix_build_user_id_base = 300;
+                ssl_cert_file = Some("/etc/ssl/certs/ca-certificates.crt".into());
             },
             #[cfg(target_os = "macos")]
             (Architecture::Aarch64(_), OperatingSystem::MacOSX { .. })
@@ -266,6 +275,7 @@ impl CommonSettings {
                 url = NIX_AARCH64_DARWIN_URL;
                 nix_build_user_prefix = "_nixbld";
                 nix_build_user_id_base = 300;
+                ssl_cert_file = Some("/etc/ssl/certs/ca-certificates.crt".into());
             },
             _ => {
                 return Err(InstallSettingsError::UnsupportedArchitecture(
@@ -285,7 +295,7 @@ impl CommonSettings {
             proxy: Default::default(),
             extra_conf: Default::default(),
             force: false,
-            ssl_cert_file: Default::default(),
+            ssl_cert_file,
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint: Some("https://install.determinate.systems/nix/diagnostic".into()),
         })


### PR DESCRIPTION
##### Description

Fixes #354.

We now continue with uninstall where possible, driving it to completion and reporting errors we found at the end, instead of failing fast.

Includes a pretty major overhaul of how we do errors in general. This ensures we **always** capture which action we emit from.

* Shifted `ActionError` to `ActionErrorKind`
* Created `ActionError`, which holds an `ActionErrorKind`, as well as an `ActionTag` noting which error emitted it.
* Gave trait `Action` a `Self::error(err_kind)` function which creates those `ActionError`s from an `ActionErrorKind`.


Also refactored the Nix `vm-tests` to include uninstall failure tests and be less... messy.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
