### PR TITLE
v0.10.1-unreleased

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.10.0"
+version = "0.10.1-unreleased"
 dependencies = [
  "async-trait",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix-installer"
 description = "The Determinate Nix Installer"
-version = "0.10.0"
+version = "0.10.1-unreleased"
 edition = "2021"
 resolver = "2"
 license = "LGPL-2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
           };
           sharedAttrs = {
             pname = "nix-installer";
-            version = "0.10.0";
+            version = "0.10.1-unreleased";
             src = builtins.path {
               name = "nix-installer-source";
               path = self;

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0",
+  "version": "0.10.1-unreleased",
   "actions": [
     {
       "action": {
@@ -359,7 +359,7 @@
     }
   },
   "diagnostic_data": {
-    "version": "0.10.0",
+    "version": "0.10.1-unreleased",
     "planner": "linux",
     "configured_settings": [],
     "os_name": "Ubuntu",

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0",
+  "version": "0.10.1-unreleased",
   "actions": [
     {
       "action": {
@@ -385,7 +385,7 @@
     }
   },
   "diagnostic_data": {
-    "version": "0.10.0",
+    "version": "0.10.1-unreleased",
     "planner": "steam-deck",
     "configured_settings": [],
     "os_name": "Ubuntu",

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.10.0",
+  "version": "0.10.1-unreleased",
   "actions": [
     {
       "action": {
@@ -415,7 +415,7 @@
     "root_disk": "disk3"
   },
   "diagnostic_data": {
-    "version": "0.10.0",
+    "version": "0.10.1-unreleased",
     "planner": "macos",
     "configured_settings": [],
     "os_name": "unknown",


### PR DESCRIPTION
##### Description

Regular post-release bump


##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
