### PR TITLE
Turn off auto-optimize-store on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Differing from the current official [Nix](https://github.com/NixOS/nix) installe
 * In `nix.conf`:
   + the `auto-allocate-uids`, `nix-command` and `flakes` features are enabled
   + `bash-prompt-prefix` is set
-  + `auto-optimise-store` is set to `true` (On Linux only)
   * `extra-nix-path` is set to `nixpkgs=flake:nixpkgs`
   * `auto-allocate-uids` is set to `true`.  (On Linux only)
 * an installation receipt (for uninstalling) is stored at `/nix/receipt.json` as well as a copy of the install binary at `/nix/nix-installer`

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -51,10 +51,6 @@ impl PlaceNixConfiguration {
             },
         };
 
-        // https://github.com/DeterminateSystems/nix-installer/issues/449#issuecomment-1551782281
-        #[cfg(not(target_os = "macos"))]
-        settings.insert("auto-optimise-store".to_string(), "true".to_string());
-
         settings.insert(
             "bash-prompt-prefix".to_string(),
             "(nix:$name)\\040".to_string(),

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -321,7 +321,6 @@
                   "settings": {
                     "experimental-features": "nix-command flakes auto-allocate-uids",
                     "build-users-group": "nixbld",
-                    "auto-optimise-store": "true",
                     "bash-prompt-prefix": "(nix:$name)\\040",
                     "extra-nix-path": "nixpkgs=flake:nixpkgs",
                     "auto-allocate-uids": "true"

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -339,7 +339,6 @@
                 "path": "/etc/nix/nix.conf",
                 "pending_nix_config": {
                   "settings": {
-                    "auto-optimise-store": "true",
                     "bash-prompt-prefix": "(nix:$name)\\040",
                     "build-users-group": "nixbld",
                     "experimental-features": "nix-command flakes auto-allocate-uids",

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -377,7 +377,6 @@
                   "settings": {
                     "extra-nix-path": "nixpkgs=flake:nixpkgs",
                     "auto-allocate-uids": "true",
-                    "auto-optimise-store": "true",
                     "build-users-group": "nixbld",
                     "bash-prompt-prefix": "(nix:$name)\\040",
                     "experimental-features": "nix-command flakes auto-allocate-uids"


### PR DESCRIPTION
##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/564

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
