### PR TITLE
Improve the SELinux heuristic to look for sestatus

### DIFF
--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -165,7 +165,7 @@ fn check_not_wsl1() -> Result<(), PlannerError> {
 }
 
 async fn detect_selinux() -> Result<bool, PlannerError> {
-    if Path::new("/sys/fs/selinux").exists() {
+    if Path::new("/sys/fs/selinux").exists() && which("sestatus").is_ok() {
         // We expect systems with SELinux to have the normal SELinux tools.
         let has_semodule = which("semodule").is_ok();
         let has_restorecon = which("restorecon").is_ok();


### PR DESCRIPTION
##### Description

On some containers (and @cole-h 's machine) our SELinux heuristics were firing in a place where SELinux wasn't existing.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
