### PR TITLE
Document the known nix-darwin related uninstall issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,10 @@ There are two possible workarounds for this:
 
 ### Using MacOS after removing `nix` while `nix-darwin` was still installed, network requests fail
 
-If `nix` was previously uninstalled (using the [reference documentation](https://nixos.org/manual/nix/stable/installation/uninstall))
-but `nix-darwin` was not uninstalled beforehand, users may experience errors similar to this:
+If `nix` was previously uninstalled without uninstalling `nix-darwin first`, users may experience errors similar to this:
 
 ```bash
-$ nix profile install nixpkgs#curl
+$ nix shell nixpkgs#curl
 error: unable to download 'https://cache.nixos.org/g8bqlgmpa4yg601w561qy2n576i6g0vh.narinfo': Problem with the SSL CA cert (path? access rights?) (77)
 ```
 
@@ -329,7 +328,7 @@ drwxr-xr-x  6 root  wheel   192B Sep 16 06:28 ..
 lrwxr-xr-x  1 root  wheel    41B Oct 17 08:26 ca-certificates.crt -> /etc/static/ssl/certs/ca-certificates.crt
 ```
 
-The problem is compounded by the matter that the [`nix-darwin` uninstaller](https://github.com/LnL7/nix-darwin#uninstalling) will not work, since it requires Nix to exist and have network connectivity.
+The problem is compounded by the matter that the [`nix-darwin` uninstaller](https://github.com/LnL7/nix-darwin#uninstalling) will not work after uninstalling Nix, since it uses Nix and requires network connectivity.
 
 It's possible to resolve this situation by removing the `org.nixos.activate-system` service and the `ca-certificates`:
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ There are two possible workarounds for this:
 
 ### Using MacOS after removing `nix` while `nix-darwin` was still installed, network requests fail
 
-If `nix` was previously uninstalled without uninstalling `nix-darwin first`, users may experience errors similar to this:
+If `nix` was previously uninstalled without uninstalling `nix-darwin` first, users may experience errors similar to this:
 
 ```bash
 $ nix shell nixpkgs#curl


### PR DESCRIPTION
##### Description

Until we add some knowledge to the `macos` planner about how to do this automatically, this is a stopgap that uses the workaround presented by @cole-h in https://github.com/DeterminateSystems/nix-installer/issues/608#issuecomment-1692499816.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
