### PR TITLE
Handle the APFS volume not existing but the Service and Fstab being present

### DIFF
--- a/src/action/macos/create_fstab_entry.rs
+++ b/src/action/macos/create_fstab_entry.rs
@@ -272,9 +272,7 @@ impl Action for CreateFstabEntry {
                 .await
                 .map_err(|e| Self::error(ActionErrorKind::Flush(fstab_path.to_owned(), e)))?;
         } else {
-            return Err(Self::error(
-                CreateFstabEntryError::CannotDetermineFstabLine,
-            ));
+            return Err(Self::error(CreateFstabEntryError::CannotDetermineFstabLine));
         }
 
         Ok(())

--- a/src/action/macos/create_fstab_entry.rs
+++ b/src/action/macos/create_fstab_entry.rs
@@ -273,7 +273,7 @@ impl Action for CreateFstabEntry {
                 .map_err(|e| Self::error(ActionErrorKind::Flush(fstab_path.to_owned(), e)))?;
         } else {
             return Err(Self::error(
-                CreateFstabEntryError::EntryNoLongerDeterminable,
+                CreateFstabEntryError::CannotDetermineFstabLine,
             ));
         }
 
@@ -305,7 +305,7 @@ pub enum CreateFstabEntryError {
     #[error("Unable to determine how to add APFS volume `{0}` the `/etc/fstab` line, likely the volume is not yet created or there is some synchronization issue, please report this")]
     CannotDetermineUuid(String),
     #[error("Unable to reliably determine which `/etc/fstab` line to remove, the volume is likely already deleted, the line involving `/nix` in `/etc/fstab` should be removed manually")]
-    EntryNoLongerDeterminable,
+    CannotDetermineFstabLine,
 }
 
 impl Into<ActionErrorKind> for CreateFstabEntryError {

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -144,12 +144,12 @@ impl Action for CreateVolumeService {
     }
     fn tracing_synopsis(&self) -> String {
         format!(
-            "{maybe_unload}reate a `launchctl` plist to mount the APFS volume `{path}`",
+            "{maybe_unload} a `launchctl` plist to mount the APFS volume `{path}`",
             path = self.path.display(),
             maybe_unload = if self.needs_bootout {
-                "Unload, then rec"
+                "Unload, then recreate"
             } else {
-                "C"
+                "Create"
             }
         )
     }

--- a/src/action/macos/kickstart_launchctl_service.rs
+++ b/src/action/macos/kickstart_launchctl_service.rs
@@ -76,7 +76,10 @@ impl Action for KickstartLaunchctlService {
         ActionTag("kickstart_launchctl_service")
     }
     fn tracing_synopsis(&self) -> String {
-        format!("Run `launchctl kickstart -k {}`", self.service)
+        format!(
+            "Run `launchctl kickstart -k {}/{}`",
+            self.domain, self.service
+        )
     }
 
     fn tracing_span(&self) -> Span {

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -25,30 +25,46 @@ use tokio::process::Command;
 pub use unmount_apfs_volume::UnmountApfsVolume;
 use uuid::Uuid;
 
-use crate::execute_command;
-
 use super::ActionErrorKind;
 
-async fn get_uuid_for_label(apfs_volume_label: &str) -> Result<Uuid, ActionErrorKind> {
-    let output = execute_command(
-        Command::new("/usr/sbin/diskutil")
-            .process_group(0)
-            .arg("info")
-            .arg("-plist")
-            .arg(apfs_volume_label)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped()),
-    )
-    .await?;
+async fn get_uuid_for_label(apfs_volume_label: &str) -> Result<Option<Uuid>, ActionErrorKind> {
+    let mut command = Command::new("/usr/sbin/diskutil");
+    command.process_group(0);
+    command.arg("info");
+    command.arg("-plist");
+    command.arg(apfs_volume_label);
+    command.stdin(std::process::Stdio::null());
+    command.stdout(std::process::Stdio::piped());
+
+    let command_str = format!("{:?}", command.as_std());
+
+    tracing::trace!(command = command_str, "Executing");
+    let output = command.output().await.map_err(|e| ActionErrorKind::command(&command, e))?;
 
     let parsed: DiskUtilApfsInfoOutput = plist::from_bytes(&output.stdout)?;
 
-    Ok(parsed.volume_uuid)
+    if let Some(error_message) = parsed.error_message {
+        let expected_not_found = format!("Could not find disk: {apfs_volume_label}");
+        if error_message.contains(&expected_not_found) {
+            return Ok(None)
+        } else {
+            return Err(ActionErrorKind::DiskUtilInfoError {
+                command: command_str,
+                message: error_message,
+            })
+        }
+    } else if let Some(uuid) = parsed.volume_uuid {
+        Ok(Some(uuid))
+    } else {
+        Err(ActionErrorKind::command_output(&command, output))
+    }
 }
 
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "PascalCase")]
 struct DiskUtilApfsInfoOutput {
+    #[serde(rename = "ErrorMessage")]
+    error_message: Option<String>,
     #[serde(rename = "VolumeUUID")]
-    volume_uuid: Uuid,
+    volume_uuid: Option<Uuid>,
 }

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -39,19 +39,22 @@ async fn get_uuid_for_label(apfs_volume_label: &str) -> Result<Option<Uuid>, Act
     let command_str = format!("{:?}", command.as_std());
 
     tracing::trace!(command = command_str, "Executing");
-    let output = command.output().await.map_err(|e| ActionErrorKind::command(&command, e))?;
+    let output = command
+        .output()
+        .await
+        .map_err(|e| ActionErrorKind::command(&command, e))?;
 
     let parsed: DiskUtilApfsInfoOutput = plist::from_bytes(&output.stdout)?;
 
     if let Some(error_message) = parsed.error_message {
         let expected_not_found = format!("Could not find disk: {apfs_volume_label}");
         if error_message.contains(&expected_not_found) {
-            return Ok(None)
+            return Ok(None);
         } else {
             return Err(ActionErrorKind::DiskUtilInfoError {
                 command: command_str,
                 message: error_message,
-            })
+            });
         }
     } else if let Some(uuid) = parsed.volume_uuid {
         Ok(Some(uuid))

--- a/src/action/macos/unmount_apfs_volume.rs
+++ b/src/action/macos/unmount_apfs_volume.rs
@@ -97,15 +97,38 @@ impl Action for UnmountApfsVolume {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        execute_command(
-            Command::new("/usr/sbin/diskutil")
-                .process_group(0)
-                .args(["unmount", "force"])
-                .arg(&self.name)
-                .stdin(std::process::Stdio::null()),
-        )
-        .await
-        .map_err(Self::error)?;
+        let Self { disk: _, name } = self;
+
+        let currently_mounted = {
+            let buf = execute_command(
+                Command::new("/usr/sbin/diskutil")
+                    .process_group(0)
+                    .args(["info", "-plist"])
+                    .arg(&name)
+                    .stdin(std::process::Stdio::null()),
+            )
+            .await
+            .map_err(Self::error)?
+            .stdout;
+            let the_plist: DiskUtilInfoOutput =
+                plist::from_reader(Cursor::new(buf)).map_err(|e| Self::error(e))?;
+
+            the_plist.mount_point.is_some()
+        };
+
+        if !currently_mounted {
+            execute_command(
+                Command::new("/usr/sbin/diskutil")
+                    .process_group(0)
+                    .args(["unmount", "force"])
+                    .arg(name)
+                    .stdin(std::process::Stdio::null()),
+            )
+            .await
+            .map_err(Self::error)?;
+        } else {
+            tracing::debug!("Volume was already unmounted, can skip unmounting")
+        }
 
         Ok(())
     }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -531,7 +531,6 @@ pub enum ActionErrorKind {
         See https://github.com/DeterminateSystems/nix-installer#without-systemd-linux-only for documentation on usage and drawbacks.\
         ")]
     SystemdMissing,
-    #[cfg(target_os = "macos")]
     #[error("`{command}` failed, message: {message}")]
     DiskUtilInfoError { command: String, message: String },
 }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -531,6 +531,9 @@ pub enum ActionErrorKind {
         See https://github.com/DeterminateSystems/nix-installer#without-systemd-linux-only for documentation on usage and drawbacks.\
         ")]
     SystemdMissing,
+    #[cfg(target_os = "macos")]
+    #[error("`{command}` failed, message: {message}")]
+    DiskUtilInfoError { command: String, message: String },
 }
 
 impl ActionErrorKind {

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -58,7 +58,8 @@
             "apfs_volume_label": "Nix Store",
             "mount_service_label": "org.nixos.darwin-store",
             "mount_point": "/nix",
-            "encrypt": false
+            "encrypt": false,
+            "needs_bootout": false
           },
           "state": "Uncompleted"
         },


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/394.


##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
