### PR TITLE
Allow the 'nix' input to point to the Nix repo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,10 @@
         ] ++ nixpkgs.lib.optionals (system == "aarch64-linux") [
           targets.aarch64-unknown-linux-musl.stable.rust-std
         ]);
+
+      nixTarballs = forAllSystems ({ system, ... }:
+        inputs.nix.tarballs_direct.${system}
+          or "${inputs.nix.checks."${system}".binaryTarball}/nix-${inputs.nix.packages."${system}".default.version}-${system}.tar.xz");
     in
     {
       overlays.default = final: prev:
@@ -87,7 +91,7 @@
             RUSTFLAGS = "--cfg tokio_unstable";
             cargoTestOptions = f: f ++ [ "--all" ];
 
-            NIX_INSTALLER_TARBALL_PATH = inputs.nix.tarballs_direct.${final.stdenv.system};
+            NIX_INSTALLER_TARBALL_PATH = nixTarballs.${final.stdenv.system};
 
             override = { preBuild ? "", ... }: {
               preBuild = preBuild + ''
@@ -132,7 +136,7 @@
             name = "nix-install-shell";
 
             RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
-            NIX_INSTALLER_TARBALL_PATH = inputs.nix.tarballs_direct.${system};
+            NIX_INSTALLER_TARBALL_PATH = nixTarballs.${system};
 
             nativeBuildInputs = with pkgs; [ ];
             buildInputs = with pkgs; [


### PR DESCRIPTION
##### Description

This way, you can build upstream Nix or a branch/fork by doing

```
# nix build --override-input github:my-org/nix/my-branch
```

without needing the https://github.com/DeterminateSystems/nix wrapper.


<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
