### PR TITLE
Set `always-allow-substitutes` to `true` in `nix.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Differing from the upstream [Nix](https://github.com/NixOS/nix) installer script
   + the `nix-command` and `flakes` features are enabled
   + `bash-prompt-prefix` is set
   + `auto-optimise-store` is set to `true` (On Linux only)
+  * `always-allow-substitutes` is set to `true`
   * `extra-nix-path` is set to `nixpkgs=flake:nixpkgs`
   * `max-jobs` is set to `auto`
   * `upgrade-nix-store-path-url` is set to `https://install.determinate.systems/nix-upgrade/stable/universal`, to prevent unintentional downgrades.

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -111,6 +111,9 @@ impl PlaceNixConfiguration {
         #[cfg(not(target_os = "macos"))]
         settings.insert("auto-optimise-store".to_string(), "true".to_string());
 
+        // https://github.com/NixOS/nix/pull/8047
+        settings.insert("always-allow-substitutes".to_string(), "true".to_string());
+
         settings.insert(
             "bash-prompt-prefix".to_string(),
             "(nix:$name)\\040".to_string(),

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -354,6 +354,7 @@
                 "path": "/etc/nix/nix.conf",
                 "pending_nix_config": {
                   "settings": {
+                    "always-allow-substitutes": true,
                     "experimental-features": "nix-command flakes auto-allocate-uids",
                     "build-users-group": "nixbld",
                     "auto-optimise-store": "true",

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -354,7 +354,7 @@
                 "path": "/etc/nix/nix.conf",
                 "pending_nix_config": {
                   "settings": {
-                    "always-allow-substitutes": true,
+                    "always-allow-substitutes": "true",
                     "experimental-features": "nix-command flakes auto-allocate-uids",
                     "build-users-group": "nixbld",
                     "auto-optimise-store": "true",

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -341,7 +341,7 @@
                 "path": "/etc/nix/nix.conf",
                 "pending_nix_config": {
                   "settings": {
-                    "always-allow-substitutes": true,
+                    "always-allow-substitutes": "true",
                     "auto-optimise-store": "true",
                     "bash-prompt-prefix": "(nix:$name)\\040",
                     "build-users-group": "nixbld",

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -341,6 +341,7 @@
                 "path": "/etc/nix/nix.conf",
                 "pending_nix_config": {
                   "settings": {
+                    "always-allow-substitutes": true,
                     "auto-optimise-store": "true",
                     "bash-prompt-prefix": "(nix:$name)\\040",
                     "build-users-group": "nixbld",

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -378,7 +378,7 @@
                 "path": "/etc/nix/nix.conf",
                 "pending_nix_config": {
                   "settings": {
-                    "always-allow-substitutes": true,
+                    "always-allow-substitutes": "true",
                     "extra-nix-path": "nixpkgs=flake:nixpkgs",
                     "auto-allocate-uids": "true",
                     "auto-optimise-store": "true",

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -378,6 +378,7 @@
                 "path": "/etc/nix/nix.conf",
                 "pending_nix_config": {
                   "settings": {
+                    "always-allow-substitutes": true,
                     "extra-nix-path": "nixpkgs=flake:nixpkgs",
                     "auto-allocate-uids": "true",
                     "auto-optimise-store": "true",


### PR DESCRIPTION
The impetus behind this is https://github.com/NixOS/nix/pull/8047.