### PR TITLE
Don't error if already installed with same settings, just warn

### DIFF
--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -142,8 +142,8 @@ impl CommandExecute for Install {
                             return Ok(ExitCode::FAILURE)
                         }
                         if existing_receipt.actions.iter().all(|v| v.state == ActionState::Completed) {
-                            eprintln!("{}", format!("Found existing plan in `{RECEIPT_LOCATION}`, with the same settings, already completed, try uninstalling (`{uninstall_command}`) and reinstalling if Nix isn't working").red());
-                            return Ok(ExitCode::FAILURE)
+                            eprintln!("{}", format!("Found existing plan in `{RECEIPT_LOCATION}`, with the same settings, already completed, try uninstalling (`{uninstall_command}`) and reinstalling if Nix isn't working").yellow());
+                            return Ok(ExitCode::SUCCESS)
                         }
                         existing_receipt
                     },


### PR DESCRIPTION
##### Description

Requested in https://github.com/DeterminateSystems/nix-installer/issues/453

![image](https://user-images.githubusercontent.com/130903/236910006-47404ec3-d203-4037-be33-a65a44c006c4.png)

We simply don't need to error if it looks like a working install with all actions complete. If the user has a broken install, they probably already know and we're not informing them of some revelation. Simply warning them should be sufficient.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
