### PR TITLE
Add tracing around the Github Actions reinstall issue

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -270,11 +270,13 @@ impl Action for ConfigureInitService {
                     .await
                     .map_err(Self::error)?;
                 if Path::new(SERVICE_DEST).exists() {
+                    tracing::trace!(path = %SERVICE_DEST, "Removing");
                     tokio::fs::remove_file(SERVICE_DEST)
                         .await
                         .map_err(|e| ActionErrorKind::Remove(SERVICE_DEST.into(), e))
                         .map_err(Self::error)?;
                 }
+                tracing::trace!(src = %SERVICE_SRC, dest = %SERVICE_DEST, "Symlinking");
                 tokio::fs::symlink(SERVICE_SRC, SERVICE_DEST)
                     .await
                     .map_err(|e| {
@@ -289,11 +291,14 @@ impl Action for ConfigureInitService {
                     .await
                     .map_err(Self::error)?;
                 if Path::new(SOCKET_DEST).exists() {
+                    tracing::trace!(path = %SOCKET_DEST, "Removing");
                     tokio::fs::remove_file(SOCKET_DEST)
                         .await
                         .map_err(|e| ActionErrorKind::Remove(SOCKET_DEST.into(), e))
                         .map_err(Self::error)?;
                 }
+
+                tracing::trace!(src = %SOCKET_SRC, dest = %SOCKET_DEST, "Symlinking");
                 tokio::fs::symlink(SOCKET_SRC, SOCKET_DEST)
                     .await
                     .map_err(|e| {


### PR DESCRIPTION
##### Description

I wrote this while debugging https://github.com/DeterminateSystems/nix-installer-action/pull/30 and it turned out rather helpful.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
