### PR TITLE
Release v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix-installer"
 description = "The Determinate Nix Installer"
-version = "0.6.1-unreleased"
+version = "0.7.0"
 edition = "2021"
 resolver = "2"
 license = "LGPL-2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
           };
           sharedAttrs = {
             pname = "nix-installer";
-            version = "0.6.1-unreleased";
+            version = "0.7.0";
             src = builtins.path {
               name = "nix-installer-source";
               path = self;

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.1-unreleased",
+  "version": "0.7.0",
   "actions": [
     {
       "action": {
@@ -952,7 +952,7 @@
     }
   },
   "diagnostic_data": {
-    "version": "0.6.1-unreleased",
+    "version": "0.7.0",
     "planner": "linux",
     "configured_settings": [],
     "os_name": "Ubuntu",

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.1-unreleased",
+  "version": "0.7.0",
   "actions": [
     {
       "action": {
@@ -1000,7 +1000,7 @@
     }
   },
   "diagnostic_data": {
-    "version": "0.6.1-unreleased",
+    "version": "0.7.0",
     "planner": "steam-deck",
     "configured_settings": [],
     "os_name": "Ubuntu",

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.1-unreleased",
+  "version": "0.7.0",
   "actions": [
     {
       "action": {


### PR DESCRIPTION
##### Description

This is mostly a bugfix release.

I tested the vm-tests and container tests and they all pass.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
