### PR TITLE
Remove unneeded lifetime

### DIFF
--- a/src/cli/arg/instrumentation.rs
+++ b/src/cli/arg/instrumentation.rs
@@ -42,7 +42,7 @@ pub struct Instrumentation {
     pub log_directives: Vec<Directive>,
 }
 
-impl<'a> Instrumentation {
+impl Instrumentation {
     pub fn log_level(&self) -> String {
         match self.verbose {
             0 => "info",
@@ -52,7 +52,7 @@ impl<'a> Instrumentation {
         .to_string()
     }
 
-    pub fn setup<'b: 'a>(&'b self) -> eyre::Result<()> {
+    pub fn setup(&self) -> eyre::Result<()> {
         let filter_layer = self.filter_layer()?;
 
         let registry = tracing_subscriber::registry()


### PR DESCRIPTION
##### Description

Remove unneeded lifetime

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
