### PR TITLE
Check user group commands exist during plan

### DIFF
--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -132,7 +132,7 @@ impl AddUserToGroup {
                         tracing::debug!(
                             "Adding user `{}` to group `{}` already complete",
                             this.name,
-                            this.group
+                            this.groupname
                         );
                         return Ok(StatefulAction::completed(this));
                     }

--- a/src/action/base/add_user_to_group.rs
+++ b/src/action/base/add_user_to_group.rs
@@ -35,6 +35,16 @@ impl AddUserToGroup {
             groupname,
             gid,
         };
+
+        if !(which::which("addgroup").is_ok() || which::which("gpasswd").is_ok()) {
+            return Err(Self::error(ActionErrorKind::MissingAddUserToGroupCommand));
+        }
+        if !(which::which("delgroup").is_ok() || which::which("gpasswd").is_ok()) {
+            return Err(Self::error(
+                ActionErrorKind::MissingRemoveUserFromGroupCommand,
+            ));
+        }
+
         // Ensure user does not exists
         if let Some(user) = User::from_name(name.as_str())
             .map_err(|e| ActionErrorKind::GettingUserId(name.clone(), e))
@@ -119,7 +129,11 @@ impl AddUserToGroup {
                     let user_in_group = output_str.split(" ").any(|v| v == &this.groupname);
 
                     if user_in_group {
-                        tracing::debug!("Creating user `{}` already complete", this.name);
+                        tracing::debug!(
+                            "Adding user `{}` to group `{}` already complete",
+                            this.name,
+                            this.group
+                        );
                         return Ok(StatefulAction::completed(this));
                     }
                 },

--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -23,6 +23,14 @@ impl CreateGroup {
             name: name.clone(),
             gid,
         };
+
+        if !(which::which("groupadd").is_ok() || which::which("addgroup").is_ok()) {
+            return Err(Self::error(ActionErrorKind::MissingGroupCreationCommand));
+        }
+        if !(which::which("groupdel").is_ok() || which::which("delgroup").is_ok()) {
+            return Err(Self::error(ActionErrorKind::MissingGroupDeletionCommand));
+        }
+
         // Ensure group does not exists
         if let Some(group) = Group::from_name(name.as_str())
             .map_err(|e| ActionErrorKind::GettingGroupId(name.clone(), e))

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -35,6 +35,14 @@ impl CreateUser {
             gid,
             comment,
         };
+
+        if !(which::which("useradd").is_ok() || which::which("adduser").is_ok()) {
+            return Err(Self::error(ActionErrorKind::MissingUserCreationCommand));
+        }
+        if !(which::which("userdel").is_ok() || which::which("deluser").is_ok()) {
+            return Err(Self::error(ActionErrorKind::MissingUserDeletionCommand));
+        }
+
         // Ensure user does not exists
         if let Some(user) = User::from_name(name.as_str())
             .map_err(|e| ActionErrorKind::GettingUserId(name.clone(), e))


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/399.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
