### PR TITLE
APFS volumes don't necessarily have names

### DIFF
--- a/src/action/macos/create_apfs_volume.rs
+++ b/src/action/macos/create_apfs_volume.rs
@@ -32,7 +32,7 @@ impl CreateApfsVolume {
             plist::from_bytes(&output.stdout).map_err(Self::error)?;
         for container in parsed.containers {
             for volume in container.volumes {
-                if volume.name == name {
+                if volume.name.as_ref() == Some(&name) {
                     return Ok(StatefulAction::completed(Self {
                         disk: disk.as_ref().to_path_buf(),
                         name,

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -83,7 +83,7 @@ impl EncryptApfsVolume {
             plist::from_bytes(&output.stdout).map_err(Self::error)?;
         for container in parsed.containers {
             for volume in container.volumes {
-                if volume.name == name {
+                if volume.name.as_ref() == Some(&name) {
                     match volume.encryption == false {
                         true => {
                             return Ok(StatefulAction::completed(Self { disk, name }));

--- a/src/os/darwin.rs
+++ b/src/os/darwin.rs
@@ -23,6 +23,6 @@ pub struct DiskUtilApfsContainer {
 #[derive(serde::Deserialize, Clone, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct DiskUtilApfsListVolume {
-    pub name: String,
+    pub name: Option<String>,
     pub encryption: bool,
 }


### PR DESCRIPTION
##### Description

Should address https://github.com/DeterminateSystems/nix-installer/issues/489, however I cannot seem to test it since the command to create a volume seems to require a name:

```bash
% diskutil apfs createVolume disk3 APFS
Usage:  diskutil apfs addVolume <containerRefDisk> <fs> <name>
        [-passprompt | -passphrase <passphrase> | -stdinpassphrase]
        [-passphraseHint <passHint>]
        [-reserve <reserveSize>] [-quota <quotaSize>]
        [-role <roles>]
        [-group[With] | -sibling <apfsVolumeDisk>]
        [-nomount | -mountpoint <mountPoint>]
        where <containerRefDisk> = Container Reference DiskIdentifier
              <fs> = an APFS file system personality: e.g. "APFS", "APFSX"
              <name> = a volume name
              <passphrase> = optionally create an encrypted volume (disk user)
              <passHint> = some string that can be shown even while locked
              <reserveSize> = optional minimum guaranteed file data capacity
              <quotaSize> = optional maximum file data usage limit
              <roles> = "0" or one or more of B|R|V|I|T|S|D|E|X|H|C|Y
              <apfsVolumeDisk> = another APFS Volume in the same Container
              <mountPoint> = "your" mount point (root only) (dir must exist)
Add a new APFS Volume to an existing APFS Container. If you specify a
passphrase, it will be encrypted with the "disk" user and that passphrase.
Ownership of the affected disks is required.
Example:  diskutil apfs addVolume disk5 APFS Foo1
          diskutil apfs addVolume disk5 APFS FooSecure2 -passphrase hello
          diskutil apfs addVolume disk5 APFS Foo3 -quota 10g -reserve 5g
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
