### PR TITLE
Add flake checker action to GHA lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Check Nixpkgs input
+        uses: DeterminateSystems/flake-checker-action@v3
+        with:
+          fail-mode: true
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:


### PR DESCRIPTION
- Add some more branding to action (#129)
- buildkite: run on x86_64 and aarch64 linux (#131)
- Remove newline before access-tokens (#136)
- BUGFIX: Call `nix-store --load-db` & add sandboxed Qemu tests (#138)
- Fix ubuntu 16.04 support (#140)
- Resolve a system unit ordering bug after update (#144)
- Note how to test action in CONTRIBUTING.md (#141)
- Correctly expected error in default planner if nix installed (#151)
- Un-whoops success message (#153)
- release: init action to create release with buildkite artifacts (#150)
- Document release flow (#155)
- Show revert instead of step while reverting (#158)
- Fix use of UID where username should be on Github actions (#157)
- Be more friendly to light terminals (#149)
- installplan should not copy self binary (#161)
- release: create releases for specified branches (#152)
- Linus/ds 576 nix store should be in path directly (#148)
- release: init action to release first party PRs (#162)
- Fixup fdesetup isactive outputting when it should not (#163)
- Update locks (#164)
- When an artifact already exists for an MD5, skip it without failure (#166)
- upload_s3: sync already-existing dir to its destination (#167)
- Rename daemon-user-count and make an alias (#159)
- Update README.md to reflect recent changes (#165)
- upload_s3: provide git ish as argument (#169)
- upload_s3: move arguments to the top (#170)
- Release v0.0.1 (#168)
- Fixup badges in README.md (#172)
- bump v0.0.2-unreleased (#176)
- Action extra conf can be lacking newline (#175)
- Add some tests to CreateFile (#182)
- BUGFIX: CreateDirectory now properly prunes when it should (#181)
- BUGFIX: CreateOrInsertIntoFile was not reverting (#180)
- Refactor the README.md (#178)
- Allow users to answer e at prompts (#183)
- Trim irrelevant mac warning (#186)
- Use remote action (#185)
- Upload tags to S3 as well to avoid egress limits (#187)
- Update action section in readme with tag (#189)
- Add `(nix:$name)` as a prefix to the bash prompt (#191)
- enter-env.sh: init (#190)
- README: recommend safer curl options (#197)
- Pass SHELL through self-escalation (#195)
- Release v0.0.2 (#198)
- Revert "Release v0.0.2 (#198)" (#200)
- release-tags: needs write permissions to id-token for oidc authentication (#199)
- Re-release v0.0.2 (#201)
- upload_s3: improve tags handling (#202)
- release: add instructions on how to use uploaded artifacts (#204)
- Improve Mac explain output (#205)
- Correct --no-modify-profile (#206)
- CONTRIBUTING: `nix check` -> `nix flake check` (#207)
- Release v0.1.0 (#208)
- v0.1.0-unreleased (#210)
- Use a UUID instead of volume name for fstab on Mac (#215)
- Add a friendly top comment about `nix-installer.sh` (#216)
- Verify the apfs volume doesn't already exist before trying to create it (#217)
- Add plist use to the CreateFstabEntry action (#221)
- Use 30k range not 3k range for UIDs on Linux and 30k for a GID on all (#222)
- init-less install (#188)
- Release v0.2.0 (#230)
- v0.2.1-unreleased (#232)
- release: only run one release action at a time (#231)
- Update dependencies (#233)
- Add 32 bit support (#229)
- Bump Nix to 2.13.2 (#236)
- Attempt to minimize steam deck display manager restart risk (#237)
- Better support users/groups existing before install (#238)
- Better support existing files with CreateFile and CreateorInsertIntoFile (#239)
- It's the Determinate Nix Installer (#242)
- Bump DeterminateSystems/update-flake-lock from 14 to 16 (#223)
- Rename some of the planners (#243)
- Make systemd unit start detect already running unit (#240)
- Offer users better error if fstab entries exist (#241)
- Workaround some Mac issues in CI (#247)
- Clarify stability (#244)
- Repair some tests (#248)
- How about a CI API call reduction? (#245)
- Release v0.3.0 (#249)
- Mac support note (#251)
- Remove some bad merge code (#252)
- Improve error message guidance (#258)
- Don't specify chmod on synthetic.conf (#259)
- Don't parallize user creation (#260)
- Add note on --no-confirm flag (#261)
- Set the correct permissions on the zshenv (#257)
- Enable deleting users and groups on Mac (#253)
- Improve permissions checking when dealing with existing files (#267)
- README: upgrade MacOS stability and note (#269)
- Add diagnostics reporting (#264)
- gitignore: ignore Nix result directories (#272)
- Use extra-nix-path to resolve nix-shell -p not working (#270)
- Prelease tidy and add is_ci to Diagnostics (#271)
- Repair is_ci handling, sudo was erasing the variables (#274)
- Release v0.4.0 (#273)
- Describe Diagnostics (#276)
- Bump tempfile to 3.4.0 (#277)
- Use 0o644 for files, not 0o664 (#278)
- Update default nix_package_url to Nix 2.13.3 (#279)
- Add newline to end of plan json output (#283)
- update: dogfood our action (#293)
- Use `launchctl load -w` on macOS (#298)
- Detect WSL1 and error (#297)
- Make errors non-exhaustive (#299)
- Add more failure context / Improve error structure (#296)
- Update some dependencies (#303)
- Integrate nix-config-parser (#263)
- Release v0.5.0 (#305)
- v0.5.1-unreleased (#307)
- Make CreateUser idempotent (#306)
- Remove nix channel placement (#304)
- README: clarify WSL means WSL2 (#315)
- Curing existing /nix (#310)
- Fix vm/container tests after #304 (#316)
- Cure existing systemd units (#313)
- Fixup a couple differences with the official installer scripts (#311)
- Cure APFS/Fstabs on Mac (#246)
- Only symlink if the link doesn't already exist in configure_init_service.rs (#317)
- Add curing vm tests (#312)
- Tweak the logging levels in CI and in some instrumentation (#318)
- Add test for missing users and groups (#321)
- Support busybox user/group modification, more informational errors (#319)
- Repair /nix removal test (#320)
- Include user index in the user comment (#330)
- Make `nix-installer plan invalid-plan` fail (#331)
- Add install script cure tests (#322)
- Only list changed plan settings in summary (#333)
- Be more positive in help output about our software working and not failing (#334)
- Default to systemd, refer to documentation if systemd is not available (#336)
- Use rustls-tls-native-roots (#332)
- Add fish vendor_conf.d support (#335)
- Explicit proxy support (#337)
- Proxy envs need to get elevated (#342)
- Groom plan synopsis (#338)
- Update the install differences in the readme (#340)
- In the README, recommend a git url (#343)
- Add ssl-cert-file option (#341)
- Update zshrc, not zshenv (#339)
- Fancy-fy the README a bit (#345)
- Update dependencies (#346)
- Set NIX_SSL_CERT_FILE in the daemon (#347)
- Use nixpkgs-unstable (#351)
- Release v0.6.0 (#352)
- Bump to 0.6.1-unreleased (#353)
- Be less grumpy about existing file permissions. (#359)
- Add Rosetta check for Mac (#355)
- Detect fdesetup properly (#361)
- Do not try to reload the systemd daemon when we are using --no-start-daemon (#365)
- Fixup diagnostic_endpoint setting to be more flexible (#374)
- Improve Mac Volume Curing (#362)
- Add Fedora v37 tests (#364)
- Make shell profile locations chosen by planner (#375)
- Use retry strategy after diskutil create (#376)
- Revert `default_missing_value` to `default_value` (#380)
- Bump dependencies (#385)
- Add semver check (#156)
- Add a bit of issue metadata (#386)
- Document version pinning (#388)
- Release v0.7.0 (#390)
- v0.7.1-unreleased (#393)
- Fixup create_volume_service action tag (#398)
- Uninstall shouldn't fail fast (#382)
- Trim fdesetup output, remove accidently committed SSL related settings (#403)
- Split output docs (#407)
- Only stop the nix daemon if it's actually active, not just enabled (#410)
- Handle the APFS volume not existing but the Service and Fstab being present (#405)
- Provide users a better error message if systemd is not active (#412)
- Avoid globbing issues by using symlinks and readlink (#413)
- Check user group commands exist during plan (#411)
- Bump aws-actions/configure-aws-credentials from 1 to 2 (#395)
- Fixup a cure case where a store path already exists so we never make a symlink (#414)
- Release v0.8.0 (#415)
- 0.8.1-unreleased (#437)
- Nix 2.13.3 -> 2.15.0 (#428)
- Bump dependencies (#444)
- fsync after writing Nix config to attempt to fix the flaky preserves_comment test (#448)
- Set permissions on unpacked Nix store paths more carefully (#451)
- Test Nix 2.15 and the auto-uid-allocation feature (#196)
- Make the RequiredBy items in the nix.mount of steam-deck planner in [Install] (#455)
- Fixup multiple --extra-conf usages (#456)
- Don't error if already installed with same settings, just warn (#454)
- Add SELinux support (#465)
- Improve failure chain on revert (#467)
- Improve messaging around version incompatability (#457)
- Regular dep bump (#468)
- Improve the SELinux heuristic to look for sestatus (#470)
- Improve container docs somewhat (#472)
- Improve WSL systemd detection (#469)
- Release v0.9.0 (#473)
- ci: release-prs: fixup tagging behavior (#471)
- Bump to v0.9.1-unreleased (#483)
- Fixup GHA home directory on Mac (#482)
- Release v0.9.1 (#484)
- Bump to v0.9.2-unreleased (#497)
- APFS volumes don't necessarily have names (#490)
- Add time machine exclusions for Mac (#480)
- Trigger buildkite on external PRs (#496)
- Improve messaging when /nix/receipt.json is already found (#491)
- Add full path to nix-installer in bug report instructions (#499)
- Support for SteamOS Nix Offload in SteamOS 20230522.1000 (#495)
- Revert "Trigger buildkite on external PRs" (#500)
- Use os-release to determine appropriate planner (#501)
- Fix uninstalling on latest steam deck with offload (#502)
- typo fix for auto-allocate-uids (#505)
- Add self test functionality (#506)
- Fix darwin devShell (#514)
- Add flake checker action to CI

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
