### PR TITLE
Fix fish support on ostree

### DIFF
--- a/src/planner/ostree.rs
+++ b/src/planner/ostree.rs
@@ -21,6 +21,19 @@ use super::{
     ShellProfileLocations,
 };
 
+// Fedora's ostree's fish package creates `/etc/fish` but fish doesn't read from it.
+// Its fish does read from /usr/local/share/fish/, but the directory doesn't exist --
+// so we ignore it.
+//
+// We use this const to forcefully create this directory and add it to shell locations
+// to think about updating.
+//
+// This may not be suitable for all possible ostree based distros, but it'll fix
+// a good number of selftest failures we're seeing.
+//
+// See: #707
+pub const OSTREE_FISH_PROFILE_LOCATION: &str = "/usr/local/share/fish/";
+
 /// A planner suitable for immutable systems using ostree, such as Fedora Silverblue
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "cli", derive(clap::Parser))]
@@ -183,6 +196,16 @@ impl Planner for Ostree {
                 .map_err(PlannerError::Action)?
                 .boxed(),
         );
+
+        if Path::new("/etc/fish").is_directory() {
+            plan.push(
+                CreateDirectory::plan(&OSTREE_FISH_PROFILE_LOCATION, None, None, 0o0755, true)
+                    .await
+                    .map_err(PlannerError::Action)?
+                    .boxed(),
+            );
+        }
+
         plan.push(
             ConfigureNix::plan(shell_profile_locations, &self.settings)
                 .await

--- a/src/planner/ostree.rs
+++ b/src/planner/ostree.rs
@@ -31,7 +31,7 @@ use super::{
 // This may not be suitable for all possible ostree based distros, but it'll fix
 // a good number of selftest failures we're seeing.
 //
-// See: #707
+// See: https://github.com/DeterminateSystems/nix-installer/issues/707
 pub const OSTREE_FISH_PROFILE_LOCATION: &str = "/usr/local/share/fish/";
 
 /// A planner suitable for immutable systems using ostree, such as Fedora Silverblue
@@ -171,10 +171,8 @@ impl Planner for Ostree {
             .iter()
             .position(|v| *v == PathBuf::from("/usr/share/fish/"))
         {
-            shell_profile_locations
-                .fish
-                .vendor_confd_prefixes
-                .remove(index);
+            shell_profile_locations.fish.vendor_confd_prefixes =
+                &[OSTREE_FISH_PROFILE_LOCATION.into()];
         }
 
         plan.push(

--- a/src/planner/ostree.rs
+++ b/src/planner/ostree.rs
@@ -11,7 +11,10 @@ use crate::{
     settings::{InitSystem, InstallSettingsError},
     Action, BuiltinPlanner,
 };
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use super::{
     linux::{
@@ -172,7 +175,7 @@ impl Planner for Ostree {
             .position(|v| *v == PathBuf::from("/usr/share/fish/"))
         {
             shell_profile_locations.fish.vendor_confd_prefixes =
-                &[OSTREE_FISH_PROFILE_LOCATION.into()];
+                vec![OSTREE_FISH_PROFILE_LOCATION.into()];
         }
 
         plan.push(

--- a/src/planner/ostree.rs
+++ b/src/planner/ostree.rs
@@ -198,7 +198,7 @@ impl Planner for Ostree {
                 .boxed(),
         );
 
-        if Path::new("/etc/fish").is_directory() {
+        if Path::new("/etc/fish").is_dir() {
             plan.push(
                 CreateDirectory::plan(&OSTREE_FISH_PROFILE_LOCATION, None, None, 0o0755, true)
                     .await


### PR DESCRIPTION
##### Description

Closes #707 

##### Checklist

- [x] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
