### PR TITLE
Make sure /etc/tmpfiles.d exists on the ostree planner

### DIFF
--- a/src/planner/ostree.rs
+++ b/src/planner/ostree.rs
@@ -200,6 +200,13 @@ impl Planner for Ostree {
         }
 
         plan.push(
+            CreateDirectory::plan("/etc/tmpfiles.d", None, None, 0o0755, false)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
+        );
+
+        plan.push(
             ConfigureInitService::plan(InitSystem::Systemd, true)
                 .await
                 .map_err(PlannerError::Action)?


### PR DESCRIPTION
##### Description

This directory is not guaranteed to exist. Adding this to the plan solves a very small handful of installation errors.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
