### PR TITLE
Revert "Release v0.12.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.12.1"
+version = "0.12.1-unreleased"
 dependencies = [
  "async-trait",
  "bytes 1.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix-installer"
 description = "The Determinate Nix Installer"
-version = "0.12.1"
+version = "0.12.1-unreleased"
 edition = "2021"
 resolver = "2"
 license = "LGPL-2.1"

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
           };
           sharedAttrs = {
             pname = "nix-installer";
-            version = "0.12.1";
+            version = "0.12.1-unreleased";
             src = builtins.path {
               name = "nix-installer-source";
               path = self;

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.1",
+  "version": "0.12.1-unreleased",
   "actions": [
     {
       "action": {
@@ -424,7 +424,7 @@
     }
   },
   "diagnostic_data": {
-    "version": "0.12.1",
+    "version": "0.12.1-unreleased",
     "planner": "linux",
     "configured_settings": [],
     "os_name": "Ubuntu",

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.1",
+  "version": "0.12.1-unreleased",
   "actions": [
     {
       "action": {
@@ -404,7 +404,7 @@
     }
   },
   "diagnostic_data": {
-    "version": "0.12.1",
+    "version": "0.12.1-unreleased",
     "planner": "steam-deck",
     "configured_settings": [],
     "os_name": "Ubuntu",

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.12.1",
+  "version": "0.12.1-unreleased",
   "actions": [
     {
       "action": {
@@ -435,7 +435,7 @@
     "root_disk": "disk3"
   },
   "diagnostic_data": {
-    "version": "0.12.1",
+    "version": "0.12.1-unreleased",
     "planner": "macos",
     "configured_settings": [],
     "os_name": "unknown",


### PR DESCRIPTION
Reverts DeterminateSystems/nix-installer#649, we obviously can't do this since the plan format changed.