### PR TITLE
Respect RFC-0097

### DIFF
--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -88,6 +88,13 @@ impl Action for MoveUnpackedNix {
                 .await
                 .map_err(|e| ActionErrorKind::CreateDirectory(dest_store.clone(), e))
                 .map_err(Self::error)?;
+            let perms: Permissions = PermissionsExt::from_mode(0o735);
+            tokio::fs::set_permissions(&dest_store, perms.clone())
+                .await
+                .map_err(|e| {
+                    ActionErrorKind::SetPermissions(perms.mode(), dest_store.to_owned(), e)
+                })
+                .map_err(Self::error)?;
         }
 
         while let Some(entry) = src_store_listing

--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -88,14 +88,13 @@ impl Action for MoveUnpackedNix {
                 .await
                 .map_err(|e| ActionErrorKind::CreateDirectory(dest_store.clone(), e))
                 .map_err(Self::error)?;
-            let perms: Permissions = PermissionsExt::from_mode(0o735);
-            tokio::fs::set_permissions(&dest_store, perms.clone())
-                .await
-                .map_err(|e| {
-                    ActionErrorKind::SetPermissions(perms.mode(), dest_store.to_owned(), e)
-                })
-                .map_err(Self::error)?;
         }
+        let perms: Permissions = PermissionsExt::from_mode(0o735);
+        tracing::warn!(?perms, ?dest_store, "Setting permissions");
+        tokio::fs::set_permissions(&dest_store, perms.clone())
+            .await
+            .map_err(|e| ActionErrorKind::SetPermissions(perms.mode(), dest_store.to_owned(), e))
+            .map_err(Self::error)?;
 
         while let Some(entry) = src_store_listing
             .next_entry()

--- a/src/action/base/move_unpacked_nix.rs
+++ b/src/action/base/move_unpacked_nix.rs
@@ -90,7 +90,6 @@ impl Action for MoveUnpackedNix {
                 .map_err(Self::error)?;
         }
         let perms: Permissions = PermissionsExt::from_mode(0o735);
-        tracing::warn!(?perms, ?dest_store, "Setting permissions");
         tokio::fs::set_permissions(&dest_store, perms.clone())
             .await
             .map_err(|e| ActionErrorKind::SetPermissions(perms.mode(), dest_store.to_owned(), e))


### PR DESCRIPTION
##### Description

Sets the default `/nix/store` permissions to 735 as per https://github.com/NixOS/rfcs/blob/master/rfcs/0097-no-read-store-dir.md.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
