### PR TITLE
Fix devshell on i686

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,6 @@
             ])
             ++ lib.optionals (pkgs.stdenv.isLinux) (with pkgs; [
               checkpolicy
-              podman
               semodule-utils
               /* users are expected to have a system docker, too */
             ]);


### PR DESCRIPTION
##### Description

Resolves this issue:

```
❯ nix flake check -L
warning: Git tree '/home/ana/git/determinatesystems/harmonic' is dirty
error:
       … while checking flake output 'devShells'

         at /nix/store/3nayh6jyn7ssyr8ijx8shz7sy9kdb5jz-source/flake.nix:123:7:

          122|
          123|       devShells = forAllSystems ({ system, pkgs, ... }:
             |       ^
          124|         let

       … while checking the derivation 'devShells.i686-linux.default'

         at /nix/store/3nayh6jyn7ssyr8ijx8shz7sy9kdb5jz-source/flake.nix:130:11:

          129|         {
          130|           default = pkgs.mkShell {
             |           ^
          131|             name = "nix-install-shell";

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: Package ‘criu-3.17.1’ in /nix/store/hmdjvalbmsb9x9wir7xq8y623abjl55w-source/pkgs/os-specific/linux/criu/default.nix:116 is not available on the requested hostPlatform:
         hostPlatform.config = "i686-unknown-linux-gnu"
         package.meta.platforms = [
           "x86_64-linux"
           "aarch64-linux"
           "armv7l-linux"
         ]
         package.meta.badPlatforms = [ ]
       , refusing to evaluate.

       a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1

        Note: For `nix shell`, `nix build`, `nix develop` or any other Nix 2.4+
        (Flake) command, `--impure` must be passed in order to read this
        environment variable.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnsupportedSystem = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnsupportedSystem = true; }
       to ~/.config/nixpkgs/config.nix.
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
