### PR TITLE
Improve container docs somewhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ podman rm -f $CONTAINER
 podman rmi $IMAGE
 ```
 
-On some container tools, such as `docker`, `sandbox = false` can be omitted. This will negatively impact compatability with container tools like `podman`.
+On some container tools, such as `docker`, `sandbox = false` can be omitted. This will negatively impact compatibility with container tools like `podman`.
 
 ## In WSL2
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 
 In Docker/Podman containers or WSL2 instances where an init (like `systemd`) is not present, pass `--init none`.
 
+For containers (without an init):
+
 > **Warning**
 > When `--init none` is used, _only_ `root` or users who can elevate to `root` privileges can run Nix:
 >
@@ -182,47 +184,55 @@ In Docker/Podman containers or WSL2 instances where an init (like `systemd`) is 
 > sudo -i nix run nixpkgs#hello
 > ```
 
-For Docker containers (without an init):
-
 ```dockerfile
 # Dockerfile
 FROM ubuntu:latest
 RUN apt update -y
 RUN apt install curl -y
-COPY nix-installer /nix-installer
-RUN /nix-installer install linux --init none --no-confirm
+RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
+  --extra-conf "sandbox = false" \
+  --init none \
+  --no-confirm
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 RUN nix run nixpkgs#hello
 ```
 
-Podman containers require `sandbox = false` in your `Nix.conf`.
-
-For podman containers without an init:
-
-```dockerfile
-# Dockerfile
-FROM ubuntu:latest
-RUN apt update -y
-RUN apt install curl -y
-COPY nix-installer /nix-installer
-RUN /nix-installer install linux --extra-conf "sandbox = false" --init none --no-confirm
-ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
-RUN nix run nixpkgs#hello
+```bash
+docker build -t ubuntu-with-nix .
+docker run --rm -ti ubuntu-with-nix
+docker rmi ubuntu-with-nix
+# or
+podman build -t ubuntu-with-nix .
+podman run --rm -ti ubuntu-with-nix
+podman rmi ubuntu-with-nix
 ```
 
-For Podman containers with a systemd init:
+For containers with a systemd init:
 
 ```dockerfile
 # Dockerfile
 FROM ubuntu:latest
 RUN apt update -y
 RUN apt install curl systemd -y
-COPY nix-installer /nix-installer
-RUN /nix-installer install linux --extra-conf "sandbox = false" --no-start-daemon --no-confirm
+RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install linux \
+  --extra-conf "sandbox = false" \
+  --no-start-daemon \
+  --no-confirm
 ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
 RUN nix run nixpkgs#hello
-CMD [ "/usr/sbin/init" ]
+CMD [ "/bin/systemd" ]
 ```
+
+```bash
+podman build -t ubuntu-systemd-with-nix .
+IMAGE=$(podman create ubuntu-systemd-with-nix)
+CONTAINER=$(podman start $IMAGE)
+podman exec -ti $CONTAINER /bin/bash
+podman rm -f $CONTAINER
+podman rmi $IMAGE
+```
+
+On some container tools, such as `docker`, `sandbox = false` can be omitted. This will negatively impact compatability with container tools like `podman`.
 
 ## In WSL2
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ podman rm -f $CONTAINER
 podman rmi $IMAGE
 ```
 
-On some container tools, such as `docker`, `sandbox = false` can be omitted. This will negatively impact compatibility with container tools like `podman`.
+On some container tools, such as `docker`, `sandbox = false` can be omitted. Omitting it will negatively impact compatibility with container tools like `podman`.
 
 ## In WSL2
 

--- a/flake.nix
+++ b/flake.nix
@@ -148,7 +148,11 @@
               check.check-editorconfig
               check.check-semver
             ]
-            ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [ libiconv ]);
+            ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [ libiconv ])
+            ++ lib.optionals (pkgs.stdenv.isLinux) (with pkgs; [
+              podman
+              /* users are expected to have a system docker, too */
+            ]);
           };
         });
 


### PR DESCRIPTION
##### Description

Our container docs weren't very helpful and were quite confusing. This should improve the state of things somewhat.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
