### PR TITLE
Bump version to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "nix-installer"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "bytes 1.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nix-installer"
 description = "The Determinate Nix Installer"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 resolver = "2"
 license = "LGPL-2.1"


### PR DESCRIPTION
##### Description

Periodic version bump to include recent changes in latest tagged.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
