### PR TITLE
Mostly replace profile scripts with Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "export"
+version = "0.1.0"
+source = "git+https://github.com/DeterminateSystems/export#cf859216f9b4b9e27ef0aa0bcb2f52ca8a4e1c02"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +971,7 @@ dependencies = [
  "color-eyre",
  "dirs",
  "dyn-clone",
+ "export",
  "eyre",
  "glob",
  "indexmap 2.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ which = "4.4.0"
 sysctl = "0.5.4"
 walkdir = "2.3.3"
 indexmap = { version = "2.0.2", features = ["serde"] }
+export = { git = "https://github.com/DeterminateSystems/export" }
 
 [dev-dependencies]
 eyre = { version = "0.6.8", default-features = false, features = [ "track-caller" ] }

--- a/src/action/common/profiles/profile.fish
+++ b/src/action/common/profiles/profile.fish
@@ -3,4 +3,4 @@ if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFI
         | while read --null key
             read --export --null "$key"
         end
-fi
+end

--- a/src/action/common/profiles/profile.fish
+++ b/src/action/common/profiles/profile.fish
@@ -1,6 +1,3 @@
-if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then
-    /nix/nix-installer export --format null-separated \
-        | while read --null key
-            read --export --null "$key"
-        end
+if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && not set -q __ETC_PROFILE_NIX_SOURCED;
+    eval "$(/nix/nix-installer export --format fish)"
 end

--- a/src/action/common/profiles/profile.fish
+++ b/src/action/common/profiles/profile.fish
@@ -1,0 +1,6 @@
+if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then
+    /nix/nix-installer export --format null-separated \
+        | while read --null key
+            read --export --null "$key"
+        end
+fi

--- a/src/action/common/profiles/profile.sh
+++ b/src/action/common/profiles/profile.sh
@@ -1,0 +1,13 @@
+# shellcheck shell=sh
+if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then
+    NIX_INSTALLER_EXPORT_DATA=$(/nix/nix-installer export --verbose --verbose --format space-newline-separated);
+    while read -r nix_installer_export_key nix_installer_export_value; do
+        export "$nix_installer_export_key=$nix_installer_export_value";
+    done <<DATA_INPUT
+$NIX_INSTALLER_EXPORT_DATA
+DATA_INPUT
+
+    unset NIX_INSTALLER_EXPORT_DATA
+else
+    echo "not running import" >&2
+fi

--- a/src/action/common/profiles/profile.sh
+++ b/src/action/common/profiles/profile.sh
@@ -7,7 +7,5 @@ if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFI
 $NIX_INSTALLER_EXPORT_DATA
 DATA_INPUT
 
-    unset NIX_INSTALLER_EXPORT_DATA
-else
-    echo "not running import" >&2
+    unset NIX_INSTALLER_EXPORT_DATA nix_installer_export_key nix_installer_export_value
 fi

--- a/src/action/common/profiles/profile.sh
+++ b/src/action/common/profiles/profile.sh
@@ -1,11 +1,15 @@
 # shellcheck shell=sh
 if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then
-    NIX_INSTALLER_EXPORT_DATA=$(/nix/nix-installer export --verbose --verbose --format space-newline-separated);
-    while read -r nix_installer_export_key nix_installer_export_value; do
-        export "$nix_installer_export_key=$nix_installer_export_value";
-    done <<DATA_INPUT
-$NIX_INSTALLER_EXPORT_DATA
+    if NIX_INSTALLER_EXPORT_DATA=$(/nix/nix-installer export --format space-newline-separated); then
+        while read -r nix_installer_export_key nix_installer_export_value; do
+            if [ -n "$nix_installer_export_key" ]; then
+                export "$nix_installer_export_key=$nix_installer_export_value";
+            fi
+        done <<DATA_INPUT
+    $NIX_INSTALLER_EXPORT_DATA
 DATA_INPUT
+        unset nix_installer_export_key nix_installer_export_value
+    fi
 
-    unset NIX_INSTALLER_EXPORT_DATA nix_installer_export_key nix_installer_export_value
+    unset NIX_INSTALLER_EXPORT_DATA
 fi

--- a/src/action/common/profiles/profile.sh
+++ b/src/action/common/profiles/profile.sh
@@ -1,15 +1,5 @@
 # shellcheck shell=sh
-if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then
-    if NIX_INSTALLER_EXPORT_DATA=$(/nix/nix-installer export --format space-newline-separated); then
-        while read -r nix_installer_export_key nix_installer_export_value; do
-            if [ -n "$nix_installer_export_key" ]; then
-                export "$nix_installer_export_key=$nix_installer_export_value";
-            fi
-        done <<DATA_INPUT
-    $NIX_INSTALLER_EXPORT_DATA
-DATA_INPUT
-        unset nix_installer_export_key nix_installer_export_value
-    fi
 
-    unset NIX_INSTALLER_EXPORT_DATA
+if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then
+    eval "$(/nix/nix-installer export --format sh)"
 fi

--- a/src/action/macos/configure_remote_building.rs
+++ b/src/action/macos/configure_remote_building.rs
@@ -1,10 +1,10 @@
-use crate::action::base::{create_or_insert_into_file, CreateOrInsertIntoFile};
-use crate::action::{Action, ActionDescription, ActionError, ActionTag, StatefulAction};
-
 use std::path::Path;
+
 use tracing::{span, Instrument, Span};
 
-const PROFILE_NIX_FILE_SHELL: &str = "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh";
+use crate::action::base::{create_or_insert_into_file, CreateOrInsertIntoFile};
+use crate::action::common::configure_shell_profile::PROFILE_NIX_FILE_SHELL;
+use crate::action::{Action, ActionDescription, ActionError, ActionTag, StatefulAction};
 
 /**
 Configure macOS's zshenv to load the Nix environment when ForceCommand is used.
@@ -20,12 +20,14 @@ impl ConfigureRemoteBuilding {
     pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
         let shell_buf = format!(
             r#"
+
 # Set up Nix only on SSH connections
 # See: https://github.com/DeterminateSystems/nix-installer/pull/714
-if [ -e '{PROFILE_NIX_FILE_SHELL}' ] && [ -n "${{SSH_CONNECTION}}" ] && [ "${{SHLVL}}" -eq 1 ]; then
+if [ -n "${{SSH_CONNECTION}}" ] && [ "${{SHLVL}}" -eq 1 ] && [ -f '{PROFILE_NIX_FILE_SHELL}' ]; then
     . '{PROFILE_NIX_FILE_SHELL}'
 fi
 # End Nix
+
 "#
         );
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,6 +49,7 @@ impl CommandExecute for NixInstallerCli {
             NixInstallerSubcommand::Install(install) => install.execute().await,
             NixInstallerSubcommand::Repair(restore_shell) => restore_shell.execute().await,
             NixInstallerSubcommand::Uninstall(revert) => revert.execute().await,
+            NixInstallerSubcommand::Export(export) => export.execute().await,
         }
     }
 }

--- a/src/cli/subcommand/export.rs
+++ b/src/cli/subcommand/export.rs
@@ -268,7 +268,7 @@ pub fn calculate_environment() -> Result<HashMap<&'static str, OsString>, Error>
         }
     }
 
-    {
+    if let Some(old_path) = env_path("MANPATH") {
         let mut path = vec![
             nix_link.join("share/man"),
             // Note: This is typically only used in single-user installs, but I chose to do it in both for simplicity.
@@ -276,9 +276,7 @@ pub fn calculate_environment() -> Result<HashMap<&'static str, OsString>, Error>
             PathBuf::from(LOCAL_STATE_DIR).join("nix/profiles/default/share/man"),
         ];
 
-        if let Some(old_path) = env_path("MANPATH") {
-            path.extend(old_path);
-        }
+        path.extend(old_path);
 
         if let Ok(dirs) = env::join_paths(&path) {
             envs.insert("MANPATH", dirs);

--- a/src/cli/subcommand/export.rs
+++ b/src/cli/subcommand/export.rs
@@ -34,28 +34,6 @@ pub enum Error {
 /**
 Emit all the environment variables that should be set to use Nix.
 
-In POSIX shell:
-
-    nix-installer export --format space-newline-separated \
-      | while IFS=' ' read key value; do
-        export "$key"="$value"
-    done
-
-In Bash / non-POSIX shell:
-
-    nix-installer export --format null-separated \
-      | while IFS= read -r -d $'\0' key && IFS= read -r -d $'\0' value; do
-        export "$key"="$value"
-    done
-
-In Fish shell:
-
-    nix-installer export --format null-separated \
-      | while read --null key
-        read --export --null "$key"
-    end
-
-
 Safety note: environment variables and values can contain any bytes except
 for a null byte. This includes newlines and spaces, which requires careful
 handling.

--- a/src/cli/subcommand/export.rs
+++ b/src/cli/subcommand/export.rs
@@ -1,0 +1,317 @@
+use std::collections::HashMap;
+use std::env;
+use std::ffi::{OsStr, OsString};
+use std::io::{stdout, BufWriter, Write};
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use crate::cli::CommandExecute;
+use clap::Parser;
+
+use tracing::{debug, warn};
+
+const LOCAL_STATE_DIR: &str = "/nix/var";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("The HOME environment variable is not set.")]
+    HomeNotSet,
+
+    #[error("__ETC_PROFILE_NIX_SOURCED is set, indicating the relevant environment variables have already been set.")]
+    AlreadyRun,
+
+    #[error("Some of the paths for XDG_DATA_DIR are not valid, due to an illegal character, like a space or colon.")]
+    InvalidXdgDataDirs(Vec<PathBuf>),
+
+    #[error("Some of the paths for PATH are not valid, due to an illegal character, like a space or colon.")]
+    InvalidPathDirs(Vec<PathBuf>),
+
+    #[error("Some of the paths for MANPATH are not valid, due to an illegal character, like a space or colon.")]
+    InvalidManPathDirs(Vec<PathBuf>),
+}
+
+/**
+Emit all the environment variables that should be set to use Nix.
+
+In POSIX shell:
+
+    nix-installer export --format space-newline-separated \
+      | while IFS=' ' read key value; do
+        export "$key"="$value"
+    done
+
+In Bash / non-POSIX shell:
+
+    nix-installer export --format null-separated \
+      | while IFS= read -r -d $'\0' key && IFS= read -r -d $'\0' value; do
+        export "$key"="$value"
+    done
+
+In Fish shell:
+
+    nix-installer export --format null-separated \
+      | while read --null key
+        read --export --null "$key"
+    end
+
+
+Safety note: environment variables and values can contain any bytes except
+for a null byte. This includes newlines and spaces, which requires careful
+handling.
+
+In `space-newline-separated` mode, `nix-installer` guarantees it will:
+
+  * only emit keys that are alpha-numeric with underscores,
+  * only emit values without newlines
+
+and will refuse to emit any output to stdout if the variables and values
+would violate these safety rules.
+
+In `null-separated` mode, `nix-installer` emits data in this format:
+
+  KEYNAME\0VALUE\0KEYNAME\0VALUE\0
+
+*/
+#[derive(Debug, Parser)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct Export {
+    #[clap(long)]
+    format: ExportFormat,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, clap::ValueEnum)]
+enum ExportFormat {
+    NullSeparated,
+    SpaceNewlineSeparated,
+}
+
+#[async_trait::async_trait]
+impl CommandExecute for Export {
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn execute(self) -> eyre::Result<ExitCode> {
+        let env = match calculate_environment() {
+            Err(Error::AlreadyRun) => {
+                debug!("Already set the environment vars, not doing it again.");
+                return Ok(ExitCode::SUCCESS);
+            },
+            Err(e) => {
+                tracing::info!(
+                    "Error calculating the environment variables required to enable Nix: {:?}",
+                    e
+                );
+                return Err(e.into());
+            },
+
+            Ok(env) => env,
+        };
+
+        let mut out = BufWriter::new(stdout());
+
+        match self.format {
+            ExportFormat::NullSeparated => {
+                debug!("Emitting null separated fields");
+
+                for (key, value) in env.into_iter() {
+                    out.write_all(key.as_bytes())?;
+                    out.write_all(&[b'\0'])?;
+                    out.write_all(&value.into_vec())?;
+                    out.write_all(&[b'\0'])?;
+                }
+            },
+            ExportFormat::SpaceNewlineSeparated => {
+                debug!("Emitting space/newline separated fields");
+
+                let mut validated_envs = HashMap::new();
+                for (key, value) in env.into_iter() {
+                    if !key.chars().all(|char| {
+                        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+                            .contains(char)
+                    }) {
+                        warn!("Key {} has an invalid character that isn't a-zA-Z_", key);
+                        return Ok(ExitCode::FAILURE);
+                    }
+
+                    let value_bytes = value.into_vec();
+
+                    if value_bytes.contains(&b'\n') {
+                        warn!(
+                            "Value for key {} has an a newline, which is prohibited",
+                            key
+                        );
+                        return Ok(ExitCode::FAILURE);
+                    }
+
+                    validated_envs.insert(key, value_bytes);
+                }
+
+                for (key, value) in validated_envs.into_iter() {
+                    out.write_all(key.as_bytes())?;
+                    out.write_all(b" ")?;
+                    out.write_all(&value)?;
+                    out.write_all(b"\n")?;
+                }
+            },
+        }
+
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
+pub fn calculate_environment() -> Result<HashMap<&'static str, OsString>, Error> {
+    let mut envs: HashMap<&'static str, OsString> = HashMap::new();
+
+    // Don't export variables twice.
+    // @PORT-NOTE nix-profile-daemon.sh.in and nix-profile-daemon.fish.in implemented
+    // this behavior, but it was not implemented in nix-profile.sh.in and nix-profile.fish.in
+    // even though I believe it is desirable in both cases.
+    if env::var_os("__ETC_PROFILE_NIX_SOURCED").is_some() {
+        return Err(Error::AlreadyRun);
+    }
+
+    // @PORT-NOTE nix-profile.sh.in and nix-profile.fish.in check HOME and USER are set,
+    // but not nix-profile-daemon.sh.in and nix-profile-daemon.fish.in.
+    // The -daemon variants appear to just assume the values are set, which is probably
+    // not safe, so we check it in all cases.
+    let home = if let Some(home) = env::var_os("HOME") {
+        PathBuf::from(home)
+    } else {
+        return Err(Error::HomeNotSet);
+    };
+
+    envs.insert("__ETC_PROFILE_NIX_SOURCED", "1".into());
+
+    let nix_link: PathBuf = {
+        let legacy_location = home.join(".nix-profile");
+        let xdg_location = env::var_os("XDG_STATE_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| home.join(".local/state"))
+            .join("nix/profile");
+
+        if xdg_location.is_symlink() {
+            // In the future we'll prefer the legacy location, but
+            // evidently this is the intended order preference:
+            // https://github.com/NixOS/nix/commit/2b801d6e3c3a3be6feb6fa2d9a0b009fa9261b45
+            xdg_location
+        } else {
+            legacy_location
+        }
+    };
+
+    let nix_profiles = &[
+        PathBuf::from(LOCAL_STATE_DIR).join("nix/profiles/default"),
+        nix_link.clone(),
+    ];
+    envs.insert(
+        "NIX_PROFILES",
+        nix_profiles
+            .iter()
+            .map(|path| path.as_os_str())
+            .collect::<Vec<_>>()
+            .join(OsStr::new(" ")),
+    );
+
+    {
+        let xdg_data_dirs: Vec<PathBuf> = env::var_os("XDG_DATA_DIRS")
+            .as_ref()
+            .map(|s| env::split_paths(s))
+            .map(|paths| paths.collect::<Vec<PathBuf>>())
+            .unwrap_or_else(|| {
+                vec![
+                    PathBuf::from("/usr/local/share"),
+                    PathBuf::from("/usr/share"),
+                ]
+            });
+
+        let nix_xdg_data_dirs = vec![
+            nix_link.join("share"),
+            PathBuf::from(LOCAL_STATE_DIR).join("nix/profiles/default/share"),
+        ];
+
+        let extended_xdg_dirs: Vec<&PathBuf> = xdg_data_dirs
+            .iter()
+            .chain(nix_xdg_data_dirs.iter())
+            .collect::<Vec<_>>();
+
+        if let Ok(dirs) = env::join_paths(&extended_xdg_dirs) {
+            envs.insert("XDG_DATA_DIRS", dirs);
+        } else {
+            return Err(Error::InvalidXdgDataDirs(
+                extended_xdg_dirs.into_iter().cloned().collect(),
+            ));
+        }
+    }
+
+    if env::var_os("NIX_SSL_CERT_FILE").is_none() {
+        let mut candidate_locations = vec![
+            PathBuf::from("/etc/ssl/certs/ca-certificates.crt"), // NixOS, Ubuntu, Debian, Gentoo, Arch
+            PathBuf::from("/etc/ssl/ca-bundle.pem"),             // openSUSE Tumbleweed
+            PathBuf::from("/etc/ssl/certs/ca-bundle.crt"),       // Old NixOS
+            PathBuf::from("/etc/pki/tls/certs/ca-bundle.crt"),   // Fedora, CentOS
+            nix_link.join("etc/ssl/certs/ca-bundle.crt"), // fall back to cacert in Nix profile
+            nix_link.join("etc/ca-bundle.crt"),           // old cacert in Nix profile
+        ];
+
+        // Add the various profiles, preferring the last profile, ie: most global profile (matches upstream behavior)
+        candidate_locations.extend(nix_profiles.iter().rev().cloned());
+
+        if let Some(cert) = candidate_locations.iter().find(|path| path.is_file()) {
+            envs.insert("NIX_SSL_CERT_FILE", cert.into());
+        } else {
+            warn!(
+                "Could not identify any SSL certificates out of these candidates: {:?}",
+                candidate_locations
+            )
+        }
+    };
+
+    {
+        let nix_path_parts = [
+            nix_link.join("bin"),
+            // Note: This is typically only used in single-user installs, but I chose to do it in both for simplicity.
+            // If there is good reason, we can make it fancier.
+            PathBuf::from(LOCAL_STATE_DIR).join("nix/profiles/default/bin"),
+        ];
+
+        let current_path = env::var_os("PATH").unwrap_or(OsString::from(""));
+        let existing_path_parts = env::split_paths(&current_path);
+
+        let all_paths: Vec<PathBuf> = nix_path_parts
+            .into_iter()
+            .chain(existing_path_parts)
+            .collect();
+
+        if let Ok(dirs) = env::join_paths(&all_paths) {
+            envs.insert("PATH", dirs);
+        } else {
+            return Err(Error::InvalidPathDirs(all_paths));
+        }
+    }
+
+    {
+        let man_path_parts = [
+            nix_link.join("share/man"),
+            // Note: This is typically only used in single-user installs, but I chose to do it in both for simplicity.
+            // If there is good reason, we can make it fancier.
+            PathBuf::from(LOCAL_STATE_DIR).join("nix/profiles/default/share/man"),
+        ];
+
+        let current_man_path = env::var_os("MANPATH").unwrap_or(OsString::from(""));
+        let existing_path_parts = env::split_paths(&current_man_path);
+
+        let all_paths: Vec<PathBuf> = man_path_parts
+            .into_iter()
+            .chain(existing_path_parts)
+            .collect();
+
+        if let Ok(dirs) = env::join_paths(&all_paths) {
+            envs.insert("MANPATH", dirs);
+        } else {
+            return Err(Error::InvalidManPathDirs(all_paths));
+        }
+    }
+
+    debug!("Calculated environment: {:#?}", envs);
+
+    Ok(envs)
+}

--- a/src/cli/subcommand/export.rs
+++ b/src/cli/subcommand/export.rs
@@ -40,7 +40,7 @@ handling.
 
 In `space-newline-separated` mode, `nix-installer` guarantees it will:
 
-  * only emit keys that are alpha-numeric with underscores,
+  * only emit keys that are alphanumeric with underscores,
   * only emit values without newlines
 
 and will refuse to emit any output to stdout if the variables and values

--- a/src/cli/subcommand/export.rs
+++ b/src/cli/subcommand/export.rs
@@ -229,12 +229,15 @@ pub fn calculate_environment() -> Result<HashMap<&'static str, OsString>, Error>
             PathBuf::from("/etc/ssl/ca-bundle.pem"),             // openSUSE Tumbleweed
             PathBuf::from("/etc/ssl/certs/ca-bundle.crt"),       // Old NixOS
             PathBuf::from("/etc/pki/tls/certs/ca-bundle.crt"),   // Fedora, CentOS
-            nix_link.join("etc/ssl/certs/ca-bundle.crt"), // fall back to cacert in Nix profile
-            nix_link.join("etc/ca-bundle.crt"),           // old cacert in Nix profile
         ];
 
         // Add the various profiles, preferring the last profile, ie: most global profile (matches upstream behavior)
-        candidate_locations.extend(nix_profiles.iter().rev().cloned());
+        for profile in nix_profiles.iter().rev() {
+            candidate_locations.extend([
+                profile.join("etc/ssl/certs/ca-bundle.crt"), // fall back to cacert in Nix profile
+                profile.join("etc/ca-bundle.crt"),           // old cacert in Nix profile
+            ]);
+        }
 
         if let Some(cert) = candidate_locations.iter().find(|path| path.is_file()) {
             envs.insert("NIX_SSL_CERT_FILE", cert.into());

--- a/src/cli/subcommand/export.rs
+++ b/src/cli/subcommand/export.rs
@@ -132,7 +132,7 @@ impl CommandExecute for Export {
 }
 
 fn nonempty_var_os(key: &str) -> Option<OsString> {
-    env::var_os(key).and_then(|val| if val.is_empty() { None } else { Some(val) })
+    env::var_os(key).filter(|val| !val.is_empty())
 }
 
 fn env_path(key: &str) -> Option<Vec<PathBuf>> {

--- a/src/cli/subcommand/export.rs
+++ b/src/cli/subcommand/export.rs
@@ -137,7 +137,7 @@ impl CommandExecute for Export {
 }
 
 fn nonempty_var_os(key: &str) -> Option<OsString> {
-    env::var_os(key).and_then(|val| if val.is_empty() { Some(val) } else { None })
+    env::var_os(key).and_then(|val| if val.is_empty() { None } else { Some(val) })
 }
 
 fn env_path(key: &str) -> Option<Vec<PathBuf>> {

--- a/src/cli/subcommand/export.rs
+++ b/src/cli/subcommand/export.rs
@@ -21,13 +21,13 @@ pub enum Error {
     #[error("__ETC_PROFILE_NIX_SOURCED is set, indicating the relevant environment variables have already been set.")]
     AlreadyRun,
 
-    #[error("Some of the paths for XDG_DATA_DIR are not valid, due to an illegal character, like a space or colon.")]
+    #[error("Some of the paths from Nix for XDG_DATA_DIR are not valid, due to an illegal character, like a colon.")]
     InvalidXdgDataDirs(Vec<PathBuf>),
 
-    #[error("Some of the paths for PATH are not valid, due to an illegal character, like a space or colon.")]
+    #[error("Some of the paths from Nix for PATH are not valid, due to an illegal character, like a colon.")]
     InvalidPathDirs(Vec<PathBuf>),
 
-    #[error("Some of the paths for MANPATH are not valid, due to an illegal character, like a space or colon.")]
+    #[error("Some of the paths from Nix for MANPATH are not valid, due to an illegal character, like a colon.")]
     InvalidManPathDirs(Vec<PathBuf>),
 }
 
@@ -69,8 +69,8 @@ impl CommandExecute for Export {
     #[tracing::instrument(level = "trace", skip_all)]
     async fn execute(self) -> eyre::Result<ExitCode> {
         let env = match calculate_environment() {
-            Err(Error::AlreadyRun) => {
-                debug!("Already set the environment vars, not doing it again.");
+            e @ Err(Error::AlreadyRun | Error::HomeNotSet) => {
+                debug!("Ignored error: {:?}", e);
                 return Ok(ExitCode::SUCCESS);
             },
             Err(e) => {

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -1,5 +1,4 @@
 use std::{
-    os::unix::prelude::PermissionsExt,
     path::{Path, PathBuf},
     process::ExitCode,
 };
@@ -12,7 +11,7 @@ use crate::{
         signal_channel, CommandExecute,
     },
     error::HasExpectedErrors,
-    plan::RECEIPT_LOCATION,
+    plan::{copy_self_to_nix_dir, RECEIPT_LOCATION},
     planner::Planner,
     settings::CommonSettings,
     BuiltinPlanner, InstallPlan, NixInstallerError,
@@ -313,9 +312,6 @@ impl CommandExecute for Install {
                 }
             },
             Ok(_) => {
-                copy_self_to_nix_dir()
-                    .await
-                    .wrap_err("Copying `nix-installer` to `/nix/nix-installer`")?;
                 println!(
                     "\
                     {success}\n\
@@ -334,12 +330,4 @@ impl CommandExecute for Install {
 
         Ok(ExitCode::SUCCESS)
     }
-}
-
-#[tracing::instrument(level = "debug")]
-async fn copy_self_to_nix_dir() -> Result<(), std::io::Error> {
-    let path = std::env::current_exe()?;
-    tokio::fs::copy(path, "/nix/nix-installer").await?;
-    tokio::fs::set_permissions("/nix/nix-installer", PermissionsExt::from_mode(0o0755)).await?;
-    Ok(())
 }

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use crate::{
-    action::ActionState,
+    action::{
+        common::configure_shell_profile::PROFILE_NIX_FILE_FISH,
+        common::configure_shell_profile::PROFILE_NIX_FILE_SHELL, ActionState,
+    },
     cli::{
         ensure_root,
         interaction::{self, PromptChoice},
@@ -312,6 +315,8 @@ impl CommandExecute for Install {
                 }
             },
             Ok(_) => {
+                let load_fish = format!(". {}", PROFILE_NIX_FILE_FISH);
+                let load_shell = format!(". {}", PROFILE_NIX_FILE_SHELL);
                 println!(
                     "\
                     {success}\n\
@@ -319,10 +324,12 @@ impl CommandExecute for Install {
                     ",
                     success = "Nix was installed successfully!".green().bold(),
                     shell_reminder = match std::env::var("SHELL") {
-                        Ok(val) if val.contains("fish") =>
-                            ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.fish".bold(),
-                        Ok(_) | Err(_) =>
-                            ". /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh".bold(),
+                        Ok(val) if val.contains("fish") => {
+                            load_fish.bold()
+                        },
+                        Ok(_) | Err(_) => {
+                            load_shell.bold()
+                        },
                     },
                 );
             },

--- a/src/cli/subcommand/mod.rs
+++ b/src/cli/subcommand/mod.rs
@@ -8,6 +8,8 @@ mod uninstall;
 use uninstall::Uninstall;
 mod self_test;
 use self_test::SelfTest;
+mod export;
+pub use export::Export;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, clap::Subcommand)]
@@ -17,4 +19,5 @@ pub enum NixInstallerSubcommand {
     Uninstall(Uninstall),
     SelfTest(SelfTest),
     Plan(Plan),
+    Export(Export),
 }


### PR DESCRIPTION
Try this PR:

```
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/738 | sh -s -- install
```

---


##### Description

(Includes clippy-nits, #737)

We rewrote the Nix installer in Rust to escape horrible and unpredictable bugs in the install scripts.
This has been super successful, but upstream still has a four critical scripts: the `nix-profile*` scripts.

Recently, we introduced a patch to add Nix's paths to `XDG_DATA_DIRS`: https://github.com/NixOS/nix/pull/8985
This had an oversight, which was fixed in a PR: https://github.com/NixOS/nix/pull/9312
...which also had an oversight which was released as 2.19.0, and fixed in a PR: https://github.com/NixOS/nix/pull/9425

This quicksand style development nightmare is exactly why we rewrote it in the first place.
I examined the four versions (`nix-profile{-daemon}.{fish,sh}`) -- which all have different peculiarities, behaviors, and bugs.

Here are some of the issues I identified while trying to understand the differences.
Note that this isn't intended to be a "call-out" thread where I drag people through the mud or make Nix look bad or whatever.
I personally introduced some, and folks at DetSys introduced others.
This code was written by smart people, trying to do the right thing, but didn't have the tools to because scripting languages suck.

1. `nix-profile-daemon.{fish,sh}` protect against double-loading but `nix-profile.{fish,sh}` don't:
    ```sh
    if [ -n "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then return; fi
    __ETC_PROFILE_NIX_SOURCED=1
    ```

    ```fish
    if test -n "$__ETC_PROFILE_NIX_SOURCED"
    exit
    end
    set __ETC_PROFILE_NIX_SOURCED 1
    ```
2. `nix-profile-daemeon.fish` sometimes leaks the `add_path` function, because it registers the function and then detects if Nix was sourced already:

    ```fish
    function add_path --argument-names new_path
      # ...snip...
    end

    # Only execute this file once per shell.
    if test -n "$__ETC_PROFILE_NIX_SOURCED"
      exit
    end

    # ...snip...

    functions -e add_path
    ```
3. `nix-profile.{fish,sh}` check that `HOME` is defined before using it, but `nix-profile-daemon.{fish,sh}` don't, exposing users with `set -u` to a potential crash in the most common use case:

    ```sh
    if [ -n "$HOME" ] && [ -n "$USER" ]; then
    ```
4. `nix-profile.{fish,sh}` requires that `USER` is defined, despite never using it. Likely leftover from a refactor around how GC roots were configured.
5. `nix-profile{-daemon}.sh` were updated to account for the XDG directory migration, but the Fish equivalent weren't:

    ```sh
    NIX_LINK="$HOME/.nix-profile"
    if [ -n "${XDG_STATE_HOME-}" ]; then
        NIX_LINK_NEW="$XDG_STATE_HOME/nix/profile"
    else
        NIX_LINK_NEW="$HOME/.local/state/nix/profile"
    fi
    ```

    vs. the naive Fish:
    
    ```fish
    set --export NIX_PROFILES "@localstatedir@/nix/profiles/default $HOME/.nix-profile"
    ```
    By way of note, the XDG migration included a useful, user-forward migration path for users who had both a legacy and an XDG-based path. It was made defunct by a logical inversion by mistake,
6. `nix-profile.sh`, `nix-profile.fish`, `nix-profile-daemon.sh` all include the user's Nix profile in the `XDG_DATA_DIRS`, but `nix-profile-daemon.fish` does not:

    ```fish
    set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:$NIX_LINK/share:/nix/var/nix/profiles/default/share"
    ```

    vs. 

    ```fish
    set --export XDG_DATA_DIRS "$XDG_DATA_DIRS:/nix/var/nix/profiles/default/share"
    ```
7. The profile scripts typically make an attempt at leaving the `NIX_SSL_CERT_FILE` environment variable alone if the user set it, but...
    * `nix-profile.sh` doesn't bother
    * `nix-profile.{fish,sh}` look to see if `NIX_SSH_CERT_FILE` (note the `H`!) is set instead of `NIX_SSL_CERT_FILE` (note the `L`).
8. All but `nix-profile-daemon.sh` will check to see if `$NIX_LINK/etc/ca-bundle.crt` exists and use that.
9. `nix-profile-daemon.{sh,fish}` both check for a file called `etc/ssl/certs/ca-bundle.crt` in all the defined `NIX_PROFILES`, but `nix-profile.{sh,fish}` don't.
10. `nix-profile.{sh,fish}` will extend `MANPATH` if it is already set, but the `-daemon` scripts won't.
11. The `nix-profile-daemon.{fish,sh}` scripts put `/nix/var/nix/profiles/default/bin` into the `PATH`, but the others don't. This is true, despite all four setting up the default profile.

So I experimented with rewriting these complicated and tricky bash profiles in Rust.

However, Rust can't set environment variables in the parent so we still need a bit of shell glue to finish the job.
The goal is to have as little shell as possible, in a way that ~never needs to be touched.

This is challenging, because we have to stick to the fundamentals of POSIX.
That means using read with a heredoc, or `eval`.

I don't like `eval`, but the heredoc method turns out to be very brittle. POSIX doesn't support \0, and this method implies trying to create a parser for the output in the most limited form of shell.

### The aborted attempt at not using eval

The Rust program emits data like this:

```
ENVVARNAME ENVVARDATA
ENVVARNAME2 ENVVARDATA2
```

where `ENVVARNAME` is guaranteed to be `a-zA-Z0-9_`, and `ENVVARDATA` has no newlines or null bytes.
Then the profile script loads the environment variables like this:

```sh
# shellcheck shell=sh
if [ -f /nix/nix-installer ] && [ -x /nix/nix-installer ] && [ -z "${__ETC_PROFILE_NIX_SOURCED:-}" ]; then
    NIX_INSTALLER_EXPORT_DATA=$(/nix/nix-installer export --format space-newline-separated);
    while read -r nix_installer_export_key nix_installer_export_value; do
        export "$nix_installer_export_key=$nix_installer_export_value";
    done <<DATA_INPUT
$NIX_INSTALLER_EXPORT_DATA
DATA_INPUT

    unset NIX_INSTALLER_EXPORT_DATA nix_installer_export_key nix_installer_export_value
fi
```

...this is profoundly ugly, but it passes shellcheck and doesn't require touching for any logical changes to the environment handling.

**Is it safe?**

No.

Previous text before I started testing against a bunch of shells:

According to the POSIX spec and testing, yes.
`IFS=' ' read -r key value` is like a `split_once`, taking the first space-separated value of each line and storing it at `$key`, and then all remaining data of the line -- regardless of spaces -- is stored at `$value`.
This means any data with spaces, tabs, backslashes, etc. should be preserved.
The only rule is the data doesn't contain a newline -- which is protected against.

### `eval`

Another way that can also be safe is to just use eval, since we know how to safely escape shell values:

```sh
eval "$(/nix/nix-installer export --format=sh)
```

The downside is this is much more "mystery-meat".
The nix-installer binary may be perceived as having more capabilities, though the capabilities aren't practically increased over the current implementation.
The user may also have concerns about the safety and correctness of the code we emit to be evaled, founded or unfounded.

Using eval is like a skepticism lightning-rod, however it is our safest and most resilient option.

## Appendix of options that are not POSIX compliant

### Null-byte separated output

This was the first try:

```sh
nix-installer export --format null-separated \
  | while IFS= read -r -d $'\0' key && IFS= read -r -d $'\0' value; do
    export "$key"="$value"
done
```

However, `read -d` and `$'\0'` aren't POSIX.

### The space and newline separation, without the heredoc

```sh
nix-installer export --format space-newline-separated \
  | while IFS=' ' read key value; do
    export "$key"="$value"
done
```

Unfortunately this doesn't work either because of subshells.
The `export "$key"="$value"` step is executed in a subshell, which doesn't change the environment of the caller.
Bash 4.2+ does have `shopt -s lastpipe`, but again -- not POSIX.

### Process substitution directly into the `while`

Like this:

```sh
while IFS=' ' read key value; do
  export "$key"="$value"
done < <(nix-installer export --format space-newline-separated)
```

However, `< <(...)` isn't POSIX.


##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

---

# TODO

- [ ] Validate the fish parts on a real system
- [ ] Add shellcheck to CI for the `profile.sh` and `profile.fish` scripts
- [x] Report upstream profile script bugs -- https://github.com/NixOS/nix/issues/9441
- [ ] Double check the environment handling matches what I outlined in the list above
- [x] Especially double check MANPATH, which is probably wrong.

# Open Questions

- [ ] Is making our own profile.sh hook a liability we don't want to take? How can we do this most safely?

---

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
