### PR TITLE
Disable auto-allocate-uids on Linux too

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,11 +418,10 @@ curl -sSf -L https://github.com/DeterminateSystems/nix-installer/releases/downlo
 Differing from the upstream [Nix](https://github.com/NixOS/nix) installer scripts:
 
 * In `nix.conf`:
-  + the `auto-allocate-uids`, `nix-command` and `flakes` features are enabled
+  + the `nix-command` and `flakes` features are enabled
   + `bash-prompt-prefix` is set
   + `auto-optimise-store` is set to `true` (On Linux only)
   * `extra-nix-path` is set to `nixpkgs=flake:nixpkgs`
-  * `auto-allocate-uids` is set to `true`.  (On Linux only)
 * an installation receipt (for uninstalling) is stored at `/nix/receipt.json` as well as a copy of the install binary at `/nix/nix-installer`
 * `nix-channel --update` is not run, `~/.nix-channels` is not provisioned
 * `NIX_SSL_CERT_FILE` is set in the various shell profiles if the `ssl-cert-file` argument is used.

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -41,7 +41,7 @@ impl PlaceNixConfiguration {
             ("build-users-group", nix_build_group_name),
             (
                 "experimental-features",
-                "nix-command flakes auto-allocate-uids".into(),
+                "nix-command flakes".into(),
             ),
         ];
 
@@ -60,10 +60,6 @@ impl PlaceNixConfiguration {
         // https://github.com/DeterminateSystems/nix-installer/issues/449#issuecomment-1551782281
         #[cfg(not(target_os = "macos"))]
         defaults_conf_settings.push(("auto-optimise-store", "true".into()));
-        // Auto-allocate uids is broken on Mac. Tools like `whoami` don't work.
-        // e.g. https://github.com/NixOS/nix/issues/8444
-        #[cfg(not(target_os = "macos"))]
-        defaults_conf_settings.push(("auto-allocate-uids", "true".into()));
         let defaults_conf_insert_fragment = defaults_conf_settings
             .iter()
             .map(|(s, v)| format!("{s} = {v}"))
@@ -148,9 +144,7 @@ impl PlaceNixConfiguration {
             );
 
             // Some settings (eg `experimental-features`) we must be able to set it.
-            let mut required_settings = vec!["experimental-features"];
-            #[cfg(not(target_os = "macos"))]
-            required_settings.push("auto-allocate-uids");
+            let required_settings = vec!["experimental-features"];
             for required_setting in required_settings {
                 if let Some((existing_setting, existing_value)) = existing_conf_settings
                     .iter()

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -39,10 +39,7 @@ impl PlaceNixConfiguration {
 
         let mut defaults_conf_settings = vec![
             ("build-users-group", nix_build_group_name),
-            (
-                "experimental-features",
-                "nix-command flakes".into(),
-            ),
+            ("experimental-features", "nix-command flakes".into()),
         ];
 
         defaults_conf_settings.push(("bash-prompt-prefix", "(nix:$name)\\040".into()));
@@ -91,7 +88,7 @@ impl PlaceNixConfiguration {
 
                 // We only scan one include of depth -- we should make this any depth, make sure to guard for loops
                 if line.starts_with("include") || line.starts_with("!include") {
-                    let allow_not_existing = line.starts_with("!");
+                    let allow_not_existing = line.starts_with('!');
                     // Need to read it in if it exists for settings
                     let path = line
                         .trim_start_matches("include")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -111,10 +111,6 @@ pub struct CommonSettings {
 
     /// Number of build users to create
     #[cfg_attr(
-        all(target_os = "linux", feature = "cli"),
-        doc = "On Linux, Nix's `auto-allocate-uids` feature will be enabled, so users don't need to be created."
-    )]
-    #[cfg_attr(
         feature = "cli",
         clap(
             long,
@@ -124,7 +120,7 @@ pub struct CommonSettings {
         )
     )]
     #[cfg_attr(all(target_os = "macos", feature = "cli"), clap(default_value = "32"))]
-    #[cfg_attr(all(target_os = "linux", feature = "cli"), clap(default_value = "0"))]
+    #[cfg_attr(all(target_os = "linux", feature = "cli"), clap(default_value = "32"))]
     pub nix_build_user_count: u32,
 
     /// The Nix build user base UID (ascending)


### PR DESCRIPTION
##### Description

We're currently trying to route around https://github.com/DeterminateSystems/nix-installer/issues/539. We saw a number of issues on Mac and we are now seeing some similar issues on certain Linux distributions. We're looking to roll this feature back until we can either develop a better heuristic or it's resolved upstream.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
