### PR TITLE
Improve WSL systemd detection

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -93,8 +93,11 @@ impl ConfigureInitService {
             InitSystem::Systemd => {
                 // If /run/systemd/system exists, we can be reasonably sure the machine is booted
                 // with systemd: https://www.freedesktop.org/software/systemd/man/sd_booted.html
-                if !(Path::new("/run/systemd/system").exists() && which::which("systemctl").is_ok())
-                {
+                if !Path::new("/run/systemd/system").exists() {
+                    return Err(Self::error(ActionErrorKind::SystemdMissing));
+                }
+
+                if which::which("systemctl").is_err() {
                     return Err(Self::error(ActionErrorKind::SystemdMissing));
                 }
 

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -93,7 +93,8 @@ impl ConfigureInitService {
             InitSystem::Systemd => {
                 // If /run/systemd/system exists, we can be reasonably sure the machine is booted
                 // with systemd: https://www.freedesktop.org/software/systemd/man/sd_booted.html
-                if !Path::new("/run/systemd/system").exists() {
+                if !(Path::new("/run/systemd/system").exists() && which::which("systemctl").is_ok())
+                {
                     return Err(Self::error(ActionErrorKind::SystemdMissing));
                 }
 

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -93,8 +93,7 @@ impl ConfigureInitService {
             InitSystem::Systemd => {
                 // If /run/systemd/system exists, we can be reasonably sure the machine is booted
                 // with systemd: https://www.freedesktop.org/software/systemd/man/sd_booted.html
-                if !(Path::new("/run/systemd/system").exists() || which::which("systemctl").is_ok())
-                {
+                if !Path::new("/run/systemd/system").exists() {
                     return Err(Self::error(ActionErrorKind::SystemdMissing));
                 }
 

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -568,6 +568,7 @@ impl HasExpectedErrors for ActionErrorKind {
             Self::PathUserMismatch(_, _, _)
             | Self::PathGroupMismatch(_, _, _)
             | Self::PathModeMismatch(_, _, _) => Some(Box::new(self)),
+            | Self::SystemdMissing => Some(Box::new(self)),
             _ => None,
         }
     }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -568,7 +568,7 @@ impl HasExpectedErrors for ActionErrorKind {
             Self::PathUserMismatch(_, _, _)
             | Self::PathGroupMismatch(_, _, _)
             | Self::PathModeMismatch(_, _, _) => Some(Box::new(self)),
-            | Self::SystemdMissing => Some(Box::new(self)),
+            Self::SystemdMissing => Some(Box::new(self)),
             _ => None,
         }
     }


### PR DESCRIPTION
##### Description
Fixes https://github.com/DeterminateSystems/nix-installer/issues/462

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
