### PR TITLE
Add full path to nix-installer in bug report instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Create an issue on [the issue page](https://github.com/DeterminateSystems/nix-in
 It should contain:
 
 1. Your OS (Linux, Mac) and architecture (x86_64, aarch64)
-2. Your `nix-installer` version (`nix-installer --version`)
+2. Your `nix-installer` version (`/nix/nix-installer --version`)
 3. The thing you tried to run (eg `nix-installer`)
 4. What happened (the output of the command, please)
 5. What you expected to happen


### PR DESCRIPTION
##### Description
`nix-installer` is not in path, so users need to specify the full path to the command.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
