### PR TITLE
Avoid globbing issues by using symlinks and readlink

### DIFF
--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -102,6 +102,14 @@ impl Action for MoveUnpackedNix {
                         ActionErrorKind::Rename(entry.path().clone(), entry_dest.to_owned(), e)
                     })
                     .map_err(Self::error)?;
+                // Leave a back link where we copied from since later we may need to know which packages we actually transferred
+                // eg, know which `nix` version we installed when curing a user with several versions installed
+                tokio::fs::symlink(&entry_dest, entry.path())
+                    .await
+                    .map_err(|e| {
+                        ActionErrorKind::Symlink(entry_dest.to_owned(), entry.path().clone(), e)
+                    })
+                    .map_err(Self::error)?;
             }
         }
 


### PR DESCRIPTION
##### Description

Attempts to address https://github.com/DeterminateSystems/nix-installer/issues/401

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
