### PR TITLE
RequiredBy items in the nix.mount of steam-deck planner in [Install]

### DIFF
--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -154,8 +154,6 @@ impl Planner for SteamDeck {
             Requires=nix-directory.service\n\
             ConditionPathIsDirectory=/nix\n\
             DefaultDependencies=no\n\
-            RequiredBy=nix-daemon.service\n\
-            RequiredBy=nix-daemon.socket\n\
             \n\
             [Mount]\n\
             What={persistence}\n\
@@ -163,6 +161,10 @@ impl Planner for SteamDeck {
             Type=none\n\
             DirectoryMode=0755\n\
             Options=bind\n\
+            \n\
+            [Install]\n\
+            RequiredBy=nix-daemon.service\n\
+            RequiredBy=nix-daemon.socket\n
         ",
             persistence = persistence.display(),
         );


### PR DESCRIPTION


##### Description

Thanks to @chewblacka https://github.com/DeterminateSystems/nix-installer/issues/416#issuecomment-1518699380

![image](https://user-images.githubusercontent.com/130903/236916643-621e799b-bfc0-45ba-a1f4-c4fdade3afe2.png)


##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
