### PR TITLE
Teach installer about Clear Linux

### DIFF
--- a/src/action/common/configure_shell_profile.rs
+++ b/src/action/common/configure_shell_profile.rs
@@ -45,11 +45,11 @@ impl ConfigureShellProfile {
             let profile_target_path = Path::new(profile_target);
             if let Some(parent) = profile_target_path.parent() {
                 if !parent.exists() {
-                    tracing::trace!(
-                        "Did not plan to edit `{}` as its parent folder does not exist.",
-                        profile_target.display(),
+                    create_directories.push(
+                        CreateDirectory::plan(parent, None, None, 0o0755, false)
+                            .await
+                            .map_err(Self::error)?,
                     );
-                    continue;
                 }
                 create_or_insert_files.push(
                     CreateOrInsertIntoFile::plan(
@@ -60,7 +60,8 @@ impl ConfigureShellProfile {
                         shell_buf.to_string(),
                         create_or_insert_into_file::Position::Beginning,
                     )
-                    .await?,
+                    .await
+                    .map_err(Self::error)?,
                 );
             }
         }

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -78,6 +78,13 @@ impl Planner for Linux {
         }
 
         plan.push(
+            CreateDirectory::plan("/etc/tmpfiles.d", None, None, 0o0755, false)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
+        );
+
+        plan.push(
             ConfigureInitService::plan(self.init.init, self.init.start_daemon)
                 .await
                 .map_err(PlannerError::Action)?


### PR DESCRIPTION
##### Description

This should address https://github.com/DeterminateSystems/nix-installer/issues/391.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
