### PR TITLE
Trim fdesetup output, remove accidently committed SSL related settings

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -403,6 +403,7 @@ impl Action for ConfigureInitService {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
+        #[cfg_attr(target_os = "macos", allow(unused_mut))]
         let mut errors = vec![];
 
         match self.init {

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -119,7 +119,8 @@ impl Planner for Macos {
                 .map_err(|e| PlannerError::Custom(Box::new(e)))?;
 
             let stdout = String::from_utf8_lossy(&output.stdout);
-            if stdout == "true" {
+            let stdout_trimmed = stdout.trim();
+            if stdout_trimmed == "true" {
                 true
             } else {
                 false

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -263,7 +263,6 @@ impl CommonSettings {
                 url = NIX_X64_64_DARWIN_URL;
                 nix_build_user_prefix = "_nixbld";
                 nix_build_user_id_base = 300;
-                ssl_cert_file = Some("/etc/ssl/certs/ca-certificates.crt".into());
             },
             #[cfg(target_os = "macos")]
             (Architecture::Aarch64(_), OperatingSystem::MacOSX { .. })
@@ -271,7 +270,6 @@ impl CommonSettings {
                 url = NIX_AARCH64_DARWIN_URL;
                 nix_build_user_prefix = "_nixbld";
                 nix_build_user_id_base = 300;
-                ssl_cert_file = Some("/etc/ssl/certs/ca-certificates.crt".into());
             },
             _ => {
                 return Err(InstallSettingsError::UnsupportedArchitecture(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -285,7 +285,7 @@ impl CommonSettings {
             proxy: Default::default(),
             extra_conf: Default::default(),
             force: false,
-            ssl_cert_file,
+            ssl_cert_file: Default::default(),
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint: Some("https://install.determinate.systems/nix/diagnostic".into()),
         })

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -232,7 +232,6 @@ impl CommonSettings {
         let url;
         let nix_build_user_prefix;
         let nix_build_user_id_base;
-        let ssl_cert_file;
 
         use target_lexicon::{Architecture, OperatingSystem};
         match (Architecture::host(), OperatingSystem::host()) {
@@ -241,21 +240,18 @@ impl CommonSettings {
                 url = NIX_X64_64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                ssl_cert_file = None;
             },
             #[cfg(target_os = "linux")]
             (Architecture::X86_32(_), OperatingSystem::Linux) => {
                 url = NIX_I686_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                ssl_cert_file = None;
             },
             #[cfg(target_os = "linux")]
             (Architecture::Aarch64(_), OperatingSystem::Linux) => {
                 url = NIX_AARCH64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                ssl_cert_file = None;
             },
             #[cfg(target_os = "macos")]
             (Architecture::X86_64, OperatingSystem::MacOSX { .. })


### PR DESCRIPTION
##### Description

This should fix the problem seen in https://github.com/DeterminateSystems/nix-installer/issues/400#issuecomment-1496566213 related to #361 

It also removes a bit of code I was testing that got merged accidently in #382 

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
