### PR TITLE
fix: workaround for lies from uname -m

### DIFF
--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -143,10 +143,16 @@ get_architecture() {
         fi
     fi
 
-    if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
-        # Darwin `uname -m` lies
-        if sysctl hw.optional.x86_64 | grep -q ': 1'; then
-            _cputype=x86_64
+    # Darwin `uname -m` lies
+    if [ "$_ostype" = Darwin ]; then
+        if [ "$_cputype" = i386 ]; then
+            if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+                _cputype=x86_64
+            fi
+        elif [ "$_cputype" = x86_64 ]; then
+            if sysctl hw.optional.arm64 | grep -q ': 1'; then
+                _cputype=arm64
+            fi
         fi
     fi
 

--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -143,14 +143,29 @@ get_architecture() {
         fi
     fi
 
-    # Darwin `uname -m` lies
+    # Copied this logic from https://github.com/rust-lang/rustup/blob/6f34807b14a811f2673d4bc639abcff58e40e0e4/rustup-init.sh#L314-L339
     if [ "$_ostype" = Darwin ]; then
+        # Darwin `uname -m` can lie due to Rosetta shenanigans. If you manage to
+        # invoke a native shell binary and then a native uname binary, you can
+        # get the real answer, but that's hard to ensure, so instead we use
+        # `sysctl` (which doesn't lie) to check for the actual architecture.
         if [ "$_cputype" = i386 ]; then
-            if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+            # Handling i386 compatibility mode in older macOS versions (<10.15)
+            # running on x86_64-based Macs.
+            # Starting from 10.15, macOS explicitly bans all i386 binaries from running.
+            # See: <https://support.apple.com/en-us/HT208436>
+
+            # Avoid `sysctl: unknown oid` stderr output and/or non-zero exit code.
+            if sysctl hw.optional.x86_64 2> /dev/null || true | grep -q ': 1'; then
                 _cputype=x86_64
             fi
         elif [ "$_cputype" = x86_64 ]; then
-            if sysctl hw.optional.arm64 | grep -q ': 1'; then
+            # Handling x86-64 compatibility mode (a.k.a. Rosetta 2)
+            # in newer macOS versions (>=11) running on arm64-based Macs.
+            # Rosetta 2 is built exclusively for x86-64 and cannot run i386 binaries.
+
+            # Avoid `sysctl: unknown oid` stderr output and/or non-zero exit code.
+            if sysctl hw.optional.arm64 2> /dev/null || true | grep -q ': 1'; then
                 _cputype=arm64
             fi
         fi


### PR DESCRIPTION

##### Description

On an arm64 mac, `uname -m` returns x86_64 which causes install script to install with the wrong architecture

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
