### PR TITLE
Tweak nix-build-user-count default in all places

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -262,21 +262,21 @@ impl CommonSettings {
                 url = NIX_X64_64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                nix_build_user_count = 0;
+                nix_build_user_count = 32;
             },
             #[cfg(target_os = "linux")]
             (Architecture::X86_32(_), OperatingSystem::Linux) => {
                 url = NIX_I686_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                nix_build_user_count = 0;
+                nix_build_user_count = 32;
             },
             #[cfg(target_os = "linux")]
             (Architecture::Aarch64(_), OperatingSystem::Linux) => {
                 url = NIX_AARCH64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                nix_build_user_count = 0;
+                nix_build_user_count = 32;
             },
             #[cfg(target_os = "macos")]
             (Architecture::X86_64, OperatingSystem::MacOSX { .. })


### PR DESCRIPTION
##### Description

I noticed this while doing final testing of #641:

```
❯ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/641 | sh -s -- install
info: downloading installer https://install.determinate.systems/nix/rev/740a9c570dc4731070aecd03bd09ba03ccaf35e3/nix-installer-x86_64-linux
`nix-installer` needs to run as `root`, attempting to escalate now via `sudo`...
Nix install plan (v0.12.0)
Planner: linux

Configured settings:
* nix_build_user_count: 32

Planned actions:
* Create directory `/nix`
* Fetch `https://releases.nixos.org/nix/nix-2.18.0/nix-2.18.0-x86_64-linux.tar.xz` to `/nix/temp-install-dir`
* Create a directory tree in `/nix`
* Move the downloaded Nix into `/n
```

Configured settings should not be like that.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
