### PR TITLE
Support remote-building to macOS hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ The Determinate Nix installer has numerous advantages:
 * supporting a expanded test suite including 'curing' cases
 * supporting SELinux and OSTree based distributions without asking users to make compromises
 * operating as a single, static binary with external dependencies such as `openssl`, only calling existing system tools (like `useradd`) where necessary
-* supports remote building out of the box
+* As a MacOS remote build target, ensures `nix` is not absent from path
 
 It has been wonderful to collaborate with other participants in the Nix Installer Working Group and members of the broader community. The working group maintains a [foundation owned fork of the installer](https://github.com/nixos/experimental-nix-installer/).
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ While `nix-installer` tries to provide a comprehensive and unquirky experience, 
 
 ### Using MacOS remote SSH builders, Nix binaries are not on `$PATH`
 
+*For Nix installations before Determinate Nix Installer version 0.14.1.*
+
 When connecting to a Mac remote SSH builder users may sometimes see this error:
 
 ```bash
@@ -288,25 +290,11 @@ There are two possible workarounds for this:
 * Update `/etc/zshenv` on the remote so that `zsh` populates the Nix path for every shell, even those that are neither *interactive* or *login*:
   ```bash
   # Nix
-  if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+  if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ] && [ -n "${SSH_CONNECTION}" ] && [ "${SHLVL}" -eq 1 ]; then
       . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
   fi
   # End Nix
   ```
-  <details>
-    <summary>This strategy has some behavioral caveats, namely, <code>$PATH</code> may have unexpected contents</summary>
-
-    For example, if `$PATH` gets unset then a script invoked, `$PATH` may not be as empty as expected:
-    ```bash
-    $ cat example.sh     
-    #! /bin/zsh
-    echo $PATH
-    $ PATH= ./example.sh 
-    /Users/ephemeraladmin/.nix-profile/bin:/nix/var/nix/profiles/default/bin:
-    ```
-    This strategy results in Nix's paths being present on `$PATH` twice and may have a minor impact on performance.
-
-  </details>
 
 ### Using MacOS after removing `nix` while `nix-darwin` was still installed, network requests fail
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A fast, friendly, and reliable tool to help you use Nix with Flakes everywhere.
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 ```
 
-The `nix-installer` has successfully completed over 500,000 installs in a number of environments, including [Github Actions](#as-a-github-action):
+The `nix-installer` has successfully completed over 1,000,000 installs in a number of environments, including [Github Actions](#as-a-github-action):
 
 | Platform                     | Multi User         | `root` only | Maturity          |
 |------------------------------|:------------------:|:-----------:|:-----------------:|

--- a/README.md
+++ b/README.md
@@ -265,37 +265,6 @@ This is especially useful when using the installer in non-interactive scripts.
 
 While `nix-installer` tries to provide a comprehensive and unquirky experience, there are unfortunately some issues which may require manual intervention or operator choices.
 
-### Using MacOS remote SSH builders, Nix binaries are not on `$PATH`
-
-*For Nix installations before Determinate Nix Installer version 0.14.1.*
-
-When connecting to a Mac remote SSH builder users may sometimes see this error:
-
-```bash
-$ nix store ping --store "ssh://$USER@$HOST"
-Store URL: ssh://$USER@$HOST
-zsh:1: command not found: nix-store
-error: cannot connect to '$USER@$HOST'
-```
-
-The way MacOS populates the `PATH` environment differs from other environments. ([Some background](https://gist.github.com/Linerre/f11ad4a6a934dcf01ee8415c9457e7b2))
-
-There are two possible workarounds for this:
-
-* **(Preferred)** Update the remote builder URL to include the `remote-program` parameter pointing to `nix-store`. For example:
-  ```bash
-  nix store ping --store "ssh://$USER@$HOST?remote-program=/nix/var/nix/profiles/default/bin/nix-store"
-  ```
-  If you are unsure where the `nix-store` binary is located, run `which nix-store` on the remote.
-* Update `/etc/zshenv` on the remote so that `zsh` populates the Nix path for every shell, even those that are neither *interactive* or *login*:
-  ```bash
-  # Nix
-  if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ] && [ -n "${SSH_CONNECTION}" ] && [ "${SHLVL}" -eq 1 ]; then
-      . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-  fi
-  # End Nix
-  ```
-
 ### Using MacOS after removing `nix` while `nix-darwin` was still installed, network requests fail
 
 If `nix` was previously uninstalled without uninstalling `nix-darwin` first, users may experience errors similar to this:

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ Subtle differences in the shell implementations and tool used in the scripts mak
 
 The Determinate Nix installer has numerous advantages:
 
+* survives macOS upgrades
 * keeping an installation receipt for easy uninstallation
 * offering users a chance to review an accurate, calculated install plan
 * having 'planners' which can create appropriate install plans for complicated targets
@@ -434,6 +435,7 @@ The Determinate Nix installer has numerous advantages:
 * supporting a expanded test suite including 'curing' cases
 * supporting SELinux and OSTree based distributions without asking users to make compromises
 * operating as a single, static binary with external dependencies such as `openssl`, only calling existing system tools (like `useradd`) where necessary
+* supports remote building out of the box
 
 It has been wonderful to collaborate with other participants in the Nix Installer Working Group and members of the broader community. The working group maintains a [foundation owned fork of the installer](https://github.com/nixos/experimental-nix-installer/).
 

--- a/src/action/macos/configure_remote_building.rs
+++ b/src/action/macos/configure_remote_building.rs
@@ -25,7 +25,7 @@ impl ConfigureRemoteBuilding {
 
         let shell_buf = format!(
             r#"
-# Nix, only on remote SSH connections -- for remote building.
+# Set up Nix only on SSH connections
 # See: https://github.com/DeterminateSystems/nix-installer/pull/714
 if [ -e '{PROFILE_NIX_FILE_SHELL}' ] && [ -n "${{SSH_CONNECTION}}" ] && [ "${{SHLVL}}" -eq 1 ]; then
     . '{PROFILE_NIX_FILE_SHELL}'

--- a/src/action/macos/configure_remote_building.rs
+++ b/src/action/macos/configure_remote_building.rs
@@ -26,7 +26,7 @@ impl ConfigureRemoteBuilding {
         let shell_buf = format!(
             r#"
 # Nix, only on remote SSH connections -- for remote building.
-# See: <TICKET NUMBER>
+# See: https://github.com/DeterminateSystems/nix-installer/pull/714
 if [ -e '{PROFILE_NIX_FILE_SHELL}' ] && [ -n "${{SSH_CONNECTION}}" ] && [ "${{SHLVL}}" -eq 1 ]; then
     . '{PROFILE_NIX_FILE_SHELL}'
 fi

--- a/src/action/macos/configure_remote_building.rs
+++ b/src/action/macos/configure_remote_building.rs
@@ -1,0 +1,166 @@
+use crate::action::base::{create_or_insert_into_file, CreateOrInsertIntoFile};
+use crate::action::{
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
+
+use std::path::Path;
+use tokio::task::JoinSet;
+use tracing::{span, Instrument, Span};
+
+const PROFILE_NIX_FILE_SHELL: &str = "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh";
+
+/**
+Configure macOS's zshenv to load the Nix environment when ForceCommand is used.
+This enables remote building, which requires `ssh host nix` to work.
+ */
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct ConfigureRemoteBuilding {
+    create_or_insert_into_files: Vec<StatefulAction<CreateOrInsertIntoFile>>,
+}
+
+impl ConfigureRemoteBuilding {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
+        let mut create_or_insert_into_files = Vec::default();
+
+        let shell_buf = format!(
+            r#"
+# Nix, only on remote SSH connections -- for remote building.
+# See: <TICKET NUMBER>
+if [ -e '{PROFILE_NIX_FILE_SHELL}' ] && [ -n "${{SSH_CONNECTION}}" ] && [ "${{SHLVL}}" -eq 1 ]; then
+    . '{PROFILE_NIX_FILE_SHELL}'
+fi
+# End Nix
+"#
+        );
+
+        let profile_target_path = Path::new("/etc/zshenv");
+        create_or_insert_into_files.push(
+            CreateOrInsertIntoFile::plan(
+                profile_target_path,
+                None,
+                None,
+                0o644,
+                shell_buf.to_string(),
+                create_or_insert_into_file::Position::Beginning,
+            )
+            .await
+            .map_err(Self::error)?,
+        );
+
+        Ok(Self {
+            create_or_insert_into_files,
+        }
+        .into())
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "configure_remote_building")]
+impl Action for ConfigureRemoteBuilding {
+    fn action_tag() -> ActionTag {
+        ActionTag("configure_remote_building")
+    }
+    fn tracing_synopsis(&self) -> String {
+        "Configuring zsh to support using Nix in non-interactive shells".to_string()
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(tracing::Level::DEBUG, "configure_remote_building",)
+    }
+
+    fn execute_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(
+            self.tracing_synopsis(),
+            vec!["Update zshenv to import Nix".to_string()],
+        )]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn execute(&mut self) -> Result<(), ActionError> {
+        let mut set = JoinSet::new();
+        let mut errors = vec![];
+
+        for (idx, create_or_insert_into_file) in
+            self.create_or_insert_into_files.iter_mut().enumerate()
+        {
+            let span = tracing::Span::current().clone();
+            let mut create_or_insert_into_file_clone = create_or_insert_into_file.clone();
+            let _abort_handle = set.spawn(async move {
+                create_or_insert_into_file_clone
+                    .try_execute()
+                    .instrument(span)
+                    .await
+                    .map_err(Self::error)?;
+                Result::<_, ActionError>::Ok((idx, create_or_insert_into_file_clone))
+            });
+        }
+
+        while let Some(result) = set.join_next().await {
+            match result {
+                Ok(Ok((idx, create_or_insert_into_file))) => {
+                    self.create_or_insert_into_files[idx] = create_or_insert_into_file
+                },
+                Ok(Err(e)) => errors.push(e),
+                Err(e) => return Err(Self::error(e))?,
+            };
+        }
+
+        if !errors.is_empty() {
+            if errors.len() == 1 {
+                return Err(Self::error(errors.into_iter().next().unwrap()))?;
+            } else {
+                return Err(Self::error(ActionErrorKind::MultipleChildren(
+                    errors.into_iter().collect(),
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn revert_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(
+            "Remove the Nix configuration from zsh's non-login shells".to_string(),
+            vec!["Update zshenv to no longer import Nix".to_string()],
+        )]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn revert(&mut self) -> Result<(), ActionError> {
+        let mut set = JoinSet::new();
+        let mut errors = vec![];
+
+        for (idx, create_or_insert_into_file) in
+            self.create_or_insert_into_files.iter_mut().enumerate()
+        {
+            let mut create_or_insert_file_clone = create_or_insert_into_file.clone();
+            let _abort_handle = set.spawn(async move {
+                create_or_insert_file_clone.try_revert().await?;
+                Result::<_, _>::Ok((idx, create_or_insert_file_clone))
+            });
+        }
+
+        while let Some(result) = set.join_next().await {
+            match result {
+                Ok(Ok((idx, create_or_insert_into_file))) => {
+                    self.create_or_insert_into_files[idx] = create_or_insert_into_file
+                },
+                Ok(Err(e)) => errors.push(e),
+                // This is quite rare and generally a very bad sign.
+                Err(e) => return Err(e).map_err(|e| Self::error(ActionErrorKind::from(e)))?,
+            };
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else if errors.len() == 1 {
+            Err(errors
+                .into_iter()
+                .next()
+                .expect("Expected 1 len Vec to have at least 1 item"))
+        } else {
+            Err(Self::error(ActionErrorKind::MultipleChildren(errors)))
+        }
+    }
+}

--- a/src/action/macos/configure_remote_building.rs
+++ b/src/action/macos/configure_remote_building.rs
@@ -72,7 +72,7 @@ impl Action for ConfigureRemoteBuilding {
     fn execute_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(
             self.tracing_synopsis(),
-            vec!["Update zshenv to import Nix".to_string()],
+            vec!["Update `/etc/zshenv` to import Nix".to_string()],
         )]
     }
 
@@ -122,7 +122,7 @@ impl Action for ConfigureRemoteBuilding {
     fn revert_description(&self) -> Vec<ActionDescription> {
         vec![ActionDescription::new(
             "Remove the Nix configuration from zsh's non-login shells".to_string(),
-            vec!["Update zshenv to no longer import Nix".to_string()],
+            vec!["Update `/etc/zshenv` to no longer import Nix".to_string()],
         )]
     }
 

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -2,6 +2,7 @@
 */
 
 pub(crate) mod bootstrap_launchctl_service;
+pub(crate) mod configure_remote_building;
 pub(crate) mod create_apfs_volume;
 pub(crate) mod create_fstab_entry;
 pub(crate) mod create_nix_hook_service;
@@ -16,6 +17,7 @@ pub(crate) mod set_tmutil_exclusions;
 pub(crate) mod unmount_apfs_volume;
 
 pub use bootstrap_launchctl_service::BootstrapLaunchctlService;
+pub use configure_remote_building::ConfigureRemoteBuilding;
 pub use create_apfs_volume::CreateApfsVolume;
 pub use create_nix_hook_service::CreateNixHookService;
 pub use create_nix_volume::{CreateNixVolume, NIX_VOLUME_MOUNTD_DEST};

--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -40,7 +40,8 @@ impl CommandExecute for Repair {
             println!("{:#?}", err);
             return Ok(ExitCode::FAILURE);
         }
-
+// TODO: Using `cfg` based on OS is not a long term solution.
+// Make this read the planner from the `/nix/receipt.json` to determine which tasks to run.
         #[cfg(target_os = "macos")]
         {
             let mut reconfigure = crate::action::macos::ConfigureRemoteBuilding::plan()

--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -38,7 +38,7 @@ impl CommandExecute for Repair {
 
         if let Err(err) = reconfigure.try_execute().await {
             println!("{:#?}", err);
-            return Ok(ExitCode::FAILURE)
+            return Ok(ExitCode::FAILURE);
         }
 
         #[cfg(target_os = "macos")]
@@ -50,7 +50,7 @@ impl CommandExecute for Repair {
 
             if let Err(err) = reconfigure.try_execute().await {
                 println!("{:#?}", err);
-                return Ok(ExitCode::FAILURE)
+                return Ok(ExitCode::FAILURE);
             }
         }
 

--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -40,8 +40,8 @@ impl CommandExecute for Repair {
             println!("{:#?}", err);
             return Ok(ExitCode::FAILURE);
         }
-// TODO: Using `cfg` based on OS is not a long term solution.
-// Make this read the planner from the `/nix/receipt.json` to determine which tasks to run.
+        // TODO: Using `cfg` based on OS is not a long term solution.
+        // Make this read the planner from the `/nix/receipt.json` to determine which tasks to run.
         #[cfg(target_os = "macos")]
         {
             let mut reconfigure = crate::action::macos::ConfigureRemoteBuilding::plan()

--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -38,9 +38,22 @@ impl CommandExecute for Repair {
 
         if let Err(err) = reconfigure.try_execute().await {
             println!("{:#?}", err);
-            Ok(ExitCode::FAILURE)
-        } else {
-            Ok(ExitCode::SUCCESS)
+            return Ok(ExitCode::FAILURE)
         }
+
+        #[cfg(target_os = "macos")]
+        {
+            let mut reconfigure = crate::action::macos::ConfigureRemoteBuilding::plan()
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed();
+
+            if let Err(err) = reconfigure.try_execute().await {
+                println!("{:#?}", err);
+                return Ok(ExitCode::FAILURE)
+            }
+        }
+
+        Ok(ExitCode::SUCCESS)
     }
 }

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -12,7 +12,9 @@ use crate::{
     action::{
         base::RemoveDirectory,
         common::{ConfigureInitService, ConfigureNix, CreateUsersAndGroups, ProvisionNix},
-        macos::{CreateNixHookService, CreateNixVolume, SetTmutilExclusions},
+        macos::{
+            ConfigureRemoteBuilding, CreateNixHookService, CreateNixVolume, SetTmutilExclusions,
+        },
         StatefulAction,
     },
     execute_command,
@@ -162,6 +164,12 @@ impl Planner for Macos {
         );
         plan.push(
             ConfigureNix::plan(ShellProfileLocations::default(), &self.settings)
+                .await
+                .map_err(PlannerError::Action)?
+                .boxed(),
+        );
+        plan.push(
+            ConfigureRemoteBuilding::plan()
                 .await
                 .map_err(PlannerError::Action)?
                 .boxed(),


### PR DESCRIPTION
Our README has long featured a snippet to add to the zshenv, with a caveat that it might behave strangely if you're writing a script with an empty PATH.

It is pretty straightforward to eliminate those caveats while still providing remote building for Nix to macOS hosts.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
