### PR TITLE
Document how to handle different branches and buildIDs of the steam deck

### DIFF
--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -79,7 +79,7 @@ To test a specific channel of the Steam Deck:
 
 
 To test on a specific build id of the Steam Deck:
-1. Determine the build id to be targetted. On a running system this is found in `/etc/os-release` under `BUILD_ID`.
+1. Determine the build id to be targeted. On a running system this is found in `/etc/os-release` under `BUILD_ID`.
 2. Run `steamos-update-os now --update-version $BUILD_ID`
     + If you can't access a specific build ID you may need to change branches, see above.
     + Be patient, don't ctrl+C it, it breaks. Don't reboot yet!

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -39,6 +39,7 @@ One time step:
 6. Run `sudo steamos-chroot --disk /dev/nvme0n1 --partset B` and inside run the same above commands
 7. Safely turn off the VM!
 
+
 Repeated step:
 1. Create a snapshot of the base install to work on
     ```sh
@@ -58,6 +59,42 @@ Repeated step:
     ```
 3. **Do your testing!** You can `ssh deck@localhost -p 2222` in and use `rsync -e 'ssh -p 2222' result/bin/nix-installer deck@localhost:nix-installer` to send a `nix-installer build.
 4. Delete `steamos-hack.qcow2`
+
+
+To test a specific channel of the Steam Deck:
+1. Use `steamos-select-branch -l` to list possible branches.
+2. Run `steamos-select-branch $BRANCH` to choose a branch
+3. Run `steamos-update`
+4. Run `sudo steamos-chroot --disk /dev/vda --partset A` and inside run this
+    ```sh
+    steamos-readonly disable
+    echo -e '[Autologin]\nSession=plasma.desktop' > /etc/sddm.conf.d/zz-steamos-autologin.conf
+    passwd deck
+    sudo systemctl enable sshd
+    steamos-readonly enable
+    exit
+    ```
+5. Run `sudo steamos-chroot --disk /dev/vda --partset B` and inside run the same above commands
+6. Safely turn off the VM!
+
+
+To test on a specific build id of the Steam Deck:
+1. Determine the build id to be targetted. On a running system this is found in `/etc/os-release` under `BUILD_ID`.
+2. Run `steamos-update-os now --update-version $BUILD_ID`
+    + If you can't access a specific build ID you may need to change branches, see above.
+    + Be patient, don't ctrl+C it, it breaks. Don't reboot yet!
+4. Run `sudo steamos-chroot --disk /dev/vda --partset A` and inside run this
+    ```sh
+    steamos-readonly disable
+    echo -e '[Autologin]\nSession=plasma.desktop' > /etc/sddm.conf.d/zz-steamos-autologin.conf
+    passwd deck
+    sudo systemctl enable sshd
+    steamos-readonly enable
+    exit
+    ```
+5. Run `sudo steamos-chroot --disk /dev/vda --partset B` and inside run the same above commands
+6. Safely turn off the VM!
+
 */
 use std::{collections::HashMap, path::PathBuf};
 


### PR DESCRIPTION

##### Description

While working on https://github.com/DeterminateSystems/nix-installer/issues/474 I realized it wasn't straightforward how to change branches/IDs of our steam deck test VM. This adds those extra instructions.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
