### PR TITLE
Use os-release to determine appropriate planner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 [features]
 default = ["cli", "diagnostics"]
 cli = ["eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error", "atty"]
-diagnostics = ["os-release", "is_ci"]
+diagnostics = ["is_ci"]
 
 [[bin]]
 name = "nix-installer"
@@ -54,7 +54,7 @@ rand = { version = "0.8.5", default-features = false, features = [ "std", "std_r
 semver = { version = "1.0.14", default-features = false, features = ["serde", "std"] }
 term = { version = "0.7.0", default-features = false }
 uuid = { version = "1.2.2", features = ["serde"] }
-os-release = { version = "0.1.0", default-features = false, optional = true }
+os-release = { version = "0.1.0", default-features = false }
 is_ci = { version = "1.1.1", default-features = false, optional = true }
 strum = { version = "0.24.1", features = ["derive"] }
 nix-config-parser = { version = "0.1.2", features = ["serde"] }


### PR DESCRIPTION
##### Description

Notably, auto detect steam decks. This also will interact with #389 in the future.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
