### PR TITLE
Support for SteamOS Nix Offload in SteamOS 20230522.1000

### DIFF
--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -165,7 +165,7 @@ impl Action for CreateDirectory {
             None
         };
 
-        create_dir(path.clone())
+        create_dir(&path)
             .await
             .map_err(|e| ActionErrorKind::CreateDirectory(path.clone(), e))
             .map_err(Self::error)?;

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -631,7 +631,7 @@ async fn disable(unit: &str, now: bool) -> Result<(), ActionErrorKind> {
 }
 
 #[cfg(target_os = "linux")]
-async fn is_active(unit: &str) -> Result<bool, ActionErrorKind> {
+pub(crate) async fn is_active(unit: &str) -> Result<bool, ActionErrorKind> {
     let mut command = Command::new("systemctl");
     command.arg("is-active");
     command.arg(unit);
@@ -649,7 +649,7 @@ async fn is_active(unit: &str) -> Result<bool, ActionErrorKind> {
 }
 
 #[cfg(target_os = "linux")]
-async fn is_enabled(unit: &str) -> Result<bool, ActionErrorKind> {
+pub(crate) async fn is_enabled(unit: &str) -> Result<bool, ActionErrorKind> {
     let mut command = Command::new("systemctl");
     command.arg("is-enabled");
     command.arg(unit);

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -631,7 +631,7 @@ async fn disable(unit: &str, now: bool) -> Result<(), ActionErrorKind> {
 }
 
 #[cfg(target_os = "linux")]
-pub(crate) async fn is_active(unit: &str) -> Result<bool, ActionErrorKind> {
+async fn is_active(unit: &str) -> Result<bool, ActionErrorKind> {
     let mut command = Command::new("systemctl");
     command.arg("is-active");
     command.arg(unit);
@@ -649,7 +649,7 @@ pub(crate) async fn is_active(unit: &str) -> Result<bool, ActionErrorKind> {
 }
 
 #[cfg(target_os = "linux")]
-pub(crate) async fn is_enabled(unit: &str) -> Result<bool, ActionErrorKind> {
+async fn is_enabled(unit: &str) -> Result<bool, ActionErrorKind> {
     let mut command = Command::new("systemctl");
     command.arg("is-enabled");
     command.arg(unit);

--- a/src/action/linux/ensure_steamos_nix_directory.rs
+++ b/src/action/linux/ensure_steamos_nix_directory.rs
@@ -13,7 +13,7 @@ use crate::action::{Action, ActionDescription, StatefulAction};
 Ensure SeamOS's `/nix` folder exists.
 
 In SteamOS build ID 20230522.1000 (and, presumably, later) a `/nix` directory and related units
-exist. In previous verions of `nix-installer` the uninstall process would remove that direcory.
+exist. In previous versions of `nix-installer` the uninstall process would remove that directory.
 This action ensures that the folder does indeed exist.
 */
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
@@ -55,7 +55,7 @@ impl Action for EnsureSteamosNixDirectory {
             vec![
                 "On more recent versions of SteamOS, a `/nix` folder now exists on the base image.".to_string(),
                 "Previously, `nix-installer` created this directory through systemd units.".to_string(),
-                "It's likely you updated SteamOS, then ran `/nix/nix-installer uninstall`, which deleted the `/nix` direcory.".to_string(),
+                "It's likely you updated SteamOS, then ran `/nix/nix-installer uninstall`, which deleted the `/nix` directory.".to_string(),
             ],
         )]
     }

--- a/src/action/linux/ensure_steamos_nix_directory.rs
+++ b/src/action/linux/ensure_steamos_nix_directory.rs
@@ -1,0 +1,102 @@
+use std::path::{Path, PathBuf};
+
+use tokio::fs::create_dir;
+use tokio::process::Command;
+use tracing::{span, Span};
+
+use crate::action::{ActionError, ActionErrorKind, ActionTag};
+use crate::execute_command;
+
+use crate::action::{Action, ActionDescription, StatefulAction};
+
+/**
+Ensure SeamOS's `/nix` folder exists.
+
+In SteamOS build ID 20230522.1000 (and, presumably, later) a `/nix` directory and related units
+exist. In previous verions of `nix-installer` the uninstall process would remove that direcory.
+This action ensures that the folder does indeed exist.
+*/
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct EnsureSteamosNixDirectory;
+
+impl EnsureSteamosNixDirectory {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
+        if which::which("steamos-readonly").is_err() {
+            return Err(Self::error(ActionErrorKind::MissingSteamosBinary(
+                "steamos-readonly".into(),
+            )));
+        }
+        if Path::new("/nix").exists() {
+            Ok(StatefulAction::completed(EnsureSteamosNixDirectory))
+        } else {
+            Ok(StatefulAction::uncompleted(EnsureSteamosNixDirectory))
+        }
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "ensure_steamos_nix_directory")]
+impl Action for EnsureSteamosNixDirectory {
+    fn action_tag() -> ActionTag {
+        ActionTag("ensure_steamos_nix_directory")
+    }
+    fn tracing_synopsis(&self) -> String {
+        format!("Ensure SteamOS's `/nix` directory exists")
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "ensure_steamos_nix_directory",)
+    }
+
+    fn execute_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(
+            self.tracing_synopsis(),
+            vec![
+                "On more recent versions of SteamOS, a `/nix` folder now exists on the base image.".to_string(),
+                "Previously, `nix-installer` created this directory through systemd units.".to_string(),
+                "It's likely you updated SteamOS, then ran `/nix/nix-installer uninstall`, which deleted the `/nix` direcory.".to_string(),
+            ],
+        )]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn execute(&mut self) -> Result<(), ActionError> {
+        execute_command(
+            Command::new("steamos-readonly")
+                .process_group(0)
+                .arg("disable")
+                .stdin(std::process::Stdio::null()),
+        )
+        .await
+        .map_err(Self::error)?;
+
+        let path = PathBuf::from("/nix");
+        create_dir(&path)
+            .await
+            .map_err(|e| ActionErrorKind::CreateDirectory(path.clone(), e))
+            .map_err(Self::error)?;
+
+        execute_command(
+            Command::new("steamos-readonly")
+                .process_group(0)
+                .arg("enable")
+                .stdin(std::process::Stdio::null()),
+        )
+        .await
+        .map_err(Self::error)?;
+
+        Ok(())
+    }
+
+    fn revert_description(&self) -> Vec<ActionDescription> {
+        vec![]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn revert(&mut self) -> Result<(), ActionError> {
+        // noop
+
+        Ok(())
+    }
+}

--- a/src/action/linux/mod.rs
+++ b/src/action/linux/mod.rs
@@ -1,5 +1,9 @@
+pub(crate) mod ensure_steamos_nix_directory;
 pub(crate) mod provision_selinux;
 pub(crate) mod start_systemd_unit;
+pub(crate) mod systemctl_daemon_reload;
 
+pub use ensure_steamos_nix_directory::EnsureSteamosNixDirectory;
 pub use provision_selinux::ProvisionSelinux;
 pub use start_systemd_unit::{StartSystemdUnit, StartSystemdUnitError};
+pub use systemctl_daemon_reload::SystemctlDaemonReload;

--- a/src/action/linux/start_systemd_unit.rs
+++ b/src/action/linux/start_systemd_unit.rs
@@ -54,7 +54,7 @@ impl Action for StartSystemdUnit {
         ActionTag("start_systemd_unit")
     }
     fn tracing_synopsis(&self) -> String {
-        format!("Enable (and start) the systemd unit {}", self.unit)
+        format!("Enable (and start) the systemd unit `{}`", self.unit)
     }
 
     fn tracing_span(&self) -> Span {
@@ -106,7 +106,7 @@ impl Action for StartSystemdUnit {
 
     fn revert_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(
-            format!("Disable (and stop) the systemd unit {}", self.unit),
+            format!("Disable (and stop) the systemd unit `{}`", self.unit),
             vec![],
         )]
     }

--- a/src/action/linux/systemctl_daemon_reload.rs
+++ b/src/action/linux/systemctl_daemon_reload.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+
+use tokio::process::Command;
+use tracing::{span, Span};
+
+use crate::action::{ActionError, ActionErrorKind, ActionTag};
+use crate::execute_command;
+
+use crate::action::{Action, ActionDescription, StatefulAction};
+
+/**
+Run `systemctl daemon-reload` (on both execute and revert)
+*/
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct SystemctlDaemonReload;
+
+impl SystemctlDaemonReload {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
+        if !Path::new("/run/systemd/system").exists() {
+            return Err(Self::error(ActionErrorKind::SystemdMissing));
+        }
+
+        if which::which("systemctl").is_err() {
+            return Err(Self::error(ActionErrorKind::SystemdMissing));
+        }
+
+        Ok(StatefulAction::uncompleted(SystemctlDaemonReload))
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "systemctl_daemon_reload")]
+impl Action for SystemctlDaemonReload {
+    fn action_tag() -> ActionTag {
+        ActionTag("systemctl_daemon_reload")
+    }
+    fn tracing_synopsis(&self) -> String {
+        format!("Run `systemctl daemon-reload`")
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "systemctl_daemon_reload",)
+    }
+
+    fn execute_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn execute(&mut self) -> Result<(), ActionError> {
+        execute_command(
+            Command::new("systemctl")
+                .process_group(0)
+                .arg("daemon-reload")
+                .stdin(std::process::Stdio::null()),
+        )
+        .await
+        .map_err(Self::error)?;
+
+        Ok(())
+    }
+
+    fn revert_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn revert(&mut self) -> Result<(), ActionError> {
+        execute_command(
+            Command::new("systemctl")
+                .process_group(0)
+                .arg("daemon-reload")
+                .stdin(std::process::Stdio::null()),
+        )
+        .await
+        .map_err(Self::error)?;
+
+        Ok(())
+    }
+}

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -243,7 +243,7 @@ pub trait Action: Send + Sync + std::fmt::Debug + dyn_clone::DynClone {
     ///
     /// If this action calls sub-[`Action`]s, care should be taken to call [`try_revert`][StatefulAction::try_revert], not [`revert`][Action::revert], so that [`ActionState`] is handled correctly and tracing is done.
     ///
-    /// /// This is called by [`InstallPlan::uninstall`](crate::InstallPlan::uninstall) through [`StatefulAction::try_revert`] which handles tracing as well as if the action needs to revert based on its `action_state`.
+    /// This is called by [`InstallPlan::uninstall`](crate::InstallPlan::uninstall) through [`StatefulAction::try_revert`] which handles tracing as well as if the action needs to revert based on its `action_state`.
     async fn revert(&mut self) -> Result<(), ActionError>;
 
     fn stateful(self) -> StatefulAction<Self>
@@ -518,6 +518,8 @@ pub enum ActionErrorKind {
     Plist(#[from] plist::Error),
     #[error("Unexpected binary tarball contents found, the build result from `https://releases.nixos.org/?prefix=nix/` or `nix build nix#hydraJobs.binaryTarball.$SYSTEM` is expected")]
     MalformedBinaryTarball,
+    #[error("Could not find `{0}` in PATH; This action only works on SteamOS, which should have this present in PATH.")]
+    MissingSteamosBinary(String),
     #[error(
         "Could not find a supported command to create users in PATH; please install `useradd` or `adduser`"
     )]

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -381,6 +381,9 @@ pub enum PlannerError {
     NixExists,
     #[error("WSL1 is not supported, please upgrade to WSL2: https://learn.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2")]
     Wsl1,
+    /// Failed to execute command
+    #[error("Failed to execute command `{0}`")]
+    Command(String, #[source] std::io::Error),
     #[cfg(feature = "diagnostics")]
     #[error(transparent)]
     Diagnostic(#[from] crate::diagnostics::DiagnosticError),
@@ -407,6 +410,7 @@ impl HasExpectedErrors for PlannerError {
             this @ PlannerError::NixOs => Some(Box::new(this)),
             this @ PlannerError::NixExists => Some(Box::new(this)),
             this @ PlannerError::Wsl1 => Some(Box::new(this)),
+            PlannerError::Command(_, _) => None,
             #[cfg(feature = "diagnostics")]
             PlannerError::Diagnostic(diagnostic_error) => Some(Box::new(diagnostic_error)),
         }

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -79,7 +79,7 @@ To test a specific channel of the Steam Deck:
 
 
 To test on a specific build id of the Steam Deck:
-1. Determine the build id to be targetted. On a running system this is found in `/etc/os-release` under `BUILD_ID`.
+1. Determine the build id to be targeted. On a running system this is found in `/etc/os-release` under `BUILD_ID`.
 2. Run `steamos-update-os now --update-version $BUILD_ID`
     + If you can't access a specific build ID you may need to change branches, see above.
     + Be patient, don't ctrl+C it, it breaks. Don't reboot yet!

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -96,11 +96,7 @@ To test on a specific build id of the Steam Deck:
 6. Safely turn off the VM!
 
 */
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    process::Output,
-};
+use std::{collections::HashMap, path::PathBuf, process::Output};
 
 use tokio::process::Command;
 

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -39,6 +39,7 @@ One time step:
 6. Run `sudo steamos-chroot --disk /dev/nvme0n1 --partset B` and inside run the same above commands
 7. Safely turn off the VM!
 
+
 Repeated step:
 1. Create a snapshot of the base install to work on
     ```sh
@@ -58,6 +59,42 @@ Repeated step:
     ```
 3. **Do your testing!** You can `ssh deck@localhost -p 2222` in and use `rsync -e 'ssh -p 2222' result/bin/nix-installer deck@localhost:nix-installer` to send a `nix-installer build.
 4. Delete `steamos-hack.qcow2`
+
+
+To test a specific channel of the Steam Deck:
+1. Use `steamos-select-branch -l` to list possible branches.
+2. Run `steamos-select-branch $BRANCH` to choose a branch
+3. Run `steamos-update`
+4. Run `sudo steamos-chroot --disk /dev/vda --partset A` and inside run this
+    ```sh
+    steamos-readonly disable
+    echo -e '[Autologin]\nSession=plasma.desktop' > /etc/sddm.conf.d/zz-steamos-autologin.conf
+    passwd deck
+    sudo systemctl enable sshd
+    steamos-readonly enable
+    exit
+    ```
+5. Run `sudo steamos-chroot --disk /dev/vda --partset B` and inside run the same above commands
+6. Safely turn off the VM!
+
+
+To test on a specific build id of the Steam Deck:
+1. Determine the build id to be targetted. On a running system this is found in `/etc/os-release` under `BUILD_ID`.
+2. Run `steamos-update-os now --update-version $BUILD_ID`
+    + If you can't access a specific build ID you may need to change branches, see above.
+    + Be patient, don't ctrl+C it, it breaks. Don't reboot yet!
+4. Run `sudo steamos-chroot --disk /dev/vda --partset A` and inside run this
+    ```sh
+    steamos-readonly disable
+    echo -e '[Autologin]\nSession=plasma.desktop' > /etc/sddm.conf.d/zz-steamos-autologin.conf
+    passwd deck
+    sudo systemctl enable sshd
+    steamos-readonly enable
+    exit
+    ```
+5. Run `sudo steamos-chroot --disk /dev/vda --partset B` and inside run the same above commands
+6. Safely turn off the VM!
+
 */
 use std::{collections::HashMap, path::PathBuf};
 


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/474

Before I undraft I need to figure out a good story for users who might have nix installed when they update to this version...

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
