### PR TITLE
README: Delete now-incorrect link listing installed `nix` versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ NIX_BUILD_GROUP_NAME=nixbuilder ./nix-installer install linux-multi --nix-buil
 
 ### Upgrading Nix
 
-You can upgrade Nix (to the version specified [here](https://raw.githubusercontent.com/NixOS/nixpkgs/master/nixos/modules/installer/tools/nix-fallback-paths.nix)) by running:
+You can upgrade Nix by running:
 
 ```
 sudo -i nix upgrade-nix


### PR DESCRIPTION
Since the latest release, it seems you use a different version of nix.

Feel free to consider this as a bug report instead of PR. I just deleted the wrong information, but you might be able to say something better instead.
