### PR TITLE
Enable clippy on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v1
       - name: Check rustfmt
         run: nix develop --command check-rustfmt
+      - name: Check Clippy
+        run: nix develop --command check-clippy
       - name: Check Spelling
         run: nix develop --command check-spelling
       - name: Check nixpkgs-fmt formatting

--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,7 @@
               check.check-nixpkgs-fmt
               check.check-editorconfig
               check.check-semver
+              check.check-clippy
             ]
             ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [
               libiconv

--- a/nix/check.nix
+++ b/nix/check.nix
@@ -50,4 +50,13 @@ in
       cargo-semver-checks semver-checks check-release
     '';
   });
+  # Clippy
+  check-clippy = (writeShellApplication {
+    name = "check-clippy";
+    runtimeInputs = with pkgs; [ cargo clippy ];
+    text = ''
+      cargo clippy
+    '';
+  });
+
 }

--- a/src/cli/subcommand/mod.rs
+++ b/src/cli/subcommand/mod.rs
@@ -7,6 +7,7 @@ use uninstall::Uninstall;
 mod self_test;
 use self_test::SelfTest;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, clap::Subcommand)]
 pub enum NixInstallerSubcommand {
     Plan(Plan),


### PR DESCRIPTION
##### Description

Because of https://github.com/DeterminateSystems/nix-installer/pull/572 (thanks @Hofer-Julian !) We can enable Clippy in CI.

It was enabled previously at one point, but we disabled it during early development and we never re-enabled it.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
