### PR TITLE
Fixup GHA home directory on Mac

### DIFF
--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -154,7 +154,11 @@ impl ConfigureShellProfile {
             let mut buf = "/nix/var/nix/profiles/default/bin\n".to_string();
             // Actions runners operate as `runner` user by default
             if let Ok(Some(runner)) = User::from_name("runner") {
-                buf += &format!("/home/{}/.nix-profile/bin\n", runner.name);
+                #[cfg(target_os = "linux")]
+                let path = format!("/home/{}/.nix-profile/bin\n", runner.name);
+                #[cfg(target_os = "macos")]
+                let path = format!("/Users/{}/.nix-profile/bin\n", runner.name);
+                buf += &path;
             }
             create_or_insert_files.push(
                 CreateOrInsertIntoFile::plan(


### PR DESCRIPTION
##### Description

We noticed when poking at https://github.com/DeterminateSystems/nix-installer-action/pull/22 that this was wrong.

Perhaps we should actually remove this code entirely and put it into the Github Action...

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
