### PR TITLE
Fixup a cure case where a store path already exists so we never make a symlink

### DIFF
--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -73,7 +73,7 @@ impl Action for SetupDefaultProfile {
         let nix_pkg = if let Some(nix_pkg) = found_nix_pkg {
             tokio::fs::read_link(&nix_pkg)
                 .await
-                .map_err(|e| ActionErrorKind::Canonicalize(nix_pkg, e))
+                .map_err(|e| ActionErrorKind::ReadSymlink(nix_pkg, e))
                 .map_err(Self::error)?
         } else {
             return Err(Self::error(SetupDefaultProfileError::NoNix));
@@ -106,7 +106,7 @@ impl Action for SetupDefaultProfile {
         let nss_ca_cert_pkg = if let Some(nss_ca_cert_pkg) = found_nss_ca_cert_pkg {
             tokio::fs::read_link(&nss_ca_cert_pkg)
                 .await
-                .map_err(|e| ActionErrorKind::Canonicalize(nss_ca_cert_pkg, e))
+                .map_err(|e| ActionErrorKind::ReadSymlink(nss_ca_cert_pkg, e))
                 .map_err(Self::error)?
         } else {
             return Err(Self::error(SetupDefaultProfileError::NoNssCacert));


### PR DESCRIPTION

##### Description

Found this while going over the prerelease checklist.
##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
