### PR TITLE
ci: release-prs: fixup tagging behavior

### DIFF
--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -12,7 +12,11 @@ jobs:
   release:
     concurrency: release
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
-    if: github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-installer' && contains(github.event.pull_request.labels.*.name, 'upload to s3')
+    # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
+    if: |
+        github.event.pull_request.head.repo.full_name == 'DeterminateSystems/nix-installer'
+        && (github.event.action == 'labeled' && github.event.label.name == 'upload to s3')
+        || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'upload to s3')
     runs-on: ubuntu-latest
     permissions:
       id-token: write # In order to request a JWT for AWS auth


### PR DESCRIPTION
We don't want to trigger a reupload when any labels change; only when we add the upload label or when the PR is reopened / pushed to.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```

---

Drafted while I test that it works.