### PR TITLE
Make our Nix installation immune to macOS upgrades

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,7 @@
             ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [
               libiconv
               darwin.apple_sdk.frameworks.Security
+              darwin.apple_sdk.frameworks.SystemConfiguration
             ])
             ++ lib.optionals (pkgs.stdenv.isLinux) (with pkgs; [
               checkpolicy

--- a/flake.nix
+++ b/flake.nix
@@ -138,6 +138,7 @@
               cargo-outdated
               cacert
               cargo-audit
+              cargo-watch
               nixpkgs-fmt
               check.check-rustfmt
               check.check-spelling

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -395,7 +395,7 @@ impl Action for ConfigureInitService {
                         .arg(DARWIN_NIX_DAEMON_DEST),
                 )
                 .await
-                .map_err(|e| Self::error(e))?;
+                .map_err(Self::error)?;
             },
             #[cfg(target_os = "linux")]
             InitSystem::Systemd => {

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -192,7 +192,7 @@ impl Action for ConfigureInitService {
                 let domain = "system";
                 let service = "org.nixos.nix-daemon";
 
-                let is_disabled = crate::action::macos::service_is_disabled(&domain, &service)
+                let is_disabled = crate::action::macos::service_is_disabled(domain, service)
                     .await
                     .map_err(Self::error)?;
                 if is_disabled {

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -182,7 +182,7 @@ impl Action for ConfigureInitService {
                 execute_command(
                     Command::new("launchctl")
                         .process_group(0)
-                        .args(&["load", "-w"])
+                        .args(["load", "-w"])
                         .arg(DARWIN_NIX_DAEMON_DEST)
                         .stdin(std::process::Stdio::null()),
                 )

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -8,9 +8,10 @@ use tokio::{
     process::Command,
 };
 
-use crate::{action::{
-    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
-}, execute_command};
+use crate::{
+    action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
+    execute_command,
+};
 
 /** Create a plist for a `launchctl` service to re-add Nix to the zshrc after upgrades.
  */
@@ -124,11 +125,14 @@ impl Action for CreateNixHookService {
         } = self;
 
         if *needs_bootout {
-            execute_command(Command::new("launchctl")
-                .process_group(0)
-                .arg("bootout")
-                .arg(format!("system/{service_label}"))
-            ).await.map_err(Self::error)?;
+            execute_command(
+                Command::new("launchctl")
+                    .process_group(0)
+                    .arg("bootout")
+                    .arg(format!("system/{service_label}")),
+            )
+            .await
+            .map_err(Self::error)?;
         }
 
         let generated_plist = generate_plist(service_label).await.map_err(Self::error)?;
@@ -205,7 +209,9 @@ pub struct KeepAliveOpts {
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum CreateNixHookServiceError {
-    #[error("`{path}` exists and contains content different than expected. Consider removing the file.")]
+    #[error(
+        "`{path}` exists and contains content different than expected. Consider removing the file."
+    )]
     DifferentPlist {
         expected: LaunchctlHookPlist,
         discovered: LaunchctlHookPlist,

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -182,7 +182,9 @@ impl Action for CreateNixHookService {
 /// This function must be able to operate at both plan and execute time.
 async fn generate_plist(service_label: &str) -> Result<LaunchctlHookPlist, ActionErrorKind> {
     let plist = LaunchctlHookPlist {
-        run_at_load: true,
+        keep_alive: KeepAliveOpts {
+            successful_exit: false,
+        },
         label: service_label.into(),
         program_arguments: vec![
             "/bin/sh".into(),
@@ -201,9 +203,15 @@ async fn generate_plist(service_label: &str) -> Result<LaunchctlHookPlist, Actio
 pub struct LaunchctlHookPlist {
     label: String,
     program_arguments: Vec<String>,
-    run_at_load: bool,
+    keep_alive: KeepAliveOpts,
     standard_error_path: String,
     standard_out_path: String,
+}
+
+#[derive(Deserialize, Clone, Debug, Serialize, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub struct KeepAliveOpts {
+    successful_exit: bool,
 }
 
 #[non_exhaustive]

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -182,9 +182,7 @@ impl Action for CreateNixHookService {
 /// This function must be able to operate at both plan and execute time.
 async fn generate_plist(service_label: &str) -> Result<LaunchctlHookPlist, ActionErrorKind> {
     let plist = LaunchctlHookPlist {
-        keep_alive: KeepAliveOpts {
-            successful_exit: false,
-        },
+        run_at_load: true,
         label: service_label.into(),
         program_arguments: vec![
             "/bin/sh".into(),
@@ -203,15 +201,9 @@ async fn generate_plist(service_label: &str) -> Result<LaunchctlHookPlist, Actio
 pub struct LaunchctlHookPlist {
     label: String,
     program_arguments: Vec<String>,
-    keep_alive: KeepAliveOpts,
+    run_at_load: bool,
     standard_error_path: String,
     standard_out_path: String,
-}
-
-#[derive(Deserialize, Clone, Debug, Serialize, PartialEq)]
-#[serde(rename_all = "PascalCase")]
-pub struct KeepAliveOpts {
-    successful_exit: bool,
 }
 
 #[non_exhaustive]

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -177,7 +177,7 @@ async fn generate_plist(service_label: &str) -> Result<LaunchctlHookPlist, Actio
         program_arguments: vec![
             "/bin/sh".into(),
             "-c".into(),
-            "/bin/wait4path /nix/nix-installer && /nix/nix-installer restore-shell".into(),
+            "/bin/wait4path /nix/nix-installer && /nix/nix-installer repair".into(),
         ],
         standard_error_path: "/nix/.nix-installer-hook.err.log".into(),
         standard_out_path: "/nix/.nix-installer-hook.out.log".into(),

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -1,0 +1,220 @@
+use serde::{Deserialize, Serialize};
+use tracing::{span, Span};
+
+use std::path::PathBuf;
+use tokio::{
+    fs::{remove_file, OpenOptions},
+    io::AsyncWriteExt,
+    process::Command,
+};
+
+use crate::action::{
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
+
+/** Create a plist for a `launchctl` service to re-add Nix to the zshrc after upgrades.
+ */
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct CreateNixHookService {
+    path: PathBuf,
+    service_label: String,
+    needs_bootout: bool,
+}
+
+impl CreateNixHookService {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
+        let mut this = Self {
+            path: PathBuf::from(
+                "/Library/LaunchDaemons/systems.determinate.nix-installer.nix-hook.plist",
+            ),
+            service_label: "systems.determinate.nix-installer.nix-hook".into(),
+            needs_bootout: false,
+        };
+
+        // If the service is currently loaded or running, we need to unload it during execute (since we will then recreate it and reload it)
+        // This `launchctl` command may fail if the service isn't loaded
+        let mut check_loaded_command = Command::new("launchctl");
+        check_loaded_command.arg("print");
+        check_loaded_command.arg(format!("system/{}", this.service_label));
+        tracing::trace!(
+            command = format!("{:?}", check_loaded_command.as_std()),
+            "Executing"
+        );
+        let check_loaded_output = check_loaded_command
+            .output()
+            .await
+            .map_err(|e| ActionErrorKind::command(&check_loaded_command, e))
+            .map_err(Self::error)?;
+        this.needs_bootout = check_loaded_output.status.success();
+        if this.needs_bootout {
+            tracing::debug!(
+                "Detected loaded service `{}` which needs unload before replacing `{}`",
+                this.service_label,
+                this.path.display(),
+            );
+        }
+
+        if this.path.exists() {
+            let discovered_plist: LaunchctlHookPlist =
+                plist::from_file(&this.path).map_err(Self::error)?;
+            let expected_plist = generate_plist(&this.service_label)
+                .await
+                .map_err(Self::error)?;
+            if discovered_plist != expected_plist {
+                tracing::trace!(
+                    ?discovered_plist,
+                    ?expected_plist,
+                    "Parsed plists not equal"
+                );
+                return Err(Self::error(CreateNixHookServiceError::DifferentPlist {
+                    expected: expected_plist,
+                    discovered: discovered_plist,
+                    path: this.path.clone(),
+                }));
+            }
+
+            tracing::debug!("Creating file `{}` already complete", this.path.display());
+            return Ok(StatefulAction::completed(this));
+        }
+
+        Ok(StatefulAction::uncompleted(this))
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "create_nix_hook_service")]
+impl Action for CreateNixHookService {
+    fn action_tag() -> ActionTag {
+        ActionTag("create_nix_hook_service")
+    }
+    fn tracing_synopsis(&self) -> String {
+        format!(
+            "{maybe_unload} a `launchctl` plist to put Nix into your PATH",
+            maybe_unload = if self.needs_bootout {
+                "Unload, then recreate"
+            } else {
+                "Create"
+            }
+        )
+    }
+
+    fn tracing_span(&self) -> Span {
+        let span = span!(
+            tracing::Level::DEBUG,
+            "create_nix_hook_service",
+            path = tracing::field::display(self.path.display()),
+            buf = tracing::field::Empty,
+        );
+
+        span
+    }
+
+    fn execute_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn execute(&mut self) -> Result<(), ActionError> {
+        let Self {
+            path,
+            service_label,
+            needs_bootout,
+        } = self;
+
+        if *needs_bootout {
+            let mut unload_command = Command::new("launchctl");
+            unload_command.arg("bootout");
+            unload_command.arg(format!("system/{service_label}"));
+            tracing::trace!(
+                command = format!("{:?}", unload_command.as_std()),
+                "Executing"
+            );
+            let unload_output = unload_command
+                .output()
+                .await
+                .map_err(|e| ActionErrorKind::command(&unload_command, e))
+                .map_err(Self::error)?;
+            if !unload_output.status.success() {
+                return Err(Self::error(ActionErrorKind::command_output(
+                    &unload_command,
+                    unload_output,
+                )));
+            }
+        }
+
+        let generated_plist = generate_plist(service_label).await.map_err(Self::error)?;
+
+        let mut options = OpenOptions::new();
+        options.create(true).write(true).read(true);
+
+        let mut file = options
+            .open(&path)
+            .await
+            .map_err(|e| Self::error(ActionErrorKind::Open(path.to_owned(), e)))?;
+
+        let mut buf = Vec::new();
+        plist::to_writer_xml(&mut buf, &generated_plist).map_err(Self::error)?;
+        file.write_all(&buf)
+            .await
+            .map_err(|e| Self::error(ActionErrorKind::Write(path.to_owned(), e)))?;
+
+        Ok(())
+    }
+
+    fn revert_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(
+            format!("Delete file `{}`", self.path.display()),
+            vec![format!("Delete file `{}`", self.path.display())],
+        )]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn revert(&mut self) -> Result<(), ActionError> {
+        remove_file(&self.path)
+            .await
+            .map_err(|e| Self::error(ActionErrorKind::Remove(self.path.to_owned(), e)))?;
+
+        Ok(())
+    }
+}
+
+/// This function must be able to operate at both plan and execute time.
+async fn generate_plist(service_label: &str) -> Result<LaunchctlHookPlist, ActionErrorKind> {
+    let plist = LaunchctlHookPlist {
+        run_at_load: true,
+        label: service_label.into(),
+        program_arguments: vec!["/nix/nix-installer".into(), "restore-rc".into()],
+        standard_error_path: "/nix/.nix-installer-hook.err.log".into(),
+        standard_out_path: "/nix/.nix-installer-hook.out.log".into(),
+    };
+
+    Ok(plist)
+}
+
+#[derive(Deserialize, Clone, Debug, Serialize, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub struct LaunchctlHookPlist {
+    run_at_load: bool,
+    label: String,
+    program_arguments: Vec<String>,
+    standard_error_path: String,
+    standard_out_path: String,
+}
+
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum CreateNixHookServiceError {
+    #[error("`{path}` contents differs, planned `{expected:?}`, discovered `{discovered:?}`")]
+    DifferentPlist {
+        expected: LaunchctlHookPlist,
+        discovered: LaunchctlHookPlist,
+        path: PathBuf,
+    },
+}
+
+impl From<CreateNixHookServiceError> for ActionErrorKind {
+    fn from(val: CreateNixHookServiceError) -> Self {
+        ActionErrorKind::Custom(Box::new(val))
+    }
+}

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -184,7 +184,7 @@ async fn generate_plist(service_label: &str) -> Result<LaunchctlHookPlist, Actio
     let plist = LaunchctlHookPlist {
         run_at_load: true,
         label: service_label.into(),
-        program_arguments: vec!["/nix/nix-installer".into(), "restore-rc".into()],
+        program_arguments: vec!["/nix/nix-installer".into(), "restore-shell".into()],
         standard_error_path: "/nix/.nix-installer-hook.err.log".into(),
         standard_out_path: "/nix/.nix-installer-hook.out.log".into(),
     };

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod bootstrap_launchctl_service;
 pub(crate) mod create_apfs_volume;
 pub(crate) mod create_fstab_entry;
+pub(crate) mod create_nix_hook_service;
 pub(crate) mod create_nix_volume;
 pub(crate) mod create_synthetic_objects;
 pub(crate) mod create_volume_service;
@@ -16,6 +17,7 @@ pub(crate) mod unmount_apfs_volume;
 
 pub use bootstrap_launchctl_service::BootstrapLaunchctlService;
 pub use create_apfs_volume::CreateApfsVolume;
+pub use create_nix_hook_service::CreateNixHookService;
 pub use create_nix_volume::{CreateNixVolume, NIX_VOLUME_MOUNTD_DEST};
 pub use create_synthetic_objects::CreateSyntheticObjects;
 pub use create_volume_service::CreateVolumeService;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -47,6 +47,7 @@ impl CommandExecute for NixInstallerCli {
             NixInstallerSubcommand::Plan(plan) => plan.execute().await,
             NixInstallerSubcommand::SelfTest(self_test) => self_test.execute().await,
             NixInstallerSubcommand::Install(install) => install.execute().await,
+            NixInstallerSubcommand::RestoreShell(restore_shell) => restore_shell.execute().await,
             NixInstallerSubcommand::Uninstall(revert) => revert.execute().await,
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -47,7 +47,7 @@ impl CommandExecute for NixInstallerCli {
             NixInstallerSubcommand::Plan(plan) => plan.execute().await,
             NixInstallerSubcommand::SelfTest(self_test) => self_test.execute().await,
             NixInstallerSubcommand::Install(install) => install.execute().await,
-            NixInstallerSubcommand::RestoreShell(restore_shell) => restore_shell.execute().await,
+            NixInstallerSubcommand::Repair(restore_shell) => restore_shell.execute().await,
             NixInstallerSubcommand::Uninstall(revert) => revert.execute().await,
         }
     }

--- a/src/cli/subcommand/mod.rs
+++ b/src/cli/subcommand/mod.rs
@@ -2,6 +2,8 @@ mod plan;
 use plan::Plan;
 mod install;
 use install::Install;
+mod restore_shell;
+use restore_shell::RestoreShell;
 mod uninstall;
 use uninstall::Uninstall;
 mod self_test;
@@ -11,6 +13,7 @@ use self_test::SelfTest;
 #[derive(Debug, clap::Subcommand)]
 pub enum NixInstallerSubcommand {
     Install(Install),
+    RestoreShell(RestoreShell),
     Uninstall(Uninstall),
     SelfTest(SelfTest),
     Plan(Plan),

--- a/src/cli/subcommand/mod.rs
+++ b/src/cli/subcommand/mod.rs
@@ -2,8 +2,8 @@ mod plan;
 use plan::Plan;
 mod install;
 use install::Install;
-mod restore_shell;
-use restore_shell::RestoreShell;
+mod repair;
+use repair::Repair;
 mod uninstall;
 use uninstall::Uninstall;
 mod self_test;
@@ -13,7 +13,7 @@ use self_test::SelfTest;
 #[derive(Debug, clap::Subcommand)]
 pub enum NixInstallerSubcommand {
     Install(Install),
-    RestoreShell(RestoreShell),
+    Repair(Repair),
     Uninstall(Uninstall),
     SelfTest(SelfTest),
     Plan(Plan),

--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -27,9 +27,7 @@ pub struct Repair {
 impl CommandExecute for Repair {
     #[tracing::instrument(level = "trace", skip_all)]
     async fn execute(self) -> eyre::Result<ExitCode> {
-        let Self {
-            no_confirm: _,
-        } = self;
+        let Self { no_confirm: _ } = self;
 
         ensure_root()?;
 

--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -1,4 +1,4 @@
-use std::{os::unix::prelude::PermissionsExt, process::ExitCode};
+use std::process::ExitCode;
 
 use crate::{
     action::common::ConfigureShellProfile,
@@ -8,11 +8,11 @@ use crate::{
 use clap::{ArgAction, Parser};
 
 /**
-Update the macOS startup files to make Nix usable after system upgrades.
+Update the shell profiles to make Nix usable after system upgrades.
 */
 #[derive(Debug, Parser)]
 #[command(args_conflicts_with_subcommands = true)]
-pub struct RestoreShell {
+pub struct Repair {
     #[clap(
         long,
         env = "NIX_INSTALLER_NO_CONFIRM",
@@ -24,7 +24,7 @@ pub struct RestoreShell {
 }
 
 #[async_trait::async_trait]
-impl CommandExecute for RestoreShell {
+impl CommandExecute for Repair {
     #[tracing::instrument(level = "trace", skip_all)]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let Self {

--- a/src/cli/subcommand/restore_shell.rs
+++ b/src/cli/subcommand/restore_shell.rs
@@ -1,0 +1,80 @@
+use std::{os::unix::prelude::PermissionsExt, process::ExitCode};
+
+use crate::{
+    action::common::ConfigureShellProfile,
+    cli::{ensure_root, CommandExecute},
+    planner::{PlannerError, ShellProfileLocations},
+};
+use clap::{ArgAction, Parser};
+
+/**
+Update the macOS startup files to make Nix usable after system upgrades.
+*/
+#[derive(Debug, Parser)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct RestoreShell {
+    #[clap(
+        long,
+        env = "NIX_INSTALLER_NO_CONFIRM",
+        action(ArgAction::SetTrue),
+        default_value = "false",
+        global = true
+    )]
+    pub no_confirm: bool,
+
+    #[clap(
+        long,
+        env = "NIX_INSTALLER_EXPLAIN",
+        action(ArgAction::SetTrue),
+        default_value = "false",
+        global = true
+    )]
+    pub explain: bool,
+}
+
+#[async_trait::async_trait]
+impl CommandExecute for RestoreShell {
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn execute(self) -> eyre::Result<ExitCode> {
+        let Self {
+            no_confirm: _,
+            explain: _,
+        } = self;
+
+        ensure_root()?;
+
+        let mut reconfigure = ConfigureShellProfile::plan(ShellProfileLocations::default())
+            .await
+            .map_err(PlannerError::Action)?
+            .boxed();
+
+        if let Err(err) = reconfigure.try_execute().await {
+            println!("{:#?}", err);
+
+            /*
+            let err = NixInstallerError::Action(err);
+            #[cfg(feature = "diagnostics")]
+            if let Some(diagnostic_data) = &self.diagnostic_data {
+                diagnostic_data
+                    .clone()
+                    .failure(&err)
+                    .send(
+                        crate::diagnostics::DiagnosticAction::RestoreShell,
+                        crate::diagnostics::DiagnosticStatus::Failure,
+                    )
+                    .await?;
+            }*/
+            Ok(ExitCode::FAILURE)
+        } else {
+            Ok(ExitCode::SUCCESS)
+        }
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+async fn copy_self_to_nix_dir() -> Result<(), std::io::Error> {
+    let path = std::env::current_exe()?;
+    tokio::fs::copy(path, "/nix/nix-installer").await?;
+    tokio::fs::set_permissions("/nix/nix-installer", PermissionsExt::from_mode(0o0755)).await?;
+    Ok(())
+}

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -176,7 +176,7 @@ impl Planner for Macos {
         } = self;
         let mut map = HashMap::default();
 
-        map.extend(settings.settings()?.into_iter());
+        map.extend(settings.settings()?);
         map.insert("volume_encrypt".into(), serde_json::to_value(encrypt)?);
         map.insert("volume_label".into(), serde_json::to_value(volume_label)?);
         map.insert("root_disk".into(), serde_json::to_value(root_disk)?);

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -12,7 +12,7 @@ use crate::{
     action::{
         base::RemoveDirectory,
         common::{ConfigureInitService, ConfigureNix, CreateUsersAndGroups, ProvisionNix},
-        macos::{CreateNixVolume, SetTmutilExclusions},
+        macos::{CreateNixHookService, CreateNixVolume, SetTmutilExclusions},
         StatefulAction,
     },
     execute_command,
@@ -152,6 +152,10 @@ impl Planner for Macos {
                 .map_err(PlannerError::Action)?
                 .boxed(),
             ConfigureNix::plan(ShellProfileLocations::default(), &self.settings)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
+            CreateNixHookService::plan()
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -231,9 +231,9 @@ impl Planner for Macos {
     }
 }
 
-impl Into<BuiltinPlanner> for Macos {
-    fn into(self) -> BuiltinPlanner {
-        BuiltinPlanner::Macos(self)
+impl From<Macos> for BuiltinPlanner {
+    fn from(val: Macos) -> Self {
+        BuiltinPlanner::Macos(val)
     }
 }
 

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -122,11 +122,8 @@ impl Planner for Macos {
 
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 let stdout_trimmed = stdout.trim();
-                if stdout_trimmed == "true" {
-                    true
-                } else {
-                    false
-                }
+
+                stdout_trimmed == "true"
             },
         };
 

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -129,58 +129,66 @@ impl Planner for Macos {
 
         let mut plan = vec![];
 
-        plan.push(CreateNixVolume::plan(
-            root_disk.unwrap(), /* We just ensured it was populated */
-            self.volume_label.clone(),
-            false,
-            encrypt,
-        )
-        .await
-        .map_err(PlannerError::Action)?
-        .boxed(),
-        );
-        plan.push(ProvisionNix::plan(&self.settings)
+        plan.push(
+            CreateNixVolume::plan(
+                root_disk.unwrap(), /* We just ensured it was populated */
+                self.volume_label.clone(),
+                false,
+                encrypt,
+            )
             .await
             .map_err(PlannerError::Action)?
-            .boxed()
+            .boxed(),
+        );
+        plan.push(
+            ProvisionNix::plan(&self.settings)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
         );
         // Auto-allocate uids is broken on Mac. Tools like `whoami` don't work.
         // e.g. https://github.com/NixOS/nix/issues/8444
-        plan.push(CreateUsersAndGroups::plan(self.settings.clone())
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed()
+        plan.push(
+            CreateUsersAndGroups::plan(self.settings.clone())
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
         );
-        plan.push(SetTmutilExclusions::plan(vec![PathBuf::from("/nix/store"), PathBuf::from("/nix/var")])
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed()
+        plan.push(
+            SetTmutilExclusions::plan(vec![PathBuf::from("/nix/store"), PathBuf::from("/nix/var")])
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
         );
-        plan.push(ConfigureNix::plan(ShellProfileLocations::default(), &self.settings)
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed()
+        plan.push(
+            ConfigureNix::plan(ShellProfileLocations::default(), &self.settings)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
         );
 
         if self.settings.modify_profile {
-            plan.push(CreateNixHookService::plan()
-                .await
-                .map_err(PlannerError::Action)?
-                .boxed()
+            plan.push(
+                CreateNixHookService::plan()
+                    .await
+                    .map_err(PlannerError::Action)?
+                    .boxed(),
             );
         }
-        
-        plan.push(ConfigureInitService::plan(InitSystem::Launchd, true)
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed()
+
+        plan.push(
+            ConfigureInitService::plan(InitSystem::Launchd, true)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
         );
-        plan.push(RemoveDirectory::plan(crate::settings::SCRATCH_DIR)
-            .await
-            .map_err(PlannerError::Action)?
-            .boxed()
+        plan.push(
+            RemoveDirectory::plan(crate::settings::SCRATCH_DIR)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
         );
-        
+
         Ok(plan)
     }
 


### PR DESCRIPTION
##### Description

This PR adds a global launch daemon on macOS which restores the shell hook after system upgrades, fixing the problem of Nix being "uninstalled" after each upgrade.

This is a rough pass to be improved. I haven't tested this exact implementation yet, but I tested the idea and it works. I'll be testing the implementation shortly.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
