### PR TITLE
Run shellcheck on `nix-installer.sh`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
   build-aarch64-linux:
     uses: ./.github/workflows/build-aarch64-linux.yml
-  
+
   build-aarch64-darwin:
     uses: ./.github/workflows/build-aarch64-darwin.yml
 
@@ -52,6 +52,8 @@ jobs:
         run: nix develop --command check-nixpkgs-fmt
       - name: Check EditorConfig conformance
         run: nix develop --command check-editorconfig
+      - name: Shell check for nix-installer.sh
+        run: nix develop --command shellcheck ./nix-installer.sh
 
   run-x86_64-linux:
     name: Run x86_64 Linux

--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,7 @@
             nativeBuildInputs = with pkgs; [ ];
             buildInputs = with pkgs; [
               toolchain
+              shellcheck
               rust-analyzer
               cargo-outdated
               cacert

--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -290,19 +290,23 @@ downloader() {
         _ciphersuites="$RETVAL"
         if [ -n "$_ciphersuites" ]; then
             if [ -n "${NIX_INSTALLER_FORCE_ALLOW_HTTP-}" ]; then
-                _err=$(curl "$_retry" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
+                # shellcheck disable=SC2086
+                _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
             else
-                _err=$(curl "$_retry" --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
+                # shellcheck disable=SC2086
+                _err=$(curl $_retry --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
             fi
             _status=$?
         else
             echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
             if ! check_help_for "$3" curl --proto --tlsv1.2; then
                 echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
-                _err=$(curl "$_retry" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
+                # shellcheck disable=SC2086
+                _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             else
-                _err=$(curl "$_retry" --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2" 2>&1)
+                # shellcheck disable=SC2086
+                _err=$(curl $_retry --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             fi
         fi

--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -290,19 +290,19 @@ downloader() {
         _ciphersuites="$RETVAL"
         if [ -n "$_ciphersuites" ]; then
             if [ -n "${NIX_INSTALLER_FORCE_ALLOW_HTTP-}" ]; then
-                _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
+                _err=$(curl "$_retry" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
             else
-                _err=$(curl $_retry --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
+                _err=$(curl "$_retry" --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
             fi
             _status=$?
         else
             echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
             if ! check_help_for "$3" curl --proto --tlsv1.2; then
                 echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
-                _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
+                _err=$(curl "$_retry" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             else
-                _err=$(curl $_retry --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2" 2>&1)
+                _err=$(curl "$_retry" --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             fi
         fi

--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -290,10 +290,10 @@ downloader() {
         _ciphersuites="$RETVAL"
         if [ -n "$_ciphersuites" ]; then
             if [ -n "${NIX_INSTALLER_FORCE_ALLOW_HTTP-}" ]; then
-                # shellcheck disable=SC2086
+                # shellcheck disable=SC2086 # ignore because $_retry could be a flag (e.g. `--retry 5`)
                 _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
             else
-                # shellcheck disable=SC2086
+                # shellcheck disable=SC2086 # ignore because $_retry could be a flag (e.g. `--retry 5`)
                 _err=$(curl $_retry --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
             fi
             _status=$?
@@ -301,11 +301,11 @@ downloader() {
             echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
             if ! check_help_for "$3" curl --proto --tlsv1.2; then
                 echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
-                # shellcheck disable=SC2086
+                # shellcheck disable=SC2086 # ignore because $_retry could be a flag (e.g. `--retry 5`)
                 _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             else
-                # shellcheck disable=SC2086
+                # shellcheck disable=SC2086 # ignore because $_retry could be a flag (e.g. `--retry 5`)
                 _err=$(curl $_retry --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             fi
@@ -414,7 +414,6 @@ check_curl_for_retry_support() {
   fi
 
   RETVAL="$_retry_supported"
-
 }
 
 # Return cipher suite string specified by user, otherwise return strong TLS 1.2-1.3 cipher suites


### PR DESCRIPTION
##### Description

At the moment, we do have a shellcheck directive in `nix-installer.sh` but we don't actually run [shellcheck](https://www.shellcheck.net/) against it. Doing so has exposed two very minor infractions but worth automating this.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
