### PR TITLE
Don't check `/run` for systemd if we're not starting the daemon

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -79,10 +79,12 @@ impl ConfigureInitService {
             },
             #[cfg(target_os = "linux")]
             InitSystem::Systemd => {
-                // If /run/systemd/system exists, we can be reasonably sure the machine is booted
-                // with systemd: https://www.freedesktop.org/software/systemd/man/sd_booted.html
-                if !Path::new("/run/systemd/system").exists() {
-                    return Err(Self::error(ActionErrorKind::SystemdMissing));
+                if start_daemon {
+                    // If /run/systemd/system exists, we can be reasonably sure the machine is booted
+                    // with systemd: https://www.freedesktop.org/software/systemd/man/sd_booted.html
+                    if !Path::new("/run/systemd/system").exists() {
+                        return Err(Self::error(ActionErrorKind::SystemdMissing));
+                    }
                 }
 
                 if which::which("systemctl").is_err() {

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -79,6 +79,8 @@ impl ConfigureInitService {
             },
             #[cfg(target_os = "linux")]
             InitSystem::Systemd => {
+                // If `no_start_daemon` is set, then we don't require a running systemd,
+                // so we don't need to check if `/run/systemd/system` exists.
                 if start_daemon {
                     // If /run/systemd/system exists, we can be reasonably sure the machine is booted
                     // with systemd: https://www.freedesktop.org/software/systemd/man/sd_booted.html


### PR DESCRIPTION
##### Description

Should fix https://github.com/DeterminateSystems/nix-installer/issues/670.

```dockerfile
FROM ubuntu:latest
RUN apt update -y
RUN apt install curl systemd -y
RUN curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/853 | sh -s -- install linux \
  --extra-conf "sandbox = false" \
  --no-start-daemon \
  --no-confirm --log-directive nix_installer=trace
ENV PATH="${PATH}:/nix/var/nix/profiles/default/bin"
RUN nix run nixpkgs#hello
CMD [ "/bin/systemd" ]
```

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
