### PR TITLE
Provide users a better error message if systemd is not active

### DIFF
--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -88,7 +88,6 @@ impl CommandExecute for Install {
             false => format!("curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/tag/v{} | sh -s -- uninstall", env!("CARGO_PKG_VERSION")),
         };
 
-
         let mut install_plan = match (planner, plan) {
             (Some(planner), None) => {
                 let chosen_planner: Box<dyn Planner> = planner.clone().boxed();

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -176,7 +176,7 @@ async fn check_nix_not_already_installed() -> Result<(), PlannerError> {
 }
 
 fn check_systemd_active() -> Result<(), PlannerError> {
-    if Path::new("/run/systemd/system").exists() {
+    if !Path::new("/run/systemd/system").exists() {
         if std::env::var("WSL_DISTRO_NAME").is_ok() {
             return Err(LinuxErrorKind::Wsl2SystemdNotActive)?;
         } else {
@@ -202,7 +202,7 @@ pub enum LinuxErrorKind {
     #[error(
         "\
         systemd was not active.\n\
-        \n
+        \n\
         On WSL2, systemd is not enabled by default. Consider enabling it by adding it to your `/etc/wsl.conf` with `echo -e '[boot]\\nsystemd=true'` then restarting WSL2 with `wsl.exe --shutdown` and re-entering the WSL shell. For more information, see https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/.\n\
         \n\
         If it will be started later consider, passing `--no-start-daemon`.\n\

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -367,7 +367,12 @@ pub enum PlannerError {
     #[error("Detected that this process is running under Rosetta, using Nix in Rosetta is not supported (Please open an issue with your use case)")]
     RosettaDetected,
     /// A Linux SELinux related error
-    #[error("This installer doesn't yet support SELinux in `Enforcing` mode. If SELinux is important to you, please see https://github.com/DeterminateSystems/nix-installer/issues/124. You can also try again after setting SELinux to `Permissive` mode with `setenforce Permissive`")]
+    #[error("\
+        This installer doesn't yet support SELinux in `Enforcing` mode.\n
+        \n\
+        If desirable, consider setting SELinux to `Permissive` mode with `setenforce Permissive`.\n\
+        \n\
+        If SELinux is important to you, please see https://github.com/DeterminateSystems/nix-installer/issues/124.")]
     SelinuxEnforcing,
     /// A UTF-8 related error
     #[error("UTF-8 error")]
@@ -397,7 +402,13 @@ impl HasExpectedErrors for PlannerError {
             this @ PlannerError::RosettaDetected => Some(Box::new(this)),
             PlannerError::Utf8(_) => None,
             PlannerError::SelinuxEnforcing => Some(Box::new(self)),
-            PlannerError::Custom(_) => None,
+            PlannerError::Custom(e) => {
+                if let Some(err) = e.downcast_ref::<linux::LinuxErrorKind>() {
+                    err.expected()
+                } else {
+                    None
+                }
+            },
             this @ PlannerError::NixOs => Some(Box::new(this)),
             this @ PlannerError::NixExists => Some(Box::new(this)),
             this @ PlannerError::Wsl1 => Some(Box::new(this)),

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -403,11 +403,11 @@ impl HasExpectedErrors for PlannerError {
             PlannerError::Utf8(_) => None,
             PlannerError::SelinuxEnforcing => Some(Box::new(self)),
             PlannerError::Custom(e) => {
+                #[cfg(target_os = "linux")]
                 if let Some(err) = e.downcast_ref::<linux::LinuxErrorKind>() {
                     err.expected()
-                } else {
-                    None
                 }
+                None
             },
             this @ PlannerError::NixOs => Some(Box::new(this)),
             this @ PlannerError::NixExists => Some(Box::new(this)),

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -405,7 +405,7 @@ impl HasExpectedErrors for PlannerError {
             PlannerError::Custom(e) => {
                 #[cfg(target_os = "linux")]
                 if let Some(err) = e.downcast_ref::<linux::LinuxErrorKind>() {
-                    err.expected()
+                    return err.expected();
                 }
                 None
             },

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -24,7 +24,7 @@ pub const NIX_X64_64_DARWIN_URL: &str =
 pub const NIX_AARCH64_DARWIN_URL: &str =
     "https://releases.nixos.org/nix/nix-2.13.3/nix-2.13.3-aarch64-darwin.tar.xz";
 
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum InitSystem {
     #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/392:

The error:

```
systemd was not active.

On WSL2, systemd is not enabled by default. Consider enabling it by adding it to your `/etc/wsl.conf` with `echo -e '[boot]\nsystemd=true'` then restarting WSL2 with `wsl.exe --shutdown` and re-entering the WSL shell. For more information, see https://devblogs.microsoft.com/commandline/systemd-support-is-now-available-in-wsl/.

If it will be started later consider, passing `--no-start-daemon`.

To use a `root`-only Nix install, consider passing `--init none`.
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
