### PR TITLE
Uninstalling should change directory if in nix

### DIFF
--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -1,10 +1,9 @@
-use nix::unistd::Group;
 use tracing::{span, Span};
 
-use super::{CreateNixTree, DeleteUsersInGroup};
+use super::CreateNixTree;
 use crate::{
     action::{
-        base::{CreateGroup, FetchAndUnpackNix, MoveUnpackedNix},
+        base::{FetchAndUnpackNix, MoveUnpackedNix},
         Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
     },
     settings::{CommonSettings, SCRATCH_DIR},

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -54,6 +54,17 @@ impl CommandExecute for Uninstall {
 
         ensure_root()?;
 
+        if let Ok(current_dir) = std::env::current_dir() {
+            let mut components = current_dir.components();
+            let should_be_root = components.next();
+            let maybe_nix = components.next();
+            if should_be_root == Some(std::path::Component::RootDir)
+                && maybe_nix == Some(std::path::Component::Normal(std::ffi::OsStr::new("nix")))
+            {
+                std::env::set_current_dir("/").wrap_err("Uninstall process was run from `/nix` folder, but could not change directory away from `/nix`, please change the current directory and try again.")?;
+            }
+        }
+
         // During install, `nix-installer` will store a copy of itself in `/nix/nix-installer`
         // If the user opted to run that particular copy of `nix-installer` to do this uninstall,
         // well, we have a problem, since the binary would delete itself.

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -61,6 +61,7 @@ impl CommandExecute for Uninstall {
             if should_be_root == Some(std::path::Component::RootDir)
                 && maybe_nix == Some(std::path::Component::Normal(std::ffi::OsStr::new("nix")))
             {
+                tracing::debug!("Changing current directory to be outside of `/nix`");
                 std::env::set_current_dir("/").wrap_err("Uninstall process was run from `/nix` folder, but could not change directory away from `/nix`, please change the current directory and try again.")?;
             }
         }


### PR DESCRIPTION
##### Description

Also includes a couple missed warnings from last PR (#524 )

Fixes #517 .

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
