### PR TITLE
Only stop the nix daemon if it's actually active, not just enabled

### DIFF
--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -236,6 +236,17 @@ let
       uninstall = installCases.install-default.uninstall;
       uninstallCheck = installCases.install-default.uninstallCheck;
     };
+    cure-self-multi-broken-daemon-stopped = {
+      preinstall = ''
+        ${nix-installer-install-quiet}
+        sudo mv /nix/receipt.json /nix/old-receipt.json
+        sudo systemctl stop nix-daemon.socket
+      '';
+      install = installCases.install-default.install;
+      check = installCases.install-default.check;
+      uninstall = installCases.install-default.uninstall;
+      uninstallCheck = installCases.install-default.uninstallCheck;
+    };
     cure-self-linux-broken-no-etc-nix = {
       preinstall = ''
         ${nix-installer-install-quiet}
@@ -284,6 +295,16 @@ let
       preinstall = ''
         ${cure-script-multi-user}
         sudo systemctl disable --now nix-daemon.socket
+      '';
+      install = installCases.install-default.install;
+      check = installCases.install-default.check;
+      uninstall = installCases.install-default.uninstall;
+      uninstallCheck = installCases.install-default.uninstallCheck;
+    };
+    cure-script-multi-broken-daemon-stopped = {
+      preinstall = ''
+        ${cure-script-multi-user}
+        sudo systemctl stop nix-daemon.socket
       '';
       install = installCases.install-default.install;
       check = installCases.install-default.check;

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -251,7 +251,7 @@ impl Action for ConfigureInitService {
                         .await
                         .map_err(Self::error)?;
                 }
-                let socket_was_active = 
+                let socket_was_active =
                     if is_active("nix-daemon.socket").await.map_err(Self::error)? {
                         stop("nix-daemon.socket").await.map_err(Self::error)?;
                         true

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -246,13 +246,13 @@ impl Action for ConfigureInitService {
                     .map_err(Self::error)?;
                 }
                 // The goal state is the `socket` enabled and active, the service not enabled and stopped (it activates via socket activation)
-                let socket_was_active =
-                    if is_enabled("nix-daemon.socket").await.map_err(Self::error)? {
-                        disable("nix-daemon.socket", true)
-                            .await
-                            .map_err(Self::error)?;
-                        true
-                    } else if is_active("nix-daemon.socket").await.map_err(Self::error)? {
+                if is_enabled("nix-daemon.socket").await.map_err(Self::error)? {
+                    disable("nix-daemon.socket", false)
+                        .await
+                        .map_err(Self::error)?;
+                }
+                let socket_was_active = 
+                    if is_active("nix-daemon.socket").await.map_err(Self::error)? {
                         stop("nix-daemon.socket").await.map_err(Self::error)?;
                         true
                     } else {


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/402

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
