### PR TITLE
Fix darwin devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,8 +140,6 @@
               cacert
               cargo-audit
               nixpkgs-fmt
-              semodule-utils
-              checkpolicy
               check.check-rustfmt
               check.check-spelling
               check.check-nixpkgs-fmt
@@ -150,7 +148,9 @@
             ]
             ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [ libiconv ])
             ++ lib.optionals (pkgs.stdenv.isLinux) (with pkgs; [
+              checkpolicy
               podman
+              semodule-utils
               /* users are expected to have a system docker, too */
             ]);
           };

--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,10 @@
               check.check-editorconfig
               check.check-semver
             ]
-            ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [ libiconv ])
+            ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [
+              libiconv
+              darwin.apple_sdk.frameworks.Security
+            ])
             ++ lib.optionals (pkgs.stdenv.isLinux) (with pkgs; [
               checkpolicy
               podman


### PR DESCRIPTION
- SELinux tools are Linux specific
- The Security framework is needed by cargo build