### PR TITLE
Fix typo

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -139,7 +139,7 @@ impl Action for ConfigureInitService {
             #[cfg(target_os = "linux")]
             InitSystem::Systemd => {
                 let mut explanation = vec![
-                    "Run `systemd-tempfiles --create --prefix=/nix/var/nix`".to_string(),
+                    "Run `systemd-tmpfiles --create --prefix=/nix/var/nix`".to_string(),
                     format!("Symlink `{SERVICE_SRC}` to `{SERVICE_DEST}`"),
                     format!("Symlink `{SOCKET_SRC}` to `{SOCKET_DEST}`"),
                     "Run `systemctl daemon-reload`".to_string(),


### PR DESCRIPTION
##### Description

Fix typo `systemd-tempfiles --create --prefix=/nix/var/nix`

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
