### PR TITLE
fsync after writing Nix config to attempt to fix the flaky preserves_comment test

### DIFF
--- a/src/action/base/create_or_merge_nix_config.rs
+++ b/src/action/base/create_or_merge_nix_config.rs
@@ -434,6 +434,10 @@ impl Action for CreateOrMergeNixConfig {
                     e,
                 ))
             })?;
+        temp_file
+            .sync_all()
+            .await
+            .map_err(|e| Self::error(ActionErrorKind::Sync(temp_file_path.clone(), e)))?;
         tokio::fs::rename(&temp_file_path, &path)
             .await
             .map_err(|e| {

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -443,6 +443,8 @@ pub enum ActionErrorKind {
     Open(std::path::PathBuf, #[source] std::io::Error),
     #[error("Write path `{0}`")]
     Write(std::path::PathBuf, #[source] std::io::Error),
+    #[error("Sync path `{0}`")]
+    Sync(std::path::PathBuf, #[source] std::io::Error),
     #[error("Seek path `{0}`")]
     Seek(std::path::PathBuf, #[source] std::io::Error),
     #[error("Flushing `{0}`")]

--- a/src/cli/arg/instrumentation.rs
+++ b/src/cli/arg/instrumentation.rs
@@ -27,7 +27,7 @@ impl std::fmt::Display for Logger {
     }
 }
 
-#[derive(clap::Args, Debug)]
+#[derive(clap::Args, Debug, Default)]
 pub struct Instrumentation {
     /// Enable debug logs, -vv for trace
     #[clap(short = 'v', env = "NIX_INSTALLER_VERBOSITY", long, action = clap::ArgAction::Count, global = true)]


### PR DESCRIPTION

##### Description

![image](https://user-images.githubusercontent.com/130903/236299601-b308e82e-5482-4610-8fa3-a6a50cc9a226.png)

We noted on some runs (https://buildkite.com/determinate-systems-inc/nix-installer/builds/1205#0187e397-9d93-4e46-8faf-690b98dd3981) that the preserves_comment test would fail.

I was unable to reproduce locally after adding this line to the `preserves_comments` test

```rust
crate::cli::arg::Instrumentation::default().setup()?;
```

Then running with

```bash
while RUST_LOG="nix_installer=trace" cargo test --lib -- preserves_comments --nocapture; do :; done
```

This PR attempts to mitigate the possibly issue we considered of fsyncing. The CI machine and my dev machine having considerably different disk configurations so it's reasonable one might fail while the other doesn't if it's fsync related.


##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
