### PR TITLE
Test installer on aarch64-linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/build-x86_64-darwin.yml
 
   build-aarch64-linux:
-    uses: ./.github/workflows/build-aarch64-darwin.yml
+    uses: ./.github/workflows/build-aarch64-linux.yml
 
   lints:
     name: Lints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-aarch64-linux
           chmod +x install-root/nix-installer-aarch64-linux install-root/nix-installer.sh
-      - run: sudo apt install fish zsh
+      - run: sudo apt install -y fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,12 +357,7 @@ jobs:
 
   run-aarch64-linux:
     name: Run aarch64 Linux
-    runs-on: ${{ matrix.system }}
-    strategy:
-      matrix:
-        system:
-          - namespace-profile-default-arm64
-          - nscloud-ubuntu-22.04-amd64-4x16
+    runs-on: namespace-profile-default-arm64
     needs: [lints, build-aarch64-linux]
     permissions:
       id-token: "write"
@@ -380,7 +375,7 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-aarch64-linux
           chmod +x install-root/nix-installer-aarch64-linux install-root/nix-installer.sh
-      - run: sudo apt install -y fish zsh
+      - run: sudo apt install fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       contents: "read"
     steps:
       - uses: actions/checkout@v3
-      - name: Restore Github cache of Buildkite artifacts
+      - name: Restore Github cache artifacts
         uses: actions/cache/restore@v3
         with:
           path: nix-installer
@@ -167,7 +167,7 @@ jobs:
       contents: "read"
     steps:
       - uses: actions/checkout@v3
-      - name: Restore Github cache of Buildkite artifacts
+      - name: Restore Github cache artifacts
         uses: actions/cache/restore@v3
         with:
           path: nix-installer
@@ -281,7 +281,7 @@ jobs:
       contents: "read"
     steps:
       - uses: actions/checkout@v3
-      - name: Restore Github cache of Buildkite artifacts
+      - name: Restore Github cache artifacts
         uses: actions/cache/restore@v3
         with:
           path: nix-installer
@@ -369,7 +369,7 @@ jobs:
       contents: "read"
     steps:
       - uses: actions/checkout@v3
-      - name: Restore Github cache of Buildkite artifacts
+      - name: Restore Github cache artifacts
         uses: actions/cache/restore@v3
         with:
           path: nix-installer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,7 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-aarch64-linux
           chmod +x install-root/nix-installer-aarch64-linux install-root/nix-installer.sh
-      - run: sudo apt install fish zsh
+      - run: sudo apt install -y fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
   build-x86_64-darwin:
     uses: ./.github/workflows/build-x86_64-darwin.yml
 
+  build-aarch64-linux:
+    uses: ./.github/workflows/build-aarch64-darwin.yml
+
   lints:
     name: Lints
     runs-on: ubuntu-latest
@@ -351,3 +354,116 @@ jobs:
           NIX_INSTALLER_LOGGER: pretty
           NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
           RUST_BACKTRACE: full
+
+  run-aarch64-linux:
+    name: Run aarch64 Linux
+    runs-on: ${{ matrix.system }}
+    strategy:
+      matrix:
+        system:
+          - namespace-profile-default-arm64
+          - nscloud-ubuntu-22.04-amd64-4x16
+    needs: [lints, build-aarch64-linux]
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Restore Github cache of Buildkite artifacts
+        uses: actions/cache/restore@v3
+        with:
+          path: nix-installer
+          key: aarch64-linux-artifacts-${{ github.sha }}
+      - name: Move & set executable
+        run: |
+          mkdir install-root
+          cp nix-installer.sh install-root/nix-installer.sh
+          mv ./nix-installer install-root/nix-installer-aarch64-linux
+          chmod +x install-root/nix-installer-aarch64-linux install-root/nix-installer.sh
+      - run: sudo apt install fish zsh
+      - name: Initial install
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          flakehub: true
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=debug
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Initial uninstall (without a `nix run` first)
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
+          RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run: |
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
+      - name: Repeated install
+        uses: DeterminateSystems/nix-installer-action@main
+        with:
+          flakehub: true
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=debug
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: echo $PATH
+        run: echo $PATH
+      - name: Test `nix` with `$GITHUB_PATH`
+        if: success() || failure()
+        run: |
+          nix run nixpkgs#hello
+          nix profile install nixpkgs#hello
+          hello
+          nix store gc
+          nix run nixpkgs#hello
+      - name: Test bash
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: bash --login {0}
+      - name: Test sh
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: sh -l {0}
+      - name: Test zsh
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: zsh --login --interactive {0}
+      - name: Test fish
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: fish --login {0}
+      - name: Repeated uninstall
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=debug
+          RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run: |
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi


### PR DESCRIPTION
Previously, we didn't have access to `aarch64-linux` runners in GHA but now we do. So this falls a small but important gap in our test suite.