### PR TITLE
Embedding the Nix installer in the binary.

### DIFF
--- a/.github/workflows/build-x86_64-darwin.yml
+++ b/.github/workflows/build-x86_64-darwin.yml
@@ -1,6 +1,6 @@
 name: Build x86_64 Darwin
 
-on: 
+on:
   workflow_call:
     inputs:
       cache-key:
@@ -11,7 +11,7 @@ on:
 jobs:
   build-x86_64-darwin:
     name: Build x86_64 Darwin
-    runs-on: macos-latest-large
+    runs-on: macos-13-large
     concurrency: ${{ inputs.cache-key }}
     permissions:
       id-token: "write"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
 
   run-x86_64-darwin:
     name: Run x86_64 Darwin
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: [lints, build-x86_64-darwin]
     permissions:
       id-token: "write"

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -11,6 +11,10 @@ on:
       - synchronize
       - labeled
 
+permissions:
+  id-token: "write"
+  contents: "read"
+
 jobs:
   build-x86_64-linux:
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
@@ -89,8 +93,6 @@ jobs:
         || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'upload to s3'))
       )
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write # In order to request a JWT for AWS auth
     needs:
       - build-x86_64-linux
       - build-i686-linux

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: write # In order to upload artifacts to GitHub releases
+  id-token: write # In order to request a JWT for AWS auth
+
 jobs:
   build-x86_64-linux:
     uses: ./.github/workflows/build-x86_64-linux.yml
@@ -32,9 +36,6 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # In order to upload artifacts to GitHub releases
-      id-token: write # In order to request a JWT for AWS auth
     needs:
       - build-x86_64-linux
       - build-i686-linux

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ NIX_BUILD_GROUP_NAME=nixbuilder ./nix-installer install linux-multi --nix-buil
 
 ### Upgrading Nix
 
-You can upgrade Nix to the version described in [`DeterminateSystems/nix-upgrade`][nix-upgrade] by running:
+You can upgrade Nix to the current recommended version of Nix by running:
 
 ```
 sudo -i nix upgrade-nix
@@ -499,4 +499,3 @@ You can read the full privacy policy for [Determinate Systems][detsys], the crea
 [wslg]: https://github.com/microsoft/wslg
 [nixgl]: https://github.com/guibou/nixGL
 [Nix]: https://nixos.org
-[nix-upgrade]: https://github.com/DeterminateSystems/nix-upgrade/blob/main/versions.nix

--- a/README.md
+++ b/README.md
@@ -389,6 +389,9 @@ You'll also need to edit your `.cargo/config.toml` to use `tokio_unstable` as we
 rustflags=["--cfg", "tokio_unstable"]
 ```
 
+You'll also need to set the `NIX_INSTALLER_TARBALL_PATH` environment variable to point to a target-appropriate Nix installation tarball, like nix-2.21.2-aarch64-darwin.tar.xz.
+The contents are embedded in the resulting binary instead of downloaded at installation time.
+
 Then it's possible to review the [documentation](https://docs.rs/nix-installer/latest/nix_installer/):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Differing from the upstream [Nix](https://github.com/NixOS/nix) installer script
   + `auto-optimise-store` is set to `true` (On Linux only)
   * `extra-nix-path` is set to `nixpkgs=flake:nixpkgs`
   * `max-jobs` is set to `auto`
-  * `upgrade-nix-store-path-url` is set to `https://install.determinate.systems/nix-upgrade/stable/universal`
+  * `upgrade-nix-store-path-url` is set to `https://install.determinate.systems/nix-upgrade/stable/universal`, to prevent unintentional downgrades.
 * an installation receipt (for uninstalling) is stored at `/nix/receipt.json` as well as a copy of the install binary at `/nix/nix-installer`
 * `nix-channel --update` is not run, `~/.nix-channels` is not provisioned
 * `ssl-cert-file` is set in `/etc/nix/nix.conf` if the `ssl-cert-file` argument is used.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ NIX_BUILD_GROUP_NAME=nixbuilder ./nix-installer install linux-multi --nix-buil
 
 ### Upgrading Nix
 
-You can upgrade Nix to the current recommended version of Nix by running:
+You can upgrade Nix to [our currently recommended version of Nix][recommended-nix] by running:
 
 ```
 sudo -i nix upgrade-nix
@@ -498,6 +498,7 @@ You can read the full privacy policy for [Determinate Systems][detsys], the crea
 [detsys]: https://determinate.systems/
 [diagnosticdata]: https://github.com/DeterminateSystems/nix-installer/blob/f9f927840d532b71f41670382a30cfcbea2d8a35/src/diagnostics.rs#L29-L43
 [privacy]: https://determinate.systems/policies/privacy
+[recommended-nix]: https://github.com/DeterminateSystems/nix/releases/latest
 [systemd]: https://systemd.io
 [wslg]: https://github.com/microsoft/wslg
 [nixgl]: https://github.com/guibou/nixGL

--- a/flake.lock
+++ b/flake.lock
@@ -88,6 +88,24 @@
     },
     "nix": {
       "inputs": {
+        "nix": "nix_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1713457987,
+        "narHash": "sha256-HNt+ocnqVlwGzYx+3DQRlfv06iSv2I7Ch5kuRH7W7m4=",
+        "rev": "f59b936e273bc761648b45a9f822693f0424da4d",
+        "revCount": 56,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix/2.21.2/018ef218-45b2-731b-8c3b-a9fc57c55fd1/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/nix/%3D2.21.2.tar.gz"
+      }
+    },
+    "nix_2": {
+      "inputs": {
         "flake-compat": "flake-compat_2",
         "libgit2": "libgit2",
         "nixpkgs": "nixpkgs",
@@ -103,7 +121,7 @@
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nix/%3D2.21.2.tar.gz"
+        "url": "https://flakehub.com/f/NixOS/nix/%3D2.21.2"
       }
     },
     "nixpkgs": {
@@ -140,12 +158,26 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712963716,
-        "narHash": "sha256-WKm9CvgCldeIVvRz87iOMi8CFVB1apJlkUT4GGvA0iM=",
-        "rev": "cfd6b5fc90b15709b780a5a1619695a88505a176",
-        "revCount": 611350,
+        "lastModified": 1714531828,
+        "narHash": "sha256-ILsf3bdY/hNNI/Hu5bSt2/KbmHaAVhBbNUOdGztTHEg=",
+        "rev": "0638fe2715d998fa81d173aad264eb671ce2ebc1",
+        "revCount": 558121,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.611350%2Brev-cfd6b5fc90b15709b780a5a1619695a88505a176/018eddfc-e6d9-74bb-a823-20f2ae60079b/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2311.558121%2Brev-0638fe2715d998fa81d173aad264eb671ce2ebc1/018f3583-6e0d-7f3d-9871-ca7b6c8c73df/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1710806803,
+        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
+        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
+        "revCount": 598982,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.598982%2Brev-b06025f1533a1e07b6db3e75151caa155d1c7eb3/018e577a-86bd-7b2f-b434-442e9ada5378/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -158,7 +190,7 @@
         "flake-compat": "flake-compat",
         "naersk": "naersk",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       }
     },
     "rust-analyzer-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
             RUSTFLAGS = "--cfg tokio_unstable";
             cargoTestOptions = f: f ++ [ "--all" ];
 
-            NIX_INSTALLER_TARBALL = inputs.nix.tarballs_direct.${final.stdenv.system};
+            NIX_INSTALLER_TARBALL_PATH = inputs.nix.tarballs_direct.${final.stdenv.system};
 
             override = { preBuild ? "", ... }: {
               preBuild = preBuild + ''
@@ -132,7 +132,7 @@
             name = "nix-install-shell";
 
             RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
-            NIX_INSTALLER_TARBALL = inputs.nix.tarballs_direct.${system};
+            NIX_INSTALLER_TARBALL_PATH = inputs.nix.tarballs_direct.${system};
 
             nativeBuildInputs = with pkgs; [ ];
             buildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
     };
 
     nix = {
-      url = "https://flakehub.com/f/NixOS/nix/=2.21.2.tar.gz";
+      url = "https://flakehub.com/f/DeterminateSystems/nix/=2.21.2.tar.gz";
       # Omitting `inputs.nixpkgs.follows = "nixpkgs";` on purpose
     };
 
@@ -87,6 +87,8 @@
             RUSTFLAGS = "--cfg tokio_unstable";
             cargoTestOptions = f: f ++ [ "--all" ];
 
+            NIX_INSTALLER_TARBALL = inputs.nix.tarballs_direct.${final.stdenv.system};
+
             override = { preBuild ? "", ... }: {
               preBuild = preBuild + ''
                 # logRun "cargo clippy --all-targets --all-features -- -D warnings"
@@ -130,6 +132,7 @@
             name = "nix-install-shell";
 
             RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
+            NIX_INSTALLER_TARBALL = inputs.nix.tarballs_direct.${system};
 
             nativeBuildInputs = with pkgs; [ ];
             buildInputs = with pkgs; [

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -70,7 +70,7 @@ impl Action for FetchAndUnpackNix {
         if let Some(ref url_or_path) = self.url_or_path {
             format!("Fetch `{}` to `{}`", url_or_path, self.dest.display())
         } else {
-            "Extract the bundled Nix".to_string()
+            format!("Extract the bundled Nix (originally from {})", crate::settings::NIX_TARBALL_PATH);
         }
     }
 

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -70,7 +70,10 @@ impl Action for FetchAndUnpackNix {
         if let Some(ref url_or_path) = self.url_or_path {
             format!("Fetch `{}` to `{}`", url_or_path, self.dest.display())
         } else {
-            format!("Extract the bundled Nix (originally from {})", crate::settings::NIX_TARBALL_PATH);
+            format!(
+                "Extract the bundled Nix (originally from {})",
+                crate::settings::NIX_TARBALL_PATH
+            )
         }
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
-pub const NIX_TARBALL_PATH: env!("NIX_INSTALLER_TARBALL_PATH");
+pub const NIX_TARBALL_PATH: &str = env!("NIX_INSTALLER_TARBALL_PATH");
 /// The NIX_INSTALLER_TARBALL_PATH environment variable should point to a target-appropriate
 /// Nix installation tarball, like nix-2.21.2-aarch64-darwin.tar.xz. The contents are embedded
 /// in the resulting binary.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,6 +11,7 @@ use url::Url;
 
 pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
+pub const NIX_TARBALL_PATH: env!("NIX_INSTALLER_TARBALL_PATH");
 /// The NIX_INSTALLER_TARBALL_PATH environment variable should point to a target-appropriate
 /// Nix installation tarball, like nix-2.21.2-aarch64-darwin.tar.xz. The contents are embedded
 /// in the resulting binary.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
-pub const NIX_TARBALL: &[u8] = include_bytes!(env!("NIX_INSTALLER_TARBALL"));
+pub const NIX_TARBALL: &[u8] = include_bytes!(env!("NIX_INSTALLER_TARBALL_PATH"));
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,21 +11,7 @@ use url::Url;
 
 pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
-/// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux x86_64
-pub const NIX_X64_64_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.21.2/nix-2.21.2-x86_64-linux.tar.xz";
-/// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux x86 (32 bit)
-pub const NIX_I686_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.21.2/nix-2.21.2-i686-linux.tar.xz";
-/// Default [`nix_package_url`](CommonSettings::nix_package_url) for Linux aarch64
-pub const NIX_AARCH64_LINUX_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.21.2/nix-2.21.2-aarch64-linux.tar.xz";
-/// Default [`nix_package_url`](CommonSettings::nix_package_url) for Darwin x86_64
-pub const NIX_X64_64_DARWIN_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.21.2/nix-2.21.2-x86_64-darwin.tar.xz";
-/// Default [`nix_package_url`](CommonSettings::nix_package_url) for Darwin aarch64
-pub const NIX_AARCH64_DARWIN_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.21.2/nix-2.21.2-aarch64-darwin.tar.xz";
+pub const NIX_TARBALL: &[u8] = include_bytes!(env!("NIX_INSTALLER_TARBALL"));
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
@@ -145,39 +131,9 @@ pub struct CommonSettings {
     /// The Nix package URL
     #[cfg_attr(
         feature = "cli",
-        clap(long, env = "NIX_INSTALLER_NIX_PACKAGE_URL", global = true, value_parser = clap::value_parser!(UrlOrPath))
+        clap(long, env = "NIX_INSTALLER_NIX_PACKAGE_URL", global = true, value_parser = clap::value_parser!(UrlOrPath), default_value = None)
     )]
-    #[cfg_attr(
-        all(target_os = "macos", target_arch = "x86_64", feature = "cli"),
-        clap(
-            default_value = NIX_X64_64_DARWIN_URL,
-        )
-    )]
-    #[cfg_attr(
-        all(target_os = "macos", target_arch = "aarch64", feature = "cli"),
-        clap(
-            default_value = NIX_AARCH64_DARWIN_URL,
-        )
-    )]
-    #[cfg_attr(
-        all(target_os = "linux", target_arch = "x86_64", feature = "cli"),
-        clap(
-            default_value = NIX_X64_64_LINUX_URL,
-        )
-    )]
-    #[cfg_attr(
-        all(target_os = "linux", target_arch = "x86", feature = "cli"),
-        clap(
-            default_value = NIX_I686_LINUX_URL,
-        )
-    )]
-    #[cfg_attr(
-        all(target_os = "linux", target_arch = "aarch64", feature = "cli"),
-        clap(
-            default_value = NIX_AARCH64_LINUX_URL,
-        )
-    )]
-    pub nix_package_url: UrlOrPath,
+    pub nix_package_url: Option<UrlOrPath>,
 
     /// The proxy to use (if any), valid proxy bases are `https://$URL`, `http://$URL` and `socks5://$URL`
     #[cfg_attr(feature = "cli", clap(long, env = "NIX_INSTALLER_PROXY"))]
@@ -250,7 +206,6 @@ pub struct CommonSettings {
 impl CommonSettings {
     /// The default settings for the given Architecture & Operating System
     pub async fn default() -> Result<Self, InstallSettingsError> {
-        let url;
         let nix_build_user_prefix;
         let nix_build_user_id_base;
         let nix_build_user_count;
@@ -259,21 +214,18 @@ impl CommonSettings {
         match (Architecture::host(), OperatingSystem::host()) {
             #[cfg(target_os = "linux")]
             (Architecture::X86_64, OperatingSystem::Linux) => {
-                url = NIX_X64_64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
                 nix_build_user_count = 32;
             },
             #[cfg(target_os = "linux")]
             (Architecture::X86_32(_), OperatingSystem::Linux) => {
-                url = NIX_I686_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
                 nix_build_user_count = 32;
             },
             #[cfg(target_os = "linux")]
             (Architecture::Aarch64(_), OperatingSystem::Linux) => {
-                url = NIX_AARCH64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
                 nix_build_user_count = 32;
@@ -281,7 +233,6 @@ impl CommonSettings {
             #[cfg(target_os = "macos")]
             (Architecture::X86_64, OperatingSystem::MacOSX { .. })
             | (Architecture::X86_64, OperatingSystem::Darwin) => {
-                url = NIX_X64_64_DARWIN_URL;
                 nix_build_user_prefix = "_nixbld";
                 nix_build_user_id_base = 300;
                 nix_build_user_count = 32;
@@ -289,7 +240,6 @@ impl CommonSettings {
             #[cfg(target_os = "macos")]
             (Architecture::Aarch64(_), OperatingSystem::MacOSX { .. })
             | (Architecture::Aarch64(_), OperatingSystem::Darwin) => {
-                url = NIX_AARCH64_DARWIN_URL;
                 nix_build_user_prefix = "_nixbld";
                 nix_build_user_id_base = 300;
                 nix_build_user_count = 32;
@@ -308,7 +258,7 @@ impl CommonSettings {
             nix_build_user_id_base,
             nix_build_user_count,
             nix_build_user_prefix: nix_build_user_prefix.to_string(),
-            nix_package_url: url.parse()?,
+            nix_package_url: None,
             proxy: Default::default(),
             extra_conf: Default::default(),
             force: false,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,6 +11,9 @@ use url::Url;
 
 pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
+/// The NIX_INSTALLER_TARBALL_PATH environment variable should point to a target-appropriate
+/// Nix installation tarball, like nix-2.21.2-aarch64-darwin.tar.xz. The contents are embedded
+/// in the resulting binary.
 pub const NIX_TARBALL: &[u8] = include_bytes!(env!("NIX_INSTALLER_TARBALL_PATH"));
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
##### Description

Embedding the Nix binary will reduce runtime failures due to fetching, and reduce the foundation's bandwidth burden by roughly half a terabyte per day.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
