### PR TITLE
Fix adduser so it doesn't create the home

### DIFF
--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -237,6 +237,7 @@ impl Action for CreateUser {
                             .args([
                                 "--home",
                                 "/var/empty",
+                                "-H", // Don't create a home.
                                 "--gecos",
                                 comment,
                                 "--ingroup",


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/692

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
