### PR TITLE
Make self-test errors a warning only

### DIFF
--- a/src/cli/subcommand/mod.rs
+++ b/src/cli/subcommand/mod.rs
@@ -7,6 +7,7 @@ use uninstall::Uninstall;
 mod self_test;
 use self_test::SelfTest;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, clap::Subcommand)]
 pub enum NixInstallerSubcommand {
     Plan(Plan),

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -228,7 +228,7 @@ impl InstallPlan {
                     .await?;
             }
 
-            Err(err)
+            tracing::warn!("{err:?}")
         } else {
             #[cfg(feature = "diagnostics")]
             if let Some(diagnostic_data) = &self.diagnostic_data {
@@ -240,9 +240,9 @@ impl InstallPlan {
                     )
                     .await?;
             }
-
-            Ok(())
         }
+
+        Ok(())
     }
 
     #[tracing::instrument(level = "debug", skip_all)]


### PR DESCRIPTION
##### Description

Make self-test errors a warning, should address some of the scariness users face when they see things like https://github.com/DeterminateSystems/nix-installer/issues/583.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
