### PR TITLE
Add support for URLs or paths in --nix-package-url and --extra-conf

### DIFF
--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -43,6 +43,7 @@ impl ConfigureNix {
         };
         let place_nix_configuration = PlaceNixConfiguration::plan(
             settings.nix_build_group_name.clone(),
+            settings.proxy.clone(),
             settings.ssl_cert_file.clone(),
             settings.extra_conf.clone(),
             settings.force,

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -198,7 +198,7 @@ use std::{error::Error, process::Output};
 use tokio::task::JoinError;
 use tracing::Span;
 
-use crate::{error::HasExpectedErrors, CertificateError};
+use crate::{error::HasExpectedErrors, settings::UrlOrPathError, CertificateError};
 
 use self::base::create_or_insert_into_file::Position;
 
@@ -584,6 +584,16 @@ pub enum ActionErrorKind {
     SystemdMissing,
     #[error("`{command}` failed, message: {message}")]
     DiskUtilInfoError { command: String, message: String },
+    #[error(transparent)]
+    UrlOrPathError(#[from] UrlOrPathError),
+    #[error("Request error")]
+    Reqwest(
+        #[from]
+        #[source]
+        reqwest::Error,
+    ),
+    #[error("Unknown url scheme")]
+    UnknownUrlScheme,
 }
 
 impl ActionErrorKind {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,9 +1,9 @@
 /*! Configurable knobs and their related errors
 */
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
 
 #[cfg(feature = "cli")]
-use clap::ArgAction;
+use clap::{ArgAction, error::{ContextKind, ContextValue}};
 use url::Url;
 
 pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
@@ -146,7 +146,7 @@ pub struct CommonSettings {
     /// The Nix package URL
     #[cfg_attr(
         feature = "cli",
-        clap(long, env = "NIX_INSTALLER_NIX_PACKAGE_URL", global = true)
+        clap(long, env = "NIX_INSTALLER_NIX_PACKAGE_URL", global = true, value_parser = clap::value_parser!(UrlOrPath))
     )]
     #[cfg_attr(
         all(target_os = "macos", target_arch = "x86_64", feature = "cli"),
@@ -178,7 +178,7 @@ pub struct CommonSettings {
             default_value = NIX_AARCH64_LINUX_URL,
         )
     )]
-    pub nix_package_url: Url,
+    pub nix_package_url: UrlOrPath,
 
     /// The proxy to use (if any), valid proxy bases are `https://$URL`, `http://$URL` and `socks5://$URL`
     #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_PROXY"))]
@@ -190,7 +190,7 @@ pub struct CommonSettings {
 
     /// Extra configuration lines for `/etc/nix.conf`
     #[cfg_attr(feature = "cli", clap(long, action = ArgAction::Append, num_args = 0.., env = "NIX_INSTALLER_EXTRA_CONF", global = true))]
-    pub extra_conf: Vec<String>,
+    pub extra_conf: Vec<UrlOrPathOrString>,
 
     /// If `nix-installer` should forcibly recreate files it finds existing
     #[cfg_attr(
@@ -366,6 +366,7 @@ impl CommonSettings {
         Ok(map)
     }
 }
+
 #[cfg(target_os = "linux")]
 async fn linux_detect_systemd_started() -> bool {
     use std::process::Stdio;
@@ -498,6 +499,193 @@ pub enum InstallSettingsError {
     ),
     #[error("No supported init system found")]
     InitNotSupported,
+    #[error(transparent)]
+    UrlOrPath(#[from] UrlOrPathError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UrlOrPathError {
+    #[error("Error parsing URL `{0}`")]
+    Url(String, #[source] url::ParseError),
+    #[error("The specified path `{0}` does not exist")]
+    PathDoesNotExist(PathBuf),
+    #[error("Error fetching URL `{0}`")]
+    Reqwest(Url, #[source] reqwest::Error),
+    #[error("I/O error when accessing `{0}`")]
+    Io(PathBuf, #[source] std::io::Error),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Clone)]
+pub enum UrlOrPath {
+    Url(Url),
+    Path(PathBuf),
+}
+
+impl Display for UrlOrPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UrlOrPath::Url(url) => f.write_fmt(format_args!("{url}")),
+            UrlOrPath::Path(path) => f.write_fmt(format_args!("{}", path.display())),
+        }
+    }
+}
+
+impl FromStr for UrlOrPath {
+    type Err = UrlOrPathError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match Url::parse(s) {
+            Ok(url) => Ok(UrlOrPath::Url(url)),
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                // This is most likely a relative path (`./boop` or `boop`)
+                // or an absolute path (`/boop`)
+                //
+                // So we'll see if such a path exists, and if so, use it
+                let path = PathBuf::from(s);
+                if path.exists() {
+                    Ok(UrlOrPath::Path(path))
+                } else {
+                    Err(UrlOrPathError::PathDoesNotExist(path))
+                }
+            },
+            Err(e) => Err(UrlOrPathError::Url(s.to_string(), e)),
+        }
+    }
+}
+
+#[cfg(feature = "cli")]
+impl clap::builder::TypedValueParser for UrlOrPath {
+    type Value = UrlOrPath;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        _arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let value_str = value.to_str().ok_or_else(|| {
+            let mut err = clap::Error::new(clap::error::ErrorKind::InvalidValue);
+            err.insert(
+                ContextKind::InvalidValue,
+                ContextValue::String(format!("`{value:?}` not a UTF-8 string")),
+            );
+            err
+        })?;
+        match UrlOrPath::from_str(value_str) {
+            Ok(v) => Ok(v),
+            Err(from_str_error) => {
+                let mut err = clap::Error::new(clap::error::ErrorKind::InvalidValue).with_cmd(cmd);
+                err.insert(
+                    clap::error::ContextKind::Custom,
+                    clap::error::ContextValue::String(from_str_error.to_string()),
+                );
+                Err(err)
+            },
+        }
+    }
+}
+
+#[test]
+fn url_or_path_parses() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(
+        UrlOrPath::from_str("https://boop.bleat")?,
+        UrlOrPath::Url(Url::from_str("https://boop.bleat")?),
+    );
+    assert_eq!(
+        UrlOrPath::from_str("file:///boop/bleat")?,
+        UrlOrPath::Url(Url::from_str("file:///boop/bleat")?),
+    );
+    // The file *must* exist!
+    assert_eq!(
+        UrlOrPath::from_str(file!())?,
+        UrlOrPath::Path(PathBuf::from_str(file!())?),
+    );
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Clone)]
+pub enum UrlOrPathOrString {
+    Url(Url),
+    Path(PathBuf),
+    String(String),
+}
+
+impl FromStr for UrlOrPathOrString {
+    type Err = url::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match Url::parse(s) {
+            Ok(url) => Ok(UrlOrPathOrString::Url(url)),
+            Err(url::ParseError::RelativeUrlWithoutBase) => {
+                // This is most likely a relative path (`./boop` or `boop`)
+                // or an absolute path (`/boop`)
+                //
+                // So we'll see if such a path exists, and if so, use it
+                let path = PathBuf::from(s);
+                if path.exists() {
+                    Ok(UrlOrPathOrString::Path(path))
+                } else {
+                    // The path doesn't exist, so the user is providing us with a string
+                    Ok(UrlOrPathOrString::String(s.into()))
+                }
+            },
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[cfg(feature = "cli")]
+impl clap::builder::TypedValueParser for UrlOrPathOrString {
+    type Value = UrlOrPathOrString;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        _arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let value_str = value.to_str().ok_or_else(|| {
+            let mut err = clap::Error::new(clap::error::ErrorKind::InvalidValue);
+            err.insert(
+                ContextKind::InvalidValue,
+                ContextValue::String(format!("`{value:?}` not a UTF-8 string")),
+            );
+            err
+        })?;
+        match UrlOrPathOrString::from_str(value_str) {
+            Ok(v) => Ok(v),
+            Err(from_str_error) => {
+                let mut err = clap::Error::new(clap::error::ErrorKind::InvalidValue).with_cmd(cmd);
+                err.insert(
+                    clap::error::ContextKind::Custom,
+                    clap::error::ContextValue::String(from_str_error.to_string()),
+                );
+                Err(err)
+            },
+        }
+    }
+}
+
+#[test]
+fn url_or_path_or_string_parses() -> Result<(), Box<dyn std::error::Error>> {
+    assert_eq!(
+        UrlOrPathOrString::from_str("https://boop.bleat")?,
+        UrlOrPathOrString::Url(Url::from_str("https://boop.bleat")?),
+    );
+    assert_eq!(
+        UrlOrPathOrString::from_str("file:///boop/bleat")?,
+        UrlOrPathOrString::Url(Url::from_str("file:///boop/bleat")?),
+    );
+    // The file *must* exist!
+    assert_eq!(
+        UrlOrPathOrString::from_str(file!())?,
+        UrlOrPathOrString::Path(PathBuf::from_str(file!())?),
+    );
+    assert_eq!(
+        UrlOrPathOrString::from_str("Boop")?,
+        UrlOrPathOrString::String(String::from("Boop")),
+    );
+    Ok(())
 }
 
 #[cfg(feature = "diagnostics")]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -588,24 +588,6 @@ impl clap::builder::TypedValueParser for UrlOrPath {
     }
 }
 
-#[test]
-fn url_or_path_parses() -> Result<(), Box<dyn std::error::Error>> {
-    assert_eq!(
-        UrlOrPath::from_str("https://boop.bleat")?,
-        UrlOrPath::Url(Url::from_str("https://boop.bleat")?),
-    );
-    assert_eq!(
-        UrlOrPath::from_str("file:///boop/bleat")?,
-        UrlOrPath::Url(Url::from_str("file:///boop/bleat")?),
-    );
-    // The file *must* exist!
-    assert_eq!(
-        UrlOrPath::from_str(file!())?,
-        UrlOrPath::Path(PathBuf::from_str(file!())?),
-    );
-    Ok(())
-}
-
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize, Clone)]
 pub enum UrlOrPathOrString {
     Url(Url),
@@ -669,32 +651,55 @@ impl clap::builder::TypedValueParser for UrlOrPathOrString {
     }
 }
 
-#[test]
-fn url_or_path_or_string_parses() -> Result<(), Box<dyn std::error::Error>> {
-    assert_eq!(
-        UrlOrPathOrString::from_str("https://boop.bleat")?,
-        UrlOrPathOrString::Url(Url::from_str("https://boop.bleat")?),
-    );
-    assert_eq!(
-        UrlOrPathOrString::from_str("file:///boop/bleat")?,
-        UrlOrPathOrString::Url(Url::from_str("file:///boop/bleat")?),
-    );
-    // The file *must* exist!
-    assert_eq!(
-        UrlOrPathOrString::from_str(file!())?,
-        UrlOrPathOrString::Path(PathBuf::from_str(file!())?),
-    );
-    assert_eq!(
-        UrlOrPathOrString::from_str("Boop")?,
-        UrlOrPathOrString::String(String::from("Boop")),
-    );
-    Ok(())
-}
-
 #[cfg(feature = "diagnostics")]
 impl crate::diagnostics::ErrorDiagnostic for InstallSettingsError {
     fn diagnostic(&self) -> String {
         let static_str: &'static str = (self).into();
         static_str.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FromStr, PathBuf, Url, UrlOrPath, UrlOrPathOrString};
+
+    #[test]
+    fn url_or_path_or_string_parses() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(
+            UrlOrPathOrString::from_str("https://boop.bleat")?,
+            UrlOrPathOrString::Url(Url::from_str("https://boop.bleat")?),
+        );
+        assert_eq!(
+            UrlOrPathOrString::from_str("file:///boop/bleat")?,
+            UrlOrPathOrString::Url(Url::from_str("file:///boop/bleat")?),
+        );
+        // The file *must* exist!
+        assert_eq!(
+            UrlOrPathOrString::from_str(file!())?,
+            UrlOrPathOrString::Path(PathBuf::from_str(file!())?),
+        );
+        assert_eq!(
+            UrlOrPathOrString::from_str("Boop")?,
+            UrlOrPathOrString::String(String::from("Boop")),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn url_or_path_parses() -> Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(
+            UrlOrPath::from_str("https://boop.bleat")?,
+            UrlOrPath::Url(Url::from_str("https://boop.bleat")?),
+        );
+        assert_eq!(
+            UrlOrPath::from_str("file:///boop/bleat")?,
+            UrlOrPath::Url(Url::from_str("file:///boop/bleat")?),
+        );
+        // The file *must* exist!
+        assert_eq!(
+            UrlOrPath::from_str(file!())?,
+            UrlOrPath::Path(PathBuf::from_str(file!())?),
+        );
+        Ok(())
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -3,7 +3,10 @@
 use std::{collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
 
 #[cfg(feature = "cli")]
-use clap::{ArgAction, error::{ContextKind, ContextValue}};
+use clap::{
+    error::{ContextKind, ContextValue},
+    ArgAction,
+};
 use url::Url;
 
 pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -18,7 +18,9 @@
         "action": "provision_nix",
         "fetch_nix": {
           "action": {
-            "url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-linux.tar.xz",
+            "url_or_path": {
+              "Url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-linux.tar.xz"
+            },
             "dest": "/nix/temp-install-dir",
             "proxy": null,
             "ssl_cert_file": null
@@ -243,14 +245,14 @@
             "create_directories": [
               {
                 "action": {
-                  "path": "/etc/zsh",
+                  "path": "/etc/fish/conf.d",
                   "user": null,
                   "group": null,
                   "mode": 493,
                   "is_mountpoint": false,
                   "force_prune_on_revert": false
                 },
-                "state": "Uncompleted"
+                "state": "Completed"
               },
               {
                 "action": {
@@ -322,6 +324,17 @@
               },
               {
                 "action": {
+                  "path": "/etc/fish/conf.d/nix.fish",
+                  "user": null,
+                  "group": null,
+                  "mode": 420,
+                  "buf": "\n# Nix\nif test -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.fish'\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.fish'\nend\n# End Nix\n\n",
+                  "position": "Beginning"
+                },
+                "state": "Uncompleted"
+              },
+              {
+                "action": {
                   "path": "/usr/share/fish/vendor_conf.d/nix.fish",
                   "user": null,
                   "group": null,
@@ -353,19 +366,19 @@
                 "path": "/etc/nix/nix.conf",
                 "user": null,
                 "group": null,
-                "mode": null,
-                "buf": "!include ./nix-installer-defaults.conf",
+                "mode": 493,
+                "buf": "include ./nix-installer-defaults.conf\n",
                 "position": "Beginning"
               },
               "state": "Uncompleted"
             },
             "create_defaults_conf": {
               "action": {
-                "path": "/etc/nix/defaults.conf",
+                "path": "/etc/nix/nix-installer-defaults.conf",
                 "user": null,
                 "group": null,
-                "mode": null,
-                "buf": "build-users-group = nixbld\nexperimental-features = nix-command flakes auto-allocate-uids\nbash-prompt-prefix = (nix:$name)\\040\nextra-nix-path = nixpkgs=flake:nixpkgs\nauto-optimise-store = true\nauto-allocate-uids = true",
+                "mode": 493,
+                "buf": "build-users-group = nixbld\nexperimental-features = nix-command flakes auto-allocate-uids\nbash-prompt-prefix = (nix:$name)\\040\nextra-nix-path = nixpkgs=flake:nixpkgs\nmax-jobs = auto\nauto-optimise-store = true\nauto-allocate-uids = true\n",
                 "replace": true
               },
               "state": "Uncompleted"
@@ -386,7 +399,7 @@
         "is_mountpoint": false,
         "force_prune_on_revert": false
       },
-      "state": "Completed"
+      "state": "Uncompleted"
     },
     {
       "action": {
@@ -413,7 +426,9 @@
       "nix_build_user_prefix": "nixbld",
       "nix_build_user_count": 0,
       "nix_build_user_id_base": 30000,
-      "nix_package_url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-linux.tar.xz",
+      "nix_package_url": {
+        "Url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-linux.tar.xz"
+      },
       "proxy": null,
       "ssl_cert_file": null,
       "extra_conf": [],

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -68,7 +68,9 @@
         "action": "provision_nix",
         "fetch_nix": {
           "action": {
-            "url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-linux.tar.xz",
+            "url_or_path": {
+              "Url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-linux.tar.xz"
+            },
             "dest": "/nix/temp-install-dir",
             "proxy": null,
             "ssl_cert_file": null
@@ -443,7 +445,9 @@
       "nix_build_user_prefix": "nixbld",
       "nix_build_user_count": 0,
       "nix_build_user_id_base": 30000,
-      "nix_package_url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-linux.tar.xz",
+      "nix_package_url": {
+        "Url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-linux.tar.xz"
+      },
       "proxy": null,
       "ssl_cert_file": null,
       "extra_conf": [],

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -88,7 +88,9 @@
         "action": "provision_nix",
         "fetch_nix": {
           "action": {
-            "url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-darwin.tar.xz",
+            "url_or_path": {
+              "Url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-darwin.tar.xz"
+            },
             "dest": "/nix/temp-install-dir",
             "proxy": null,
             "ssl_cert_file": null
@@ -1090,7 +1092,9 @@
       "nix_build_user_prefix": "_nixbld",
       "nix_build_user_count": 32,
       "nix_build_user_id_base": 300,
-      "nix_package_url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-darwin.tar.xz",
+      "nix_package_url": {
+        "Url": "https://releases.nixos.org/nix/nix-2.17.0/nix-2.17.0-x86_64-darwin.tar.xz"
+      },
       "proxy": null,
       "ssl_cert_file": null,
       "extra_conf": [],


### PR DESCRIPTION
##### Description

During testing I quite often want to pass file paths to `--nix-package-url`, the `file:///` URL bits always trip me up and require me to think about my cwd etc. This PR tidies up some related code and adds a similar functionality to the `--extra-conf` such that I can pass something that looks like a URL or file path and have it just work.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
