### PR TITLE
fix create build users action description

### DIFF
--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -77,7 +77,7 @@ impl Action for CreateUsersAndGroups {
         } else {
             format!(
                 "Create build users (UID {}-{}) and group (GID {})",
-                self.nix_build_user_id_base,
+                self.nix_build_user_id_base + 1,
                 self.nix_build_user_id_base + self.nix_build_user_count,
                 self.nix_build_group_id
             )


### PR DESCRIPTION
##### Description

UID range start is off by 1 in action description:
`* Create build users (UID 300-332) and group (GID 30000)`
`* Create build users (UID 301-332) and group (GID 30000)`

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
