### PR TITLE
Uninvert EnableOwnership logic

### DIFF
--- a/src/action/macos/enable_ownership.rs
+++ b/src/action/macos/enable_ownership.rs
@@ -68,7 +68,7 @@ impl Action for EnableOwnership {
             let the_plist: DiskUtilInfoOutput =
                 plist::from_reader(Cursor::new(buf)).map_err(Self::error)?;
 
-            the_plist.global_permissions_enabled
+            !the_plist.global_permissions_enabled
         };
 
         if should_enable_ownership {


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/582.

This was tested on Detsys's ephemeral Macs.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
