### PR TITLE
Use ssl-cert-file config

### DIFF
--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -46,6 +46,7 @@ impl ConfigureNix {
         };
         let place_nix_configuration = PlaceNixConfiguration::plan(
             settings.nix_build_group_name.clone(),
+            settings.ssl_cert_file.clone(),
             settings.extra_conf.clone(),
             settings.force,
         )

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -34,12 +34,9 @@ impl ConfigureNix {
 
         let configure_shell_profile = if settings.modify_profile {
             Some(
-                ConfigureShellProfile::plan(
-                    shell_profile_locations,
-                    settings.ssl_cert_file.clone(),
-                )
-                .await
-                .map_err(Self::error)?,
+                ConfigureShellProfile::plan(shell_profile_locations)
+                    .await
+                    .map_err(Self::error)?,
             )
         } else {
             None

--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -26,25 +26,13 @@ impl ConfigureShellProfile {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         locations: ShellProfileLocations,
-        ssl_cert_file: Option<PathBuf>,
     ) -> Result<StatefulAction<Self>, ActionError> {
         let mut create_or_insert_files = Vec::default();
         let mut create_directories = Vec::default();
 
-        let maybe_ssl_cert_file_setting = if let Some(ssl_cert_file) = ssl_cert_file {
-            format!(
-                "export NIX_SSL_CERT_FILE={:?}\n",
-                ssl_cert_file.canonicalize().map_err(|e| {
-                    Self::error(ActionErrorKind::Canonicalize(ssl_cert_file, e))
-                })?
-            )
-        } else {
-            "".to_string()
-        };
         let shell_buf = format!(
             "\n\
             # Nix\n\
-            {maybe_ssl_cert_file_setting}\
             if [ -e '{PROFILE_NIX_FILE_SHELL}' ]; then\n\
             {inde}. '{PROFILE_NIX_FILE_SHELL}'\n\
             fi\n\
@@ -80,7 +68,6 @@ impl ConfigureShellProfile {
         let fish_buf = format!(
             "\n\
             # Nix\n\
-            {maybe_ssl_cert_file_setting}\
             if test -e '{PROFILE_NIX_FILE_FISH}'\n\
             {inde}. '{PROFILE_NIX_FILE_FISH}'\n\
             end\n\

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -6,6 +6,7 @@ use crate::action::{
     Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
 };
 use std::collections::hash_map::Entry;
+use std::path::PathBuf;
 
 const NIX_CONF_FOLDER: &str = "/etc/nix";
 const NIX_CONF: &str = "/etc/nix/nix.conf";
@@ -23,6 +24,7 @@ impl PlaceNixConfiguration {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(
         nix_build_group_name: String,
+        ssl_cert_file: Option<PathBuf>,
         extra_conf: Vec<String>,
         force: bool,
     ) -> Result<StatefulAction<Self>, ActionError> {
@@ -53,6 +55,12 @@ impl PlaceNixConfiguration {
             "bash-prompt-prefix".to_string(),
             "(nix:$name)\\040".to_string(),
         );
+        if let Some(ssl_cert_file) = ssl_cert_file {
+            settings.insert(
+                "ssl-cert-file".to_string(),
+                ssl_cert_file.display().to_string(),
+            );
+        }
         settings.insert(
             "extra-nix-path".to_string(),
             "nixpkgs=flake:nixpkgs".to_string(),

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -56,9 +56,12 @@ impl PlaceNixConfiguration {
             "(nix:$name)\\040".to_string(),
         );
         if let Some(ssl_cert_file) = ssl_cert_file {
+            let ssl_cert_file_canonical = ssl_cert_file
+                .canonicalize()
+                .map_err(|e| Self::error(ActionErrorKind::Canonicalize(ssl_cert_file, e)))?;
             settings.insert(
                 "ssl-cert-file".to_string(),
-                ssl_cert_file.display().to_string(),
+                ssl_cert_file_canonical.display().to_string(),
             );
         }
         settings.insert(

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -307,7 +307,7 @@ impl CommandExecute for Install {
                 println!(
                     "\
                     {success}\n\
-                    To get started using Nix, open a new shell or run `{maybe_ssl_cert_file_reminder}{shell_reminder}`\n\
+                    To get started using Nix, open a new shell or run `{shell_reminder}`\n\
                     ",
                     success = "Nix was installed successfully!".green().bold(),
                     shell_reminder = match std::env::var("SHELL") {
@@ -316,16 +316,6 @@ impl CommandExecute for Install {
                         Ok(_) | Err(_) =>
                             ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh".bold(),
                     },
-                    maybe_ssl_cert_file_reminder = if let Some(ssl_cert_file) = &settings.ssl_cert_file {
-                        format!(
-                            "export NIX_SSL_CERT_FILE={:?}; ",
-                            ssl_cert_file
-                                .canonicalize()
-                                .map_err(|e| { eyre!(e).wrap_err(format!("Could not canonicalize {}", ssl_cert_file.display())) })?
-                        )
-                    } else {
-                        "".to_string()
-                    }
                 );
             },
         }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -174,8 +174,10 @@ impl DiagnosticData {
                 tracing::debug!("Sending diagnostic to `{endpoint}`");
                 let mut buildable_client = reqwest::Client::builder();
                 if let Some(ssl_cert_file) = &self.ssl_cert_file {
-                    let ssl_cert = parse_ssl_cert(&ssl_cert_file).await?;
-                    buildable_client = buildable_client.add_root_certificate(ssl_cert);
+                    let ssl_cert = parse_ssl_cert(&ssl_cert_file).await.ok();
+                    if let Some(ssl_cert) = ssl_cert {
+                        buildable_client = buildable_client.add_root_certificate(ssl_cert);
+                    }
                 }
                 let client = buildable_client
                     .build()

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -89,7 +89,7 @@ impl DiagnosticData {
             os_version,
             triple: target_lexicon::HOST.to_string(),
             is_ci,
-            ssl_cert_file,
+            ssl_cert_file: ssl_cert_file.and_then(|v| v.canonicalize().ok()),
             failure_chain: None,
         })
     }

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -88,14 +88,10 @@ impl Planner for Linux {
         }
 
         plan.push(
-            ConfigureInitService::plan(
-                self.init.init,
-                self.init.start_daemon,
-                self.settings.ssl_cert_file.clone(),
-            )
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed(),
+            ConfigureInitService::plan(self.init.init, self.init.start_daemon)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
         );
         plan.push(
             RemoveDirectory::plan(crate::settings::SCRATCH_DIR)

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -157,14 +157,10 @@ impl Planner for Macos {
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),
-            ConfigureInitService::plan(
-                InitSystem::Launchd,
-                true,
-                self.settings.ssl_cert_file.clone(),
-            )
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed(),
+            ConfigureInitService::plan(InitSystem::Launchd, true)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
             RemoveDirectory::plan(crate::settings::SCRATCH_DIR)
                 .await
                 .map_err(PlannerError::Action)?

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -334,14 +334,10 @@ impl Planner for SteamDeck {
                 .map_err(PlannerError::Action)?
                 .boxed(),
             // Init is required for the steam-deck archetype to make the `/nix` mount
-            ConfigureInitService::plan(
-                InitSystem::Systemd,
-                true,
-                self.settings.ssl_cert_file.clone(),
-            )
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed(),
+            ConfigureInitService::plan(InitSystem::Systemd, true)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
             StartSystemdUnit::plan("ensure-symlinked-units-resolve.service".to_string(), true)
                 .await
                 .map_err(PlannerError::Action)?


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/516, uses https://github.com/NixOS/nix/pull/8062

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
