### PR TITLE
Check versions on uninstall for safety

### DIFF
--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     cli::{ensure_root, interaction::PromptChoice, signal_channel},
     error::HasExpectedErrors,
-    plan::RECEIPT_LOCATION,
+    plan::{current_version, RECEIPT_LOCATION},
     InstallPlan, NixInstallerError,
 };
 use clap::{ArgAction, Parser};
@@ -111,7 +111,48 @@ impl CommandExecute for Uninstall {
         let install_receipt_string = tokio::fs::read_to_string(receipt)
             .await
             .wrap_err("Reading receipt")?;
-        let mut plan: InstallPlan = serde_json::from_str(&install_receipt_string)?;
+
+        let mut plan: InstallPlan = match serde_json::from_str(&install_receipt_string) {
+            Ok(plan) => plan,
+            Err(plan_err) => {
+                #[derive(serde::Deserialize)]
+                struct MinimalPlan {
+                    version: semver::Version,
+                }
+                let minimal_plan: Result<MinimalPlan, _> =
+                    serde_json::from_str(&install_receipt_string);
+                match minimal_plan {
+                    Ok(minimal_plan) => {
+                        return Err(plan_err).wrap_err_with(|| {
+                            let plan_version = minimal_plan.version;
+                            let current_version = current_version().map(|v| v.to_string()).unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
+                            format!(
+                            "\
+                            Unable to parse plan, this plan was created by `nix-installer` version `{plan_version}`, this is `nix-installer` version `{current_version}`\n\
+                            To uninstall, either run  `/nix/nix-installer uninstall` or `curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/tag/{plan_version} | sh -s -- uninstall`\
+                            ").red().to_string()
+                        });
+                    },
+                    Err(_minimal_plan_err) => return Err(plan_err)?,
+                }
+            },
+        };
+
+        if let Err(e) = plan.check_compatible() {
+            let version = plan.version;
+            eprintln!(
+                "{}", 
+                format!("\
+                    {e}\n\
+                    \n\
+                    Found existing plan in `{RECEIPT_LOCATION}` which was created by a version incompatible `nix-installer`.\n\
+                    \n
+                    To uninstall, either run `/nix/nix-installer uninstall` or `curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/tag/${version} | sh -s -- uninstall`\n\
+                    \n\
+                ").red()
+            );
+            return Ok(ExitCode::FAILURE);
+        }
 
         if let Err(err) = plan.pre_uninstall_check().await {
             if let Some(expected) = err.expected() {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -425,7 +425,7 @@ async fn write_receipt(plan: InstallPlan) -> Result<(), NixInstallerError> {
     Result::<(), NixInstallerError>::Ok(())
 }
 
-fn current_version() -> Result<Version, NixInstallerError> {
+pub fn current_version() -> Result<Version, NixInstallerError> {
     let nix_installer_version_str = env!("CARGO_PKG_VERSION");
     Version::from_str(nix_installer_version_str).map_err(|e| {
         NixInstallerError::InvalidCurrentVersion(nix_installer_version_str.to_string(), e)


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/575

I am rather embarassed I never added this. I fully intended to. 😓 

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
