### PR TITLE
Prefer launchtl's bootstrap / bootout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,24 @@ $ chmod +x nix-installer
 $ ./nix-installer
 ```
 
-`nix-installer` installs Nix by following a *plan* made by a *planner*. Review the available planners:
+`nix-installer` installs Nix by following a _plan_ made by a _planner_. Review the available planners:
 
 ```bash
-$ ./nix-installer install --help
-Execute an install (possibly using an existing plan)
+foo@ubuntuserver2204:~$ ./nix-installer install --help
+Install Nix using a planner
 
-To pass custom options, select a planner, for example `nix-installer install linux-multi --help`
+By default, an appropriate planner is heuristically determined based on the system.
+
+Some planners have additional options which can be set from the planner's subcommand.
 
 Usage: nix-installer install [OPTIONS] [PLAN]
        nix-installer install <COMMAND>
 
 Commands:
-  linux
-          A planner for Linux installs
-  steam-deck
-          A planner suitable for the Valve Steam Deck running SteamOS
-  help
-          Print this message or the help of the given subcommand(s)
+  linux       A planner for traditional, mutable Linux systems like Debian, RHEL, or Arch
+  steam-deck  A planner for the Valve Steam Deck running SteamOS
+  ostree      A planner suitable for immutable systems using ostree, such as Fedora Silverblue
+  help        Print this message or the help of the given subcommand(s)
 # ...
 ```
 
@@ -90,9 +90,9 @@ Options:
 Planners can be configured via environment variable or command arguments:
 
 ```bash
-$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | NIX_BUILD_GROUP_NAME=nixbuilder sh -s -- install linux-multi --nix-build-group-id 4000
+$ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | NIX_BUILD_GROUP_NAME=nixbuilder sh -s -- install --nix-build-group-id 4000
 # Or...
-$ NIX_BUILD_GROUP_NAME=nixbuilder ./nix-installer install linux-multi --nix-build-group-id 4000
+$ NIX_BUILD_GROUP_NAME=nixbuilder ./nix-installer install --nix-build-group-id 4000
 ```
 
 ### Upgrading Nix

--- a/src/action/common/configure_enterprise_edition_init_service.rs
+++ b/src/action/common/configure_enterprise_edition_init_service.rs
@@ -91,7 +91,7 @@ impl Action for ConfigureEnterpriseEditionInitService {
             Command::new("launchctl")
                 .process_group(0)
                 .arg("bootstrap")
-                .args([domain, service])
+                .args([domain, daemon_file])
                 .stdin(std::process::Stdio::null()),
         )
         .await
@@ -143,7 +143,7 @@ impl Action for ConfigureEnterpriseEditionInitService {
             Command::new("launchctl")
                 .process_group(0)
                 .arg("bootout")
-                .args([DARWIN_LAUNCHD_DOMAIN, DARWIN_LAUNCHD_SERVICE]),
+                .arg([DARWIN_LAUNCHD_DOMAIN, DARWIN_LAUNCHD_SERVICE].join("/")),
         )
         .await
         .map_err(Self::error)?;

--- a/src/action/common/configure_enterprise_edition_init_service.rs
+++ b/src/action/common/configure_enterprise_edition_init_service.rs
@@ -52,7 +52,7 @@ impl Action for ConfigureEnterpriseEditionInitService {
         let mut explanation = vec![format!("Create `{DARWIN_ENTERPRISE_EDITION_DAEMON_DEST}`")];
         if self.start_daemon {
             explanation.push(format!(
-                "Run `launchctl load {DARWIN_ENTERPRISE_EDITION_DAEMON_DEST}`"
+                "Run `launchctl bootstrap {DARWIN_ENTERPRISE_EDITION_DAEMON_DEST}`"
             ));
         }
 
@@ -86,8 +86,8 @@ impl Action for ConfigureEnterpriseEditionInitService {
         execute_command(
             Command::new("launchctl")
                 .process_group(0)
-                .args(["load", "-w"])
-                .arg(daemon_file)
+                .arg("bootstrap")
+                .args([domain, service])
                 .stdin(std::process::Stdio::null()),
         )
         .await
@@ -128,7 +128,7 @@ impl Action for ConfigureEnterpriseEditionInitService {
         vec![ActionDescription::new(
             "Unconfigure Nix daemon related settings with launchctl".to_string(),
             vec![format!(
-                "Run `launchctl unload {DARWIN_ENTERPRISE_EDITION_DAEMON_DEST}`"
+                "Run `launchctl bootout {DARWIN_ENTERPRISE_EDITION_DAEMON_DEST}`"
             )],
         )]
     }
@@ -138,8 +138,8 @@ impl Action for ConfigureEnterpriseEditionInitService {
         execute_command(
             Command::new("launchctl")
                 .process_group(0)
-                .arg("unload")
-                .arg(DARWIN_ENTERPRISE_EDITION_DAEMON_DEST),
+                .arg("bootout")
+                .args([domain, service])
         )
         .await
         .map_err(Self::error)?;

--- a/src/action/common/configure_enterprise_edition_init_service.rs
+++ b/src/action/common/configure_enterprise_edition_init_service.rs
@@ -15,6 +15,10 @@ use crate::action::{Action, ActionDescription};
 #[cfg(target_os = "macos")]
 const DARWIN_ENTERPRISE_EDITION_DAEMON_DEST: &str =
     "/Library/LaunchDaemons/systems.determinate.nix-daemon.plist";
+#[cfg(target_os = "macos")]
+const DARWIN_LAUNCHD_DOMAIN: &str = "system";
+#[cfg(target_os = "macos")]
+const DARWIN_LAUNCHD_SERVICE: &str = "systems.determinate.nix-daemon";
 /**
 Configure the init to run the Nix daemon
 */
@@ -64,8 +68,8 @@ impl Action for ConfigureEnterpriseEditionInitService {
         let Self { start_daemon } = self;
 
         let daemon_file = DARWIN_ENTERPRISE_EDITION_DAEMON_DEST;
-        let domain = "system";
-        let service = "systems.determinate.nix-daemon";
+        let domain = DARWIN_LAUNCHD_DOMAIN;
+        let service = DARWIN_LAUNCHD_SERVICE;
 
         let generated_plist = generate_plist();
 
@@ -139,7 +143,7 @@ impl Action for ConfigureEnterpriseEditionInitService {
             Command::new("launchctl")
                 .process_group(0)
                 .arg("bootout")
-                .args([domain, service])
+                .args([DARWIN_LAUNCHD_DOMAIN, DARWIN_LAUNCHD_SERVICE]),
         )
         .await
         .map_err(Self::error)?;

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -158,7 +158,7 @@ impl Action for ConfigureInitService {
                     "Copy `{DARWIN_NIX_DAEMON_SOURCE}` to `{DARWIN_NIX_DAEMON_DEST}`"
                 )];
                 if self.start_daemon {
-                    explanation.push(format!("Run `launchctl load {DARWIN_NIX_DAEMON_DEST}`"));
+                    explanation.push(format!("Run `launchctl bootstrap {DARWIN_NIX_DAEMON_DEST}`"));
                 }
                 vec.push(ActionDescription::new(self.tracing_synopsis(), explanation))
             },
@@ -191,8 +191,8 @@ impl Action for ConfigureInitService {
                 execute_command(
                     Command::new("launchctl")
                         .process_group(0)
-                        .args(["load", "-w"])
-                        .arg(daemon_file)
+                        .arg("bootstrap")
+                        .args([domain, service])
                         .stdin(std::process::Stdio::null()),
                 )
                 .await
@@ -378,7 +378,7 @@ impl Action for ConfigureInitService {
             InitSystem::Launchd => {
                 vec![ActionDescription::new(
                     "Unconfigure Nix daemon related settings with launchctl".to_string(),
-                    vec![format!("Run `launchctl unload {DARWIN_NIX_DAEMON_DEST}`")],
+                    vec![format!("Run `launchctl bootout {DARWIN_NIX_DAEMON_DEST}`")],
                 )]
             },
             #[cfg(not(target_os = "macos"))]
@@ -397,8 +397,8 @@ impl Action for ConfigureInitService {
                 execute_command(
                     Command::new("launchctl")
                         .process_group(0)
-                        .arg("unload")
-                        .arg(DARWIN_NIX_DAEMON_DEST),
+                        .arg("bootout")
+                        .args([domain, service]),
                 )
                 .await
                 .map_err(Self::error)?;

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -198,7 +198,7 @@ impl Action for ConfigureInitService {
                     Command::new("launchctl")
                         .process_group(0)
                         .arg("bootstrap")
-                        .args([domain, service])
+                        .args([domain, daemon_file])
                         .stdin(std::process::Stdio::null()),
                 )
                 .await
@@ -404,7 +404,7 @@ impl Action for ConfigureInitService {
                     Command::new("launchctl")
                         .process_group(0)
                         .arg("bootout")
-                        .args([DARWIN_LAUNCHD_DOMAIN, DARWIN_LAUNCHD_SERVICE]),
+                        .arg([DARWIN_LAUNCHD_DOMAIN, DARWIN_LAUNCHD_SERVICE].join("/")),
                 )
                 .await
                 .map_err(Self::error)?;

--- a/src/planner/macos/profile_queries.rs
+++ b/src/planner/macos/profile_queries.rs
@@ -77,11 +77,11 @@ pub fn blocks_internal_mounting(policies: &Policies) -> Vec<TargetProfileHardDis
 
             let MountControls { harddisk_internal } = mount_controls;
 
-            return Some(TargetProfileHardDiskInternalOpts {
+            Some(TargetProfileHardDiskInternalOpts {
                 target: target_profile_item.target,
                 profile: target_profile_item.profile,
-                opts: &harddisk_internal,
-            });
+                opts: harddisk_internal,
+            })
         })
         .filter(|TargetProfileHardDiskInternalOpts { opts, .. }| {
             opts.iter().any(|x| {


### PR DESCRIPTION
##### Description

This might fix "Operation not permitted" issues. See: https://joelsenders.wordpress.com/2019/03/14/dear-launchctl-were-all-using-you-wrong/


##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
