### PR TITLE
Enable repl-flake experimental feature

### DIFF
--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -95,7 +95,7 @@ impl PlaceNixConfiguration {
 
         let mut defaults_conf_settings = vec![
             ("build-users-group", nix_build_group_name),
-            ("experimental-features", "nix-command flakes".into()),
+            ("experimental-features", "nix-command flakes repl-flake".into()),
         ];
 
         defaults_conf_settings.push(("bash-prompt-prefix", "(nix:$name)\\040".into()));

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -95,7 +95,10 @@ impl PlaceNixConfiguration {
 
         let mut defaults_conf_settings = vec![
             ("build-users-group", nix_build_group_name),
-            ("experimental-features", "nix-command flakes repl-flake".into()),
+            (
+                "experimental-features",
+                "nix-command flakes repl-flake".into(),
+            ),
         ];
 
         defaults_conf_settings.push(("bash-prompt-prefix", "(nix:$name)\\040".into()));


### PR DESCRIPTION
##### Description

The `repl-flake` feature is really handy for folks adopting Nix with flakes.

Nix already warns about needing to use `-f` or `--file` in the future for the 'old' behavior:

```
❯ nix repl flake.nix
warning: future versions of Nix will require using `--file` to load a file
```


This makes stuff like the following work:

```bash
❯ nix repl .#
Welcome to Nix 2.17.0. Type :? for help.

Loading installable 'git+file:///home/ana/git/determinatesystems/nix-installer#'...
Added 5 variables.
nix-repl> packages
{ aarch64-darwin = { ... }; aarch64-linux = { ... }; i686-linux = { ... }; x86_64-darwin = { ... }; x86_64-linux = { ... }; }
```

And:

```
❯ nix repl "github:nixos/nixpkgs?dir=lib"
Welcome to Nix 2.17.0. Type :? for help.

Loading installable 'github:nixos/nixpkgs?dir=lib#'...
Added 1 variables.
nix-repl> lib.
lib.__unfix__                      lib.debug                          lib.genList                        lib.isType                         lib.mesonEnable                    lib.pathIsDirectory                lib.testAllTrue
lib.add                            lib.deepSeq
# ...
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
