### PR TITLE
Add time machine exclusions for Mac

### DIFF
--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -103,27 +103,6 @@ impl CreateNixVolume {
                 .map_err(Self::error)?;
         let enable_ownership = EnableOwnership::plan("/nix").await.map_err(Self::error)?;
 
-        /* Testing with `sudo tmutil addexclusion -p /nix` and  `sudo tmutil addexclusion -v "Nix Store"` on DetSys's Macs
-           yielded this error:
-
-           ```
-            tmutil: addexclusion requires Full Disk Access privileges.
-            To allow this operation, select Full Disk Access in the Privacy
-            tab of the Security & Privacy preference pane, and add Terminal
-            to the list of applications which are allowed Full Disk Access.
-            ```
-
-            So we do these subdirectories instead.
-        */
-        let set_tmutil_exclusions = vec![
-            SetTmutilExclusion::plan("/nix/store")
-                .await
-                .map_err(Self::error)?,
-            SetTmutilExclusion::plan("/nix/var")
-                .await
-                .map_err(Self::error)?,
-        ];
-
         Ok(Self {
             disk: disk.to_path_buf(),
             name,

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -13,10 +13,7 @@ use std::{
 use tokio::process::Command;
 use tracing::{span, Span};
 
-use super::{
-    create_fstab_entry::CreateFstabEntry, CreateVolumeService, KickstartLaunchctlService,
-    SetTmutilExclusion,
-};
+use super::{create_fstab_entry::CreateFstabEntry, CreateVolumeService, KickstartLaunchctlService};
 
 pub const NIX_VOLUME_MOUNTD_DEST: &str = "/Library/LaunchDaemons/org.nixos.darwin-store.plist";
 

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -103,6 +103,18 @@ impl CreateNixVolume {
                 .map_err(Self::error)?;
         let enable_ownership = EnableOwnership::plan("/nix").await.map_err(Self::error)?;
 
+        /* Testing with `sudo tmutil addexclusion -p /nix` and  `sudo tmutil addexclusion -v "Nix Store"` on DetSys's Macs
+           yielded this error:
+
+           ```
+            tmutil: addexclusion requires Full Disk Access privileges.
+            To allow this operation, select Full Disk Access in the Privacy
+            tab of the Security & Privacy preference pane, and add Terminal
+            to the list of applications which are allowed Full Disk Access.
+            ```
+
+            So we do these subdirectories instead.
+        */
         let set_tmutil_exclusions = vec![
             SetTmutilExclusion::plan("/nix/store")
                 .await

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod enable_ownership;
 pub(crate) mod encrypt_apfs_volume;
 pub(crate) mod kickstart_launchctl_service;
 pub(crate) mod set_tmutil_exclusion;
+pub(crate) mod set_tmutil_exclusions;
 pub(crate) mod unmount_apfs_volume;
 
 pub use bootstrap_launchctl_service::BootstrapLaunchctlService;
@@ -23,6 +24,7 @@ pub use encrypt_apfs_volume::EncryptApfsVolume;
 pub use kickstart_launchctl_service::KickstartLaunchctlService;
 use serde::Deserialize;
 pub use set_tmutil_exclusion::SetTmutilExclusion;
+pub use set_tmutil_exclusions::SetTmutilExclusions;
 use tokio::process::Command;
 pub use unmount_apfs_volume::UnmountApfsVolume;
 use uuid::Uuid;

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod create_volume_service;
 pub(crate) mod enable_ownership;
 pub(crate) mod encrypt_apfs_volume;
 pub(crate) mod kickstart_launchctl_service;
+pub(crate) mod set_tmutil_exclusion;
 pub(crate) mod unmount_apfs_volume;
 
 pub use bootstrap_launchctl_service::BootstrapLaunchctlService;
@@ -21,6 +22,7 @@ pub use enable_ownership::{EnableOwnership, EnableOwnershipError};
 pub use encrypt_apfs_volume::EncryptApfsVolume;
 pub use kickstart_launchctl_service::KickstartLaunchctlService;
 use serde::Deserialize;
+pub use set_tmutil_exclusion::SetTmutilExclusion;
 use tokio::process::Command;
 pub use unmount_apfs_volume::UnmountApfsVolume;
 use uuid::Uuid;

--- a/src/action/macos/set_tmutil_exclusion.rs
+++ b/src/action/macos/set_tmutil_exclusion.rs
@@ -1,14 +1,12 @@
-use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
 use tracing::{span, Span};
 
-use crate::action::{ActionError, ActionErrorKind, ActionTag, StatefulAction};
+use crate::action::{ActionError, ActionTag, StatefulAction};
 use crate::execute_command;
 
 use crate::action::{Action, ActionDescription};
-use crate::os::darwin::DiskUtilInfoOutput;
 
 /**
 Set a time machine exclusion on a path.

--- a/src/action/macos/set_tmutil_exclusion.rs
+++ b/src/action/macos/set_tmutil_exclusion.rs
@@ -1,0 +1,102 @@
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+
+use tokio::process::Command;
+use tracing::{span, Span};
+
+use crate::action::{ActionError, ActionErrorKind, ActionTag, StatefulAction};
+use crate::execute_command;
+
+use crate::action::{Action, ActionDescription};
+use crate::os::darwin::DiskUtilInfoOutput;
+
+/**
+Set a time machine exclusion on a path.
+
+Note, this cannot be used on Volumes easily:
+
+```bash,no_run
+% sudo tmutil addexclusion -v "Nix Store"
+tmutil: addexclusion requires Full Disk Access privileges.
+To allow this operation, select Full Disk Access in the Privacy
+tab of the Security & Privacy preference pane, and add Terminal
+to the list of applications which are allowed Full Disk Access.
+% sudo tmutil addexclusion /nix
+/nix: The operation couldn’t be completed. Invalid argument
+```
+
+ */
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct SetTmutilExclusion {
+    path: PathBuf,
+}
+
+impl SetTmutilExclusion {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn plan(path: impl AsRef<Path>) -> Result<StatefulAction<Self>, ActionError> {
+        Ok(Self {
+            path: path.as_ref().to_path_buf(),
+        }
+        .into())
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "set_tmutil_exclusion")]
+impl Action for SetTmutilExclusion {
+    fn action_tag() -> ActionTag {
+        ActionTag("set_tmutil_exclusion")
+    }
+    fn tracing_synopsis(&self) -> String {
+        format!(
+            "Configure Time Machine exclusion on `{}`",
+            self.path.display()
+        )
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "set_tmutil_exclusion",
+            path = %self.path.display(),
+        )
+    }
+
+    fn execute_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn execute(&mut self) -> Result<(), ActionError> {
+        execute_command(
+            Command::new("tmutil")
+                .process_group(0)
+                .arg("addexclusion")
+                .arg(&self.path)
+                .stdin(std::process::Stdio::null()),
+        )
+        .await
+        .map_err(Self::error)?;
+
+        Ok(())
+    }
+
+    fn revert_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn revert(&mut self) -> Result<(), ActionError> {
+        execute_command(
+            Command::new("tmutil")
+                .process_group(0)
+                .arg("removeexclusion")
+                .arg(&self.path)
+                .stdin(std::process::Stdio::null()),
+        )
+        .await
+        .map_err(Self::error)?;
+
+        Ok(())
+    }
+}

--- a/src/action/macos/set_tmutil_exclusions.rs
+++ b/src/action/macos/set_tmutil_exclusions.rs
@@ -1,0 +1,137 @@
+use tracing::{span, Span};
+
+use crate::action::base::CreateDirectory;
+use crate::action::{
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
+
+/**
+Set a time machine exclusion on several paths.
+
+Note, this cannot be used on Volumes easily:
+
+```bash,no_run
+% sudo tmutil addexclusion -v "Nix Store"
+tmutil: addexclusion requires Full Disk Access privileges.
+To allow this operation, select Full Disk Access in the Privacy
+tab of the Security & Privacy preference pane, and add Terminal
+to the list of applications which are allowed Full Disk Access.
+% sudo tmutil addexclusion /nix
+/nix: The operation couldn’t be completed. Invalid argument
+```
+
+ */
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct SetTmutilExclusions {
+    set_tmutil_exclusions: Vec<StatefulAction<SetTmutilExclusion>>,
+}
+
+impl SetTmutilExclusions {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn plan(paths: Vec<PathBuf>) -> Result<StatefulAction<Self>, ActionError> {
+        /* Testing with `sudo tmutil addexclusion -p /nix` and  `sudo tmutil addexclusion -v "Nix Store"` on DetSys's Macs
+           yielded this error:
+
+           ```
+            tmutil: addexclusion requires Full Disk Access privileges.
+            To allow this operation, select Full Disk Access in the Privacy
+            tab of the Security & Privacy preference pane, and add Terminal
+            to the list of applications which are allowed Full Disk Access.
+            ```
+
+            So we do these subdirectories instead.
+        */
+        let set_tmutil_exclusions = Vec::new();
+        for path in paths {
+            set_tmutil_exclusion = SetTmutilExclusion::plan(path).await.map_err(Self::error)?;
+            set_tmutil_exclusions.push(set_tmutil_exclusion);
+        }
+
+        Ok(Self {
+            set_tmutil_exclusions,
+        }
+        .into())
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "set_tmutil_exclusions")]
+impl Action for SetTmutilExclusions {
+    fn action_tag() -> ActionTag {
+        ActionTag("set_tmutil_exclusions")
+    }
+    fn tracing_synopsis(&self) -> String {
+        String::from("Configure Time Machine exclusions")
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "set_tmutil_exclusions",)
+    }
+
+    fn execute_description(&self) -> Vec<ActionDescription> {
+        let Self { create_directories } = &self;
+
+        let mut create_directory_descriptions = Vec::new();
+        for create_directory in create_directories {
+            if let Some(val) = create_directory.describe_execute().iter().next() {
+                create_directory_descriptions.push(val.description.clone())
+            }
+        }
+        vec![ActionDescription::new(
+            self.tracing_synopsis(),
+            create_directory_descriptions,
+        )]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn execute(&mut self) -> Result<(), ActionError> {
+        // Just do sequential since parallelizing this will have little benefit
+        for create_directory in self.create_directories.iter_mut() {
+            create_directory.try_execute().await.map_err(Self::error)?;
+        }
+
+        Ok(())
+    }
+
+    fn revert_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(
+            format!("Remove the directory tree in `/nix`"),
+            vec![
+                format!(
+                    "Nix and the Nix daemon require a Nix Store, which will be stored at `/nix`"
+                ),
+                format!(
+                    "Removes: {}",
+                    PATHS
+                        .iter()
+                        .rev()
+                        .map(|v| format!("`{v}`"))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            ],
+        )]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn revert(&mut self) -> Result<(), ActionError> {
+        let mut errors = vec![];
+        // Just do sequential since parallelizing this will have little benefit
+        for create_directory in self.create_directories.iter_mut().rev() {
+            if let Err(err) = create_directory.try_revert().await {
+                errors.push(err);
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
+        } else {
+            Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
+        }
+    }
+}

--- a/src/action/macos/set_tmutil_exclusions.rs
+++ b/src/action/macos/set_tmutil_exclusions.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use tracing::{span, Span};
 
-use crate::action::base::CreateDirectory;
 use crate::action::{
     Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
 };

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -143,7 +143,7 @@ impl Planner for Macos {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            SetTmutilExclusions::plan(vec!["/nix/store", "/nix/var"])
+            SetTmutilExclusions::plan(vec![PathBuf::from("/nix/store"), PathBuf::from("/nix/var")])
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -130,10 +130,6 @@ impl Planner for Macos {
         };
 
         Ok(vec![
-            // Create Volume step:
-            //
-            // setup_Synthetic -> create_synthetic_objects
-            // Unmount -> create_volume -> Setup_fstab -> maybe encrypt_volume -> launchctl bootstrap -> launchctl kickstart -> await_volume -> maybe enableOwnership
             CreateNixVolume::plan(
                 root_disk.unwrap(), /* We just ensured it was populated */
                 self.volume_label.clone(),
@@ -144,6 +140,10 @@ impl Planner for Macos {
             .map_err(PlannerError::Action)?
             .boxed(),
             ProvisionNix::plan(&self.settings)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
+            SetTmutilExclusions::plan(vec!["/nix/store", "/nix/var"])
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Cursor};
+use std::{collections::HashMap, io::Cursor, path::PathBuf};
 
 #[cfg(feature = "cli")]
 use clap::ArgAction;

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -10,7 +10,7 @@ use crate::{
     action::{
         base::RemoveDirectory,
         common::{ConfigureInitService, ConfigureNix, ProvisionNix},
-        macos::CreateNixVolume,
+        macos::{CreateNixVolume, SetTmutilExclusions},
         StatefulAction,
     },
     execute_command,

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -397,9 +397,9 @@ impl HasExpectedErrors for PlannerError {
             this @ PlannerError::RosettaDetected => Some(Box::new(this)),
             PlannerError::Utf8(_) => None,
             PlannerError::SelinuxRequirements => Some(Box::new(self)),
-            PlannerError::Custom(e) => {
+            PlannerError::Custom(_e) => {
                 #[cfg(target_os = "linux")]
-                if let Some(err) = e.downcast_ref::<linux::LinuxErrorKind>() {
+                if let Some(err) = _e.downcast_ref::<linux::LinuxErrorKind>() {
                     return err.expected();
                 }
                 None

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -77,21 +77,7 @@
             "path": "/nix"
           },
           "state": "Uncompleted"
-        },
-        "set_tmutil_exclusions": [
-          {
-            "action": {
-              "path": "/nix/store"
-            },
-            "state": "Uncompleted"
-          },
-          {
-            "action": {
-              "path": "/nix/var"
-            },
-            "state": "Uncompleted"
-          }
-        ]
+        }
       },
       "state": "Uncompleted"
     },
@@ -107,7 +93,7 @@
           },
           "state": "Uncompleted"
         },
-        "delete_users": [],
+        "delete_users_in_group": null,
         "create_group": {
           "action": {
             "name": "nixbld",
@@ -263,6 +249,26 @@
     },
     {
       "action": {
+        "action": "set_tmutil_exclusions",
+        "set_tmutil_exclusions": [
+          {
+            "action": {
+              "path": "/nix/store"
+            },
+            "state": "Uncompleted"
+          },
+          {
+            "action": {
+              "path": "/nix/var"
+            },
+            "state": "Uncompleted"
+          }
+        ]
+      },
+      "state": "Uncompleted"
+    },
+    {
+      "action": {
         "action": "configure_nix",
         "setup_default_profile": {
           "action": {
@@ -353,12 +359,12 @@
                 "path": "/etc/nix/nix.conf",
                 "pending_nix_config": {
                   "settings": {
-                    "experimental-features": "nix-command flakes auto-allocate-uids",
                     "extra-nix-path": "nixpkgs=flake:nixpkgs",
+                    "auto-allocate-uids": "true",
                     "auto-optimise-store": "true",
                     "build-users-group": "nixbld",
                     "bash-prompt-prefix": "(nix:$name)\\040",
-                    "auto-allocate-uids": "true"
+                    "experimental-features": "nix-command flakes auto-allocate-uids"
                   }
                 }
               },

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -77,7 +77,21 @@
             "path": "/nix"
           },
           "state": "Uncompleted"
-        }
+        },
+        "set_tmutil_exclusions": [
+          {
+            "action": {
+              "path": "/nix/store"
+            },
+            "state": "Uncompleted"
+          },
+          {
+            "action": {
+              "path": "/nix/var"
+            },
+            "state": "Uncompleted"
+          }
+        ]
       },
       "state": "Uncompleted"
     },

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -25,11 +25,11 @@ fn plan_compat_steam_deck() -> eyre::Result<()> {
     Ok(())
 }
 
-// Ensure existing plans still parse
-// If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
-#[cfg(target_os = "macos")]
-#[test]
-fn plan_compat_macos() -> eyre::Result<()> {
-    let _: InstallPlan = serde_json::from_str(MACOS)?;
-    Ok(())
-}
+// // Ensure existing plans still parse
+// // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
+// #[cfg(target_os = "macos")]
+// #[test]
+// fn plan_compat_macos() -> eyre::Result<()> {
+//     let _: InstallPlan = serde_json::from_str(MACOS)?;
+//     Ok(())
+// }

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -25,11 +25,11 @@ fn plan_compat_steam_deck() -> eyre::Result<()> {
     Ok(())
 }
 
-// // Ensure existing plans still parse
-// // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
-// #[cfg(target_os = "macos")]
-// #[test]
-// fn plan_compat_macos() -> eyre::Result<()> {
-//     let _: InstallPlan = serde_json::from_str(MACOS)?;
-//     Ok(())
-// }
+// Ensure existing plans still parse
+// If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
+#[cfg(target_os = "macos")]
+#[test]
+fn plan_compat_macos() -> eyre::Result<()> {
+    let _: InstallPlan = serde_json::from_str(MACOS)?;
+    Ok(())
+}


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/479 most likely?

![image](https://github.com/DeterminateSystems/nix-installer/assets/130903/eea76590-958a-40bf-8327-31627cf77e6f)


##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
