### PR TITLE
Update nix-config-parser to use indexmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,9 +614,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 
 [[package]]
 name = "heck"
@@ -784,12 +784,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "serde",
 ]
 
@@ -943,10 +943,11 @@ dependencies = [
 
 [[package]]
 name = "nix-config-parser"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a94767d6f881412ae02a87a4b6136b4079cbda9d3eab8f4ae272c9db740902c"
+checksum = "383d96c6f2c44fc706e7a523743434465d62db109b7c8364b642f35853475d67"
 dependencies = [
+ "indexmap 2.0.2",
  "serde",
  "thiserror",
 ]
@@ -963,6 +964,7 @@ dependencies = [
  "dyn-clone",
  "eyre",
  "glob",
+ "indexmap 2.0.2",
  "is_ci",
  "nix",
  "nix-config-parser",
@@ -1527,7 +1529,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
  "serde",
  "serde_json",
  "serde_with_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,11 @@ uuid = { version = "1.2.2", features = ["serde"] }
 os-release = { version = "0.1.0", default-features = false }
 is_ci = { version = "1.1.1", default-features = false, optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
-nix-config-parser = { version = "0.1.2", features = ["serde"] }
+nix-config-parser = { version = "0.2", features = ["serde"] }
 which = "4.4.0"
 sysctl = "0.5.4"
 walkdir = "2.3.3"
+indexmap = { version = "2.0.2", features = ["serde"] }
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -8,7 +8,7 @@ use crate::action::{
 };
 use crate::parse_ssl_cert;
 use crate::settings::UrlOrPathOrString;
-use std::collections::hash_map::Entry;
+use indexmap::map::Entry;
 use std::path::PathBuf;
 
 const NIX_CONF_FOLDER: &str = "/etc/nix";


### PR DESCRIPTION
##### Description

Includes https://github.com/DeterminateSystems/nix-config-parser/pull/25

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
