### PR TITLE
`launchctl bootstrap` fails with disabled in a dirty state

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -200,8 +200,7 @@ impl Action for ConfigureInitService {
                         Command::new("launchctl")
                             .process_group(0)
                             .arg("enable")
-                            .arg(&domain)
-                            .arg(&service)
+                            .arg(&format!("{domain}/{service}"))
                             .stdin(std::process::Stdio::null()),
                     )
                     .await

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -192,7 +192,7 @@ impl Action for ConfigureInitService {
                 let domain = "system";
                 let service = "org.nixos.nix-daemon";
 
-                let is_disabled = service_is_disabled(&domain, &service)
+                let is_disabled = crate::action::macos::service_is_disabled(&domain, &service)
                     .await
                     .map_err(Self::error)?;
                 if *is_disabled {

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -189,13 +189,32 @@ impl Action for ConfigureInitService {
                 .await
                 .map_err(Self::error)?;
 
+                let domain = "system";
+                let path = "org.nixos.nix-daemon";
+
+                let is_disabled = service_is_disabled(&domain, &service)
+                    .await
+                    .map_err(Self::error)?;
+                if *is_disabled {
+                    execute_command(
+                        Command::new("launchctl")
+                            .process_group(0)
+                            .arg("enable")
+                            .arg(&domain)
+                            .arg(&service)
+                            .stdin(std::process::Stdio::null()),
+                    )
+                    .await
+                    .map_err(Self::error)?;
+                }
+
                 if *start_daemon {
                     execute_command(
                         Command::new("launchctl")
                             .process_group(0)
                             .arg("kickstart")
                             .arg("-k")
-                            .arg("system/org.nixos.nix-daemon")
+                            .arg(&format!("{domain}/{service}"))
                             .stdin(std::process::Stdio::null()),
                     )
                     .await

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -190,7 +190,7 @@ impl Action for ConfigureInitService {
                 .map_err(Self::error)?;
 
                 let domain = "system";
-                let path = "org.nixos.nix-daemon";
+                let service = "org.nixos.nix-daemon";
 
                 let is_disabled = service_is_disabled(&domain, &service)
                     .await

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -195,7 +195,7 @@ impl Action for ConfigureInitService {
                 let is_disabled = crate::action::macos::service_is_disabled(&domain, &service)
                     .await
                     .map_err(Self::error)?;
-                if *is_disabled {
+                if is_disabled {
                     execute_command(
                         Command::new("launchctl")
                             .process_group(0)

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -123,8 +123,7 @@ impl Action for BootstrapLaunchctlService {
                 Command::new("launchctl")
                     .process_group(0)
                     .arg("enable")
-                    .arg(&domain)
-                    .arg(&service)
+                    .arg(&format!("{domain}/{service}"))
                     .stdin(std::process::Stdio::null()),
             )
             .await

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -93,6 +93,7 @@ pub(crate) async fn service_is_disabled(
     )
     .await?;
     let utf8_output = String::from_utf8_lossy(&output.stdout);
-
-    Ok(utf8_output.contains(&format!("\"{service}\" => disabled")))
+    let is_disabled = utf8_output.contains(&format!("\"{service}\" => disabled"));
+    tracing::trace!(is_disabled, "Service disabled status");
+    Ok(is_disabled)
 }

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -79,7 +79,10 @@ struct DiskUtilApfsInfoOutput {
 }
 
 #[tracing::instrument]
-async fn service_is_disabled(domain: &str, service: &str) -> Result<bool, ActionErrorKind> {
+pub(crate) async fn service_is_disabled(
+    domain: &str,
+    service: &str,
+) -> Result<bool, ActionErrorKind> {
     let output = execute_command(
         Command::new("launchctl")
             .arg("print-disabled")

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -61,7 +61,9 @@
           "action": {
             "domain": "system",
             "service": "org.nixos.darwin-store",
-            "path": "/Library/LaunchDaemons/org.nixos.darwin-store.plist"
+            "path": "/Library/LaunchDaemons/org.nixos.darwin-store.plist",
+            "is_present": false,
+            "is_disabled": false
           },
           "state": "Uncompleted"
         },


### PR DESCRIPTION
##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/530.

Teaches the installer to re-enable a service before bootstrapping it.

```
% sudo launchctl disable system/org.nixos.nix-daemon
% sudo launchctl disable system/org.nixos.darwin-store
% sudo launchctl print-disabled system

        disabled services = {
                # ...
                "org.nixos.darwin-store" => disabled
                "org.nixos.nix-daemon" => disabled
                # ...
        }
% ./nix-installer install
`nix-installer` needs to run as `root`, attempting to escalate now via `sudo`...
Nix install plan (v0.10.1-unreleased)
Planner: macos (with default settings)

Planned actions:
* Create an APFS volume `Nix Store` for Nix on `disk3` and add it to `/etc/fstab` mounting on `/nix`
* Fetch `https://releases.nixos.org/nix/nix-2.15.0/nix-2.15.0-aarch64-darwin.tar.xz` to `/nix/temp-install-dir`
* Create a directory tree in `/nix`
* Move the downloaded Nix into `/nix`
* Create build users (UID 300-332) and group (GID 30000)
* Configure Time Machine exclusions
* Setup the default Nix profile
* Place the Nix configuration in `/etc/nix/nix.conf`
* Configure the shell profiles
* Configure Nix daemon related settings with launchctl
* Remove directory `/nix/temp-install-dir`


Proceed? ([Y]es/[n]o/[e]xplain): y
 INFO Step: Create an APFS volume `Nix Store` for Nix on `disk3` and add it to `/etc/fstab` mounting on `/nix`
 INFO Step: Provision Nix
 INFO Step: Create build users (UID 300-332) and group (GID 30000)
 INFO Step: Configure Time Machine exclusions
 INFO Step: Configure Nix
 INFO Step: Configure Nix daemon related settings with launchctl
 INFO Step: Remove directory `/nix/temp-install-dir`
Nix was installed successfully!
To get started using Nix, open a new shell or run `. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh`

% sudo launchctl print-disabled system

        disabled services = {
                # ...
                "org.nixos.darwin-store" => enabled
                "org.nixos.nix-daemon" => enabled
                # ...
        }
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
