### PR TITLE
Link to Nix on wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/v/nix-installer)](https://crates.io/crates/nix-installer)
 [![Docs.rs](https://img.shields.io/docsrs/nix-installer)](https://docs.rs/nix-installer/latest/nix_installer/)
 
-A fast, friendly, and reliable tool to help you use Nix with Flakes everywhere.
+A fast, friendly, and reliable tool to help you use [Nix](https://en.wikipedia.org/wiki/Nix_(package_manager)) with Flakes everywhere.
 
 
 ```bash


### PR DESCRIPTION
I often link to the Determinate Nix installer from internal documentation and other (sometimes private) repos. 
The audience is often unaware of what Nix is and many times it's just another tool they need to install to get something done. 
For such an audience landing on this repo I noticed that there is no explanation of what Nix really is, so I thought a link to Wikipedia would give them some context if they care to learn more about it.