### PR TITLE
bugfix: Let Mac users specify encryption directly

### DIFF
--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -108,25 +108,26 @@ impl Planner for Macos {
             },
         };
 
-        let encrypt = if self.encrypt == None {
-            let output = Command::new("/usr/bin/fdesetup")
-                .arg("isactive")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .process_group(0)
-                .output()
-                .await
-                .map_err(|e| PlannerError::Custom(Box::new(e)))?;
+        let encrypt = match self.encrypt {
+            Some(choice) => choice,
+            None => {
+                let output = Command::new("/usr/bin/fdesetup")
+                    .arg("isactive")
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .process_group(0)
+                    .output()
+                    .await
+                    .map_err(|e| PlannerError::Custom(Box::new(e)))?;
 
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let stdout_trimmed = stdout.trim();
-            if stdout_trimmed == "true" {
-                true
-            } else {
-                false
-            }
-        } else {
-            false
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stdout_trimmed = stdout.trim();
+                if stdout_trimmed == "true" {
+                    true
+                } else {
+                    false
+                }
+            },
         };
 
         Ok(vec![


### PR DESCRIPTION
##### Description

Should fix https://github.com/DeterminateSystems/nix-installer/issues/543

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
