### PR TITLE
Remove the writable flag, don't set too many permission bits

### DIFF
--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -422,6 +422,8 @@ pub enum ActionErrorKind {
         std::path::PathBuf,
         #[source] std::io::Error,
     ),
+    #[error("Getting filesystem metadata for `{0}` on `{1}`")]
+    GetMetadata(std::path::PathBuf, #[source] std::io::Error),
     #[error("Set mode `{0:#o}` on `{1}`")]
     SetPermissions(u32, std::path::PathBuf, #[source] std::io::Error),
     #[error("Remove file `{0}`")]


### PR DESCRIPTION
##### Description

Making everything 0o555 is too much, since many files in the store
are not supposed to be executable. Those should be 0o444. Instead
of splatting 0o555 out, take a more measured approach and remove
the writable flag from the on-disk mode.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
