### PR TITLE
Improve messaging when /nix/receipt.json is already found

### DIFF
--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -24,6 +24,12 @@ use color_eyre::{
 };
 use owo_colors::OwoColorize;
 
+const EXISTING_INCOMPATIBLE_PLAN_GUIDANCE: &'static str = "\
+    If you are trying to upgrade Nix, try running `sudo -i nix upgrade-nix` instead.\n\
+    If you are trying to install Nix over an existing install (from an incompatible `nix-installer` install), try running `/nix/nix-installer uninstall` then try to install again.\n\
+    If you are using `nix-installer` in an automated curing process and seeing this message, consider pinning the version you use via https://github.com/DeterminateSystems/nix-installer#accessing-other-versions.\
+";
+
 /// Execute an install (possibly using an existing plan)
 ///
 /// To pass custom options, select a planner, for example `nix-installer install linux-multi --help`
@@ -105,9 +111,7 @@ impl CommandExecute for Install {
                                     {e}\n\
                                     \n\
                                     Found existing plan in `{RECEIPT_LOCATION}` which was created by a version incompatible `nix-installer`.\n\
-                                    If you are trying to upgrade Nix, try running `sudo -i nix upgrade-nix` instead.\n\
-                                    If you are trying to install Nix over an existing install (from an incompatible `nix-installer` install), try running `/nix/nix-installer uninstall` then try to install again.\n\
-                                    If you are using `nix-installer` in an automated curing process and seeing this message, consider pinning the version you use via https://github.com/DeterminateSystems/nix-installer#accessing-other-versions.\n\
+                                    {EXISTING_INCOMPATIBLE_PLAN_GUIDANCE}\n\
                                 ").red()
                             );
                             return Ok(ExitCode::FAILURE)
@@ -158,9 +162,7 @@ impl CommandExecute for Install {
                                     {e}\n\
                                     \n\
                                     Found existing plan in `{RECEIPT_LOCATION}` which was created by a version incompatible `nix-installer`.\n\
-                                    If you are trying to upgrade Nix, try running `sudo -i nix upgrade-nix` instead.\n\
-                                    If you are trying to install Nix over an existing install (from an incompatible `nix-installer` install), try running `/nix/nix-installer uninstall` then try to install again.\n\
-                                    If you are using `nix-installer` in an automated curing process and seeing this message, consider pinning the version you use via https://github.com/DeterminateSystems/nix-installer#accessing-other-versions.\n\
+                                    {EXISTING_INCOMPATIBLE_PLAN_GUIDANCE}\n\
                                 ").red()
                             );
                             return Ok(ExitCode::FAILURE)

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, str::FromStr};
 
 use crate::{
     action::{Action, ActionDescription, StatefulAction},
-    planner::{BuiltinPlanner, Planner},
+    planner::{BuiltinPlanner, Planner, PlannerError},
     NixInstallerError,
 };
 use owo_colors::OwoColorize;
@@ -18,7 +18,6 @@ revert
 */
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct InstallPlan {
-    #[serde(deserialize_with = "ensure_version")]
     pub(crate) version: Version,
 
     pub(crate) actions: Vec<StatefulAction<Box<dyn Action>>>,
@@ -144,6 +143,7 @@ impl InstallPlan {
         &mut self,
         cancel_channel: impl Into<Option<Receiver<()>>>,
     ) -> Result<(), NixInstallerError> {
+        self.check_compatible()?;
         let Self { actions, .. } = self;
         let mut cancel_channel = cancel_channel.into();
 
@@ -293,6 +293,7 @@ impl InstallPlan {
         &mut self,
         cancel_channel: impl Into<Option<Receiver<()>>>,
     ) -> Result<(), NixInstallerError> {
+        self.check_compatible()?;
         let Self { actions, .. } = self;
         let mut cancel_channel = cancel_channel.into();
         let mut errors = vec![];
@@ -359,6 +360,21 @@ impl InstallPlan {
             return Err(error);
         }
     }
+
+    pub fn check_compatible(&self) -> Result<(), NixInstallerError> {
+        let self_version_string = self.version.to_string();
+        let req = VersionReq::parse(&self_version_string)
+            .map_err(|e| NixInstallerError::InvalidVersionRequirement(self_version_string, e))?;
+        let nix_installer_version = current_version()?;
+        if req.matches(&nix_installer_version) {
+            Ok(())
+        } else {
+            Err(NixInstallerError::IncompatibleVersion {
+                binary: nix_installer_version,
+                plan: self.version.clone(),
+            })
+        }
+    }
 }
 
 async fn write_receipt(plan: InstallPlan) -> Result<(), NixInstallerError> {
@@ -374,30 +390,11 @@ async fn write_receipt(plan: InstallPlan) -> Result<(), NixInstallerError> {
     Result::<(), NixInstallerError>::Ok(())
 }
 
-fn current_version() -> Result<Version, semver::Error> {
+fn current_version() -> Result<Version, NixInstallerError> {
     let nix_installer_version_str = env!("CARGO_PKG_VERSION");
-    Version::from_str(nix_installer_version_str)
-}
-
-fn ensure_version<'de, D: Deserializer<'de>>(d: D) -> Result<Version, D::Error> {
-    let plan_version = Version::deserialize(d)?;
-    let req = VersionReq::parse(&plan_version.to_string()).map_err(|_e| {
-        D::Error::custom(&format!(
-            "Could not parse version `{plan_version}` as a version requirement, please report this",
-        ))
-    })?;
-    let nix_installer_version = current_version().map_err(|_e| {
-        D::Error::custom(&format!(
-            "Could not parse `nix-installer`'s version `{}` as a valid version according to Semantic Versioning, therefore the plan version ({plan_version}) compatibility cannot be checked", env!("CARGO_PKG_VERSION")
-        ))
-    })?;
-    if req.matches(&nix_installer_version) {
-        Ok(plan_version)
-    } else {
-        Err(D::Error::custom(&format!(
-            "This version of `nix-installer` ({nix_installer_version}) is not compatible with this plan's version ({plan_version}), you probably are trying to install with a new version of `nix-installer` which is not compatible with version {plan_version} plans. To upgrade Nix, try `sudo -i nix upgrade-nix`. To reinstall Nix, try `/nix/nix-installer uninstall` then installing again from the instructions on https://github.com/DeterminateSystems/nix-installer. To continue using this plan, download the matching release from https://github.com/DeterminateSystems/nix-installer/releases.",
-        )))
-    }
+    Version::from_str(nix_installer_version_str).map_err(|e| {
+        NixInstallerError::InvalidCurrentVersion(nix_installer_version_str.to_string(), e)
+    })
 }
 
 #[cfg(test)]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -2,12 +2,11 @@ use std::{path::PathBuf, str::FromStr};
 
 use crate::{
     action::{Action, ActionDescription, StatefulAction},
-    planner::{BuiltinPlanner, Planner, PlannerError},
+    planner::{BuiltinPlanner, Planner},
     NixInstallerError,
 };
 use owo_colors::OwoColorize;
 use semver::{Version, VersionReq};
-use serde::{de::Error, Deserialize, Deserializer};
 use tokio::sync::broadcast::Receiver;
 
 pub const RECEIPT_LOCATION: &str = "/nix/receipt.json";
@@ -412,8 +411,8 @@ mod test {
             "version": good_version,
             "actions": [],
         });
-        let maybe_plan: Result<InstallPlan, serde_json::Error> = serde_json::from_value(value);
-        maybe_plan.unwrap();
+        let maybe_plan: InstallPlan = serde_json::from_value(value)?;
+        maybe_plan.check_compatible()?;
         Ok(())
     }
 
@@ -426,10 +425,8 @@ mod test {
             "version": bad_version,
             "actions": [],
         });
-        let maybe_plan: Result<InstallPlan, serde_json::Error> = serde_json::from_value(value);
-        assert!(maybe_plan.is_err());
-        let err = maybe_plan.unwrap_err();
-        assert!(err.is_data());
+        let maybe_plan: InstallPlan = serde_json::from_value(value)?;
+        assert!(maybe_plan.check_compatible().is_err());
         Ok(())
     }
 }


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/488

```
ana@ephemeral-ubuntu:~/Downloads$ ./nix-installer install
`nix-installer` needs to run as `root`, attempting to escalate now via `sudo`...
`nix-installer` version `0.9.1-unreleased` is not compatible with this plan's version `0.6.0`

Found existing plan in `/nix/receipt.json` which was created by a version incompatible `nix-installer`.
If you are trying to upgrade Nix, try running `sudo -i nix upgrade-nix` instead.
If you are trying to install Nix over an existing install (from an incompatible `nix-installer` install), try running `/nix/nix-installer uninstall` then try to install again.
If you are using `nix-installer` in an automated curing process and seeing this message, consider pinning the version you use via https://github.com/DeterminateSystems/nix-installer#accessing-other-versions.
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
