### PR TITLE
Trigger buildkite on external prs

### DIFF
--- a/.github/workflows/buildkite-external-prs.yaml
+++ b/.github/workflows/buildkite-external-prs.yaml
@@ -1,0 +1,23 @@
+name: Trigger Buildkite on External PR
+
+on:
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  trigger:
+    # Only intra-repo PRs are allowed to have Buildkite run on them automatically
+    # In order to allow PRs from third parties to build on Buildkite, we require an org member add a label after the PR has been vetted.
+    # This will only happen when the label is added, so as to reduce the risk of an innocuous first commit with malicious follow-up commits (after the label was added).
+    # This means, if the contributor's PR needs changes, someone with the ability to change labels will need to _remove_ the `trigger buildkite` label, _and then re-add it_.
+    if: github.event.action == 'labeled' && github.event.label.name == 'trigger buildkite'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger a Buildkite Build
+        uses: "buildkite/trigger-pipeline-action@v1.5.0"
+        env:
+          BUILDKITE_API_ACCESS_TOKEN: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}
+          PIPELINE: "determinate-systems-inc/nix-installer"
+          COMMIT: ${{ github.event.pull_request.head.sha }}
+          MESSAGE:  ":github: Triggered from a GitHub Action"


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
