### PR TITLE
Add --set-home to sudo invocation

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -97,10 +97,13 @@ pub fn ensure_root() -> eyre::Result<()> {
                 .dimmed()
         );
         let sudo_cstring = CString::new("sudo").wrap_err("Making C string of `sudo`")?;
+        let set_home_cstring =
+            CString::new("--set-home").wrap_err("Making C string of `--set-home`")?;
 
         let args = std::env::args();
         let mut arg_vec_cstring = vec![];
         arg_vec_cstring.push(sudo_cstring.clone());
+        arg_vec_cstring.push(set_home_cstring);
 
         let mut env_list = vec![];
         for (key, value) in std::env::vars() {


### PR DESCRIPTION
It is assumed that `dirs::home_dir()` refers to root's home directory.
This is used, for example, to setup a root profile with nix-env in
`SetupDefaultProfile`.

`dirs::home_dir()` is derived from `$HOME`, but on macOS, by default
`sudo` does not set `$HOME` to root's home unless
`--set-home` is passed.

```
> sudo bash -c 'echo $HOME'
/Users/matthew
> sudo --set-home bash -c 'echo $HOME'
/var/root
```

Pass `--set-home` to the `sudo` invocation so that `$HOME` is always
set, regardless of the system's security policy.