### PR TITLE
Add 'sudo' to suggestions for launchd-related config fixes

### DIFF
--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -311,7 +311,7 @@ pub enum CreateVolumeServiceError {
     },
     #[error("UUID for APFS volume labelled `{0}` was not found")]
     CannotDetermineUuid(String),
-    #[error("An APFS volume labelled `{1}` does not exist, but there exists an fstab entry for that volume, as well as a service file at `{0}`. Consider removing the line containing `/nix` from the `/etc/fstab` and running `rm {0}`")]
+    #[error("An APFS volume labelled `{1}` does not exist, but there exists an fstab entry for that volume, as well as a service file at `{0}`. Consider removing the line containing `/nix` from the `/etc/fstab` and running `sudo rm {0}`")]
     VolumeDoesNotExistButVolumeServiceAndFstabEntryDoes(PathBuf, String),
 }
 

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -254,9 +254,9 @@ impl Action for EncryptApfsVolume {
 pub enum EncryptApfsVolumeError {
     #[error("The keychain has an existing password for a non-existing \"{0}\" volume on disk `{1}`, consider removing the password with `sudo security delete-generic-password  -a \"{0}\" -s \"Nix Store\" -l \"{1} encryption password\" -D \"Encrypted volume password\"`. Note that it's possible to have several passwords stored, so you may need to run this command several times until receiving the message `The specified item could not be found in the keychain.`")]
     ExistingPasswordFound(String, PathBuf),
-    #[error("The keychain lacks a password for the already existing \"{0}\" volume on disk `{1}`, consider removing the volume with `diskutil apfs deleteVolume \"{0}\"` (if you receive error -69888, you may need to run `launchctl bootout system/org.nixos.darwin-store` and `launchctl bootout system/org.nixos.nix-daemon` first)")]
+    #[error("The keychain lacks a password for the already existing \"{0}\" volume on disk `{1}`, consider removing the volume with `diskutil apfs deleteVolume \"{0}\"` (if you receive error -69888, you may need to run `sudo launchctl bootout system/org.nixos.darwin-store` and `sudo launchctl bootout system/org.nixos.nix-daemon` first)")]
     MissingPasswordForExistingVolume(String, PathBuf),
-    #[error("The existing APFS volume \"{0}\" on disk `{1}` is not encrypted but it should be, consider removing the volume with `diskutil apfs deleteVolume \"{0}\"` (if you receive error -69888, you may need to run `launchctl bootout system/org.nixos.darwin-store` and `launchctl bootout system/org.nixos.nix-daemon` first)")]
+    #[error("The existing APFS volume \"{0}\" on disk `{1}` is not encrypted but it should be, consider removing the volume with `diskutil apfs deleteVolume \"{0}\"` (if you receive error -69888, you may need to run `sudo launchctl bootout system/org.nixos.darwin-store` and `sudo launchctl bootout system/org.nixos.nix-daemon` first)")]
     ExistingVolumeNotEncrypted(String, PathBuf),
 }
 


### PR DESCRIPTION
##### Description

When I ran through the installer and had remnants of the old Nix installer, I was running the suggested commands in another terminal and so had to remember to preface them with `sudo`. Just a small fix I figured might help with the suggestions! Feel free to take it if you deem appropriate.

##### Checklist

- [x] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
