### PR TITLE
Set max jobs to auto

### DIFF
--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -47,6 +47,7 @@ impl PlaceNixConfiguration {
 
         defaults_conf_settings.push(("bash-prompt-prefix", "(nix:$name)\\040".into()));
         defaults_conf_settings.push(("extra-nix-path", "nixpkgs=flake:nixpkgs".into()));
+        defaults_conf_settings.push(("max-jobs", "auto".to_string()));
         if let Some(ssl_cert_file) = ssl_cert_file {
             let ssl_cert_file_canonical = ssl_cert_file
                 .canonicalize()


### PR DESCRIPTION
##### Description

1 is the default on non-NixOS and that's lame.

https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-max-jobs

Depends on #620 

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
