### PR TITLE
Remove atty dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +217,7 @@ checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -805,13 +811,12 @@ checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix",
+ "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]
 
@@ -862,6 +867,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -937,7 +948,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -958,7 +969,6 @@ name = "nix-installer"
 version = "0.10.1-unreleased"
 dependencies = [
  "async-trait",
- "atty",
  "bytes 1.4.0",
  "clap",
  "color-eyre",
@@ -1207,7 +1217,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1216,7 +1226,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1329,11 +1339,24 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -1438,7 +1461,7 @@ version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1656,7 +1679,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed66d6a2ccbd656659289bc90767895b7abbdec897a0fc6031aca3ed1cb51d3e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -1691,7 +1714,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 
 [features]
 default = ["cli", "diagnostics"]
-cli = ["eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error", "atty"]
+cli = ["eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error"]
 diagnostics = ["is_ci"]
 
 [[bin]]
@@ -25,7 +25,6 @@ required-features = [ "cli" ]
 
 [dependencies]
 async-trait = { version = "0.1.57", default-features = false }
-atty = { version = "0.2.14", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false, features = ["std", "serde"] }
 clap = { version = "4", features = ["std", "color", "usage", "help", "error-context", "suggestions", "derive", "env"], optional = true }
 color-eyre = { version = "0.6.2", default-features = false, features = [ "track-caller", "issue-url", "tracing-error", "capture-spantrace", "color-spantrace" ], optional = true }

--- a/src/bin/nix-installer.rs
+++ b/src/bin/nix-installer.rs
@@ -1,4 +1,4 @@
-use std::process::ExitCode;
+use std::{io::IsTerminal, process::ExitCode};
 
 use clap::Parser;
 use nix_installer::cli::CommandExecute;
@@ -10,7 +10,7 @@ async fn main() -> eyre::Result<ExitCode> {
         .add_issue_metadata("version", env!("CARGO_PKG_VERSION"))
         .add_issue_metadata("os", std::env::consts::OS)
         .add_issue_metadata("arch", std::env::consts::ARCH)
-        .theme(if !atty::is(atty::Stream::Stderr) {
+        .theme(if !std::io::stderr().is_terminal() {
             color_eyre::config::Theme::new()
         } else {
             color_eyre::config::Theme::dark()

--- a/src/cli/arg/instrumentation.rs
+++ b/src/cli/arg/instrumentation.rs
@@ -1,6 +1,6 @@
-use atty::Stream;
 use eyre::WrapErr;
 use std::error::Error;
+use std::io::IsTerminal;
 use tracing_error::ErrorLayer;
 use tracing_subscriber::{
     filter::Directive, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
@@ -86,7 +86,7 @@ impl<'a> Instrumentation {
         S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
     {
         tracing_subscriber::fmt::Layer::new()
-            .with_ansi(atty::is(Stream::Stderr))
+            .with_ansi(std::io::stderr().is_terminal())
             .with_writer(std::io::stderr)
     }
 
@@ -95,7 +95,7 @@ impl<'a> Instrumentation {
         S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
     {
         tracing_subscriber::fmt::Layer::new()
-            .with_ansi(atty::is(Stream::Stderr))
+            .with_ansi(std::io::stderr().is_terminal())
             .with_writer(std::io::stderr)
             .pretty()
     }
@@ -105,7 +105,7 @@ impl<'a> Instrumentation {
         S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
     {
         tracing_subscriber::fmt::Layer::new()
-            .with_ansi(atty::is(Stream::Stderr))
+            .with_ansi(std::io::stderr().is_terminal())
             .with_writer(std::io::stderr)
             .json()
     }
@@ -115,7 +115,7 @@ impl<'a> Instrumentation {
         S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
     {
         tracing_subscriber::fmt::Layer::new()
-            .with_ansi(atty::is(Stream::Stderr))
+            .with_ansi(std::io::stderr().is_terminal())
             .with_writer(std::io::stderr)
             .compact()
             .without_time()


### PR DESCRIPTION
##### Description

https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html exists now! Yay!

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
