### PR TITLE
MacOS installer does not honor case sensitive setting

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -169,7 +169,7 @@ impl Action for ConfigureInitService {
             #[cfg(target_os = "macos")]
             InitSystem::Launchd => {
                 let src = std::path::Path::new(DARWIN_NIX_DAEMON_SOURCE);
-                tokio::fs::copy(src.clone(), DARWIN_NIX_DAEMON_DEST)
+                tokio::fs::copy(src, DARWIN_NIX_DAEMON_DEST)
                     .await
                     .map_err(|e| {
                         Self::error(ActionErrorKind::Copy(

--- a/src/planner/macos.rs
+++ b/src/planner/macos.rs
@@ -135,7 +135,7 @@ impl Planner for Macos {
             CreateNixVolume::plan(
                 root_disk.unwrap(), /* We just ensured it was populated */
                 self.volume_label.clone(),
-                false,
+                self.case_sensitive,
                 encrypt,
             )
             .await


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/716

```
> nix-installer install macos --case-sensitive
> sudo diskutil apfs list
....
        ---------------------------------------------------
        APFS Volume Disk (Role):   disk3s7 (No specific role)
        Name:                      Nix Store (Case-sensitive)
        Mount Point:               /nix
        Capacity Consumed:         72744960 B (72.7 MB)
        Sealed:                    No
        FileVault:                 No (Encrypted at rest)
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
