### PR TITLE
Fix the Mac CI with Silverblue

### DIFF
--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -207,6 +207,7 @@ impl BuiltinPlanner {
         }
     }
 
+    #[cfg(target_os = "linux")]
     async fn detect_linux_distro() -> Result<Self, PlannerError> {
         let is_steam_deck =
             os_release::OsRelease::new().is_ok_and(|os_release| os_release.id == "steamos");


### PR DESCRIPTION
##### Description

https://github.com/DeterminateSystems/nix-installer/pull/586 wasn't working on Mac, so this fixes it.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
