### PR TITLE
Fetch updates from i.d.s by default

### DIFF
--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -131,7 +131,7 @@ impl PlaceNixConfiguration {
         );
         settings.insert(
             "upgrade-nix-store-path-url".to_string(),
-            "https://install.determinate.systems/nix-upgrade/stable/Universal".to_string(),
+            "https://install.determinate.systems/nix-upgrade/stable/universal".to_string(),
         );
 
         let create_directory = CreateDirectory::plan(NIX_CONF_FOLDER, None, None, 0o0755, force)

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -129,6 +129,10 @@ impl PlaceNixConfiguration {
             "extra-nix-path".to_string(),
             "nixpkgs=flake:nixpkgs".to_string(),
         );
+        settings.insert(
+            "upgrade-nix-store-path-url".to_string(),
+            "https://install.determinate.systems/nix-upgrade/stable/Universal".to_string(),
+        );
 
         let create_directory = CreateDirectory::plan(NIX_CONF_FOLDER, None, None, 0o0755, force)
             .await


### PR DESCRIPTION
Our goal is to deliver a solid experience with Nix flakes, including an upgrade path that is safe. Occasionally, the upstream Nix project may introduce regressions for the common flake path. This is not desirable for our users, who depend on a consistent and stable flakes experience.

Additionally, the Nix project isn't directly responsible for delivering updates to users as that role is delegated to the Nixpkgs project.

Overall, this means upgrades are not consistently delivered to users.

This update directs future update requests to install.determinate.systems, which we will upgrade as part of our standard release process.

Our standard release process includes proactive testing: validating our installer and Nix's behavior across a wide variety of platforms and scenarios.

After an update passes our proactive validation, we do a phased rollout of reactive monitoring: the update is released to a small percentage of users on GitHub Actions. We monitor the failure rate of the installer and overall workflows to ensure the updated Nix isn't causing widespread failure we weren't able to identify ahead of time.

Only after a release passes both proactive and reactive validation, our macOS .pkg and nix-upgrade paths are bumped to the most recent release. This gives user the confidence they're looking for that the Nix release they're getting is safe.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
