### PR TITLE
Plan prompts for sudo

### DIFF
--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -95,7 +95,7 @@ impl PlaceNixConfiguration {
 
                 // We only scan one include of depth -- we should make this any depth, make sure to guard for loops
                 if line.starts_with("include") || line.starts_with("!include") {
-                    let allow_not_existing = line.starts_with("!");
+                    let allow_not_existing = line.starts_with('!');
                     // Need to read it in if it exists for settings
                     let path = line
                         .trim_start_matches("include")

--- a/src/cli/subcommand/plan.rs
+++ b/src/cli/subcommand/plan.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, process::ExitCode};
 
-use crate::{error::HasExpectedErrors, BuiltinPlanner, cli::ensure_root};
+use crate::{cli::ensure_root, error::HasExpectedErrors, BuiltinPlanner};
 use clap::Parser;
 
 use eyre::WrapErr;

--- a/src/cli/subcommand/plan.rs
+++ b/src/cli/subcommand/plan.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, process::ExitCode};
 
-use crate::{error::HasExpectedErrors, BuiltinPlanner};
+use crate::{error::HasExpectedErrors, BuiltinPlanner, cli::ensure_root};
 use clap::Parser;
 
 use eyre::WrapErr;
@@ -31,6 +31,8 @@ impl CommandExecute for Plan {
     #[tracing::instrument(level = "debug", skip_all, fields())]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self { planner, output } = self;
+
+        ensure_root()?;
 
         let planner = match planner {
             Some(planner) => planner,


### PR DESCRIPTION
##### Description

Fixes #578 

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
