### PR TITLE
Set permissions on unpacked Nix store paths more carefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "typetag",
  "url",
  "uuid",
+ "walkdir",
  "which",
  "xz2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ strum = { version = "0.24.1", features = ["derive"] }
 nix-config-parser = { version = "0.1.2", features = ["serde"] }
 which = "4.4.0"
 sysctl = "0.5.4"
+walkdir = "2.3.3"
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -143,6 +143,9 @@ impl Action for FetchAndUnpackNix {
 
         let decoder = xz2::read::XzDecoder::new(bytes.reader());
         let mut archive = tar::Archive::new(decoder);
+        archive.set_preserve_permissions(true);
+        archive.set_preserve_mtime(true);
+        archive.set_unpack_xattrs(true);
         archive
             .unpack(&dest_clone)
             .map_err(FetchUrlError::Unarchive)

--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -1,6 +1,11 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs::Permissions,
+    os::unix::prelude::PermissionsExt,
+    path::{Path, PathBuf},
+};
 
 use tracing::{span, Span};
+use walkdir::WalkDir;
 
 use crate::action::{
     Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
@@ -106,6 +111,21 @@ impl Action for MoveUnpackedNix {
                     ActionErrorKind::Rename(entry.path().clone(), entry_dest.to_owned(), e)
                 })
                 .map_err(Self::error)?;
+
+            let perms: Permissions = PermissionsExt::from_mode(0o555);
+            for entry_item in WalkDir::new(&entry_dest).into_iter().filter_map(Result::ok) {
+                tokio::fs::set_permissions(&entry_item.path(), perms.clone())
+                    .await
+                    .map_err(|e| {
+                        ActionErrorKind::SetPermissions(
+                            perms.mode(),
+                            entry_item.path().to_owned(),
+                            e,
+                        )
+                    })
+                    .map_err(Self::error)?;
+            }
+
             // Leave a back link where we copied from since later we may need to know which packages we actually transferred
             // eg, know which `nix` version we installed when curing a user with several versions installed
             tokio::fs::symlink(&entry_dest, entry.path())

--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -113,7 +113,11 @@ impl Action for MoveUnpackedNix {
                 .map_err(Self::error)?;
 
             let perms: Permissions = PermissionsExt::from_mode(0o555);
-            for entry_item in WalkDir::new(&entry_dest).into_iter().filter_map(Result::ok) {
+            for entry_item in WalkDir::new(&entry_dest)
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|e| !e.file_type().is_symlink())
+            {
                 tokio::fs::set_permissions(&entry_item.path(), perms.clone())
                     .await
                     .map_err(|e| {

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -415,7 +415,7 @@ pub enum ActionErrorKind {
         std::path::PathBuf,
         #[source] std::io::Error,
     ),
-    #[error("Set mode `{0}` on `{1}`")]
+    #[error("Set mode `{0:#o}` on `{1}`")]
     SetPermissions(u32, std::path::PathBuf, #[source] std::io::Error),
     #[error("Remove file `{0}`")]
     Remove(std::path::PathBuf, #[source] std::io::Error),


### PR DESCRIPTION
##### Description

In https://github.com/DeterminateSystems/nix-installer/issues/449#issuecomment-1535594272 @evanrichter noticed we weren't properly ensuring all the store paths we unpacked were not writable.

This PR makes us both respect the permissions from the archive for non-store destined paths, as well as forcibly makes any store paths `555` (and thus not writable).

After this PR, running `nix store optimise` offers no errors about writable files.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
