### PR TITLE
Make the init configurator support arbitrary socket files

### DIFF
--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -232,7 +232,7 @@ fn generate_plist() -> DeterminateNixDaemonPlist {
         },
         sockets: HashMap::from([
             (
-                "determinate-nixd-http".to_string(),
+                "determinate-nixd.socket".to_string(),
                 Socket {
                     sock_family: SocketFamily::Unix,
                     sock_passive: true,

--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tracing::{span, Span};
 
-use crate::action::{ActionError, ActionErrorKind, ActionTag, StatefulAction};
-
+use crate::action::common::configure_init_service::{SocketFile, UnitSrc};
 use crate::action::{common::ConfigureInitService, Action, ActionDescription};
+use crate::action::{ActionError, ActionErrorKind, ActionTag, StatefulAction};
 use crate::settings::InitSystem;
 
 // Linux
@@ -46,10 +46,31 @@ impl ConfigureDeterminateNixdInitService {
             _ => None,
         };
 
-        let configure_init_service =
-            ConfigureInitService::plan(init, start_daemon, None, service_dest, service_name)
-                .await
-                .map_err(Self::error)?;
+        let configure_init_service = ConfigureInitService::plan(
+            init,
+            start_daemon,
+            None,
+            service_dest,
+            service_name,
+            vec![
+                SocketFile {
+                    name: "nix-daemon.socket".into(),
+                    src: UnitSrc::Literal(
+                        include_str!("./nix-daemon.determinate-nixd.socket").to_string(),
+                    ),
+                    dest: "/etc/systemd/system/nix-daemon.socket".into(),
+                },
+                SocketFile {
+                    name: "determinate-nixd.socket".into(),
+                    src: UnitSrc::Literal(
+                        include_str!("./nixd.determinate-nixd.socket").to_string(),
+                    ),
+                    dest: "/etc/systemd/system/determinate-nixd.socket".into(),
+                },
+            ],
+        )
+        .await
+        .map_err(Self::error)?;
 
         Ok(Self {
             init,

--- a/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.socket
+++ b/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.socket
@@ -1,0 +1,14 @@
+[Unit]
+Description=Determinate Nix Daemon Socket
+Before=multi-user.target
+RequiresMountsFor=/nix/store
+RequiresMountsFor=/nix/var
+RequiresMountsFor=/nix/var/nix/db
+ConditionPathIsReadWrite=/nix/var/nix/daemon-socket
+
+[Socket]
+FileDescriptorName=nix-daemon.socket
+ListenStream=/nix/var/nix/daemon-socket/socket
+
+[Install]
+WantedBy=sockets.target

--- a/src/action/common/configure_determinate_nixd_init_service/nixd.determinate-nixd.socket
+++ b/src/action/common/configure_determinate_nixd_init_service/nixd.determinate-nixd.socket
@@ -1,0 +1,13 @@
+[Unit]
+Description=Determinate Nixd Daemon Socket
+Before=multi-user.target
+RequiresMountsFor=/nix/store
+RequiresMountsFor=/nix/var/determinate
+ConditionPathIsReadWrite=/nix/var/determinate
+
+[Socket]
+FileDescriptorName=determinate-nixd-http
+ListenStream=/nix/var/determinate/determinate-nixd.socket
+
+[Install]
+WantedBy=sockets.target

--- a/src/action/common/configure_determinate_nixd_init_service/nixd.determinate-nixd.socket
+++ b/src/action/common/configure_determinate_nixd_init_service/nixd.determinate-nixd.socket
@@ -6,7 +6,7 @@ RequiresMountsFor=/nix/var/determinate
 ConditionPathIsReadWrite=/nix/var/determinate
 
 [Socket]
-FileDescriptorName=determinate-nixd-http
+FileDescriptorName=determinate-nixd.socket
 ListenStream=/nix/var/determinate/determinate-nixd.socket
 
 [Install]

--- a/src/action/common/configure_upstream_init_service.rs
+++ b/src/action/common/configure_upstream_init_service.rs
@@ -4,6 +4,7 @@ use tracing::{span, Span};
 
 use crate::action::{ActionError, ActionTag, StatefulAction};
 
+use crate::action::common::configure_init_service::{SocketFile, UnitSrc};
 use crate::action::{common::ConfigureInitService, Action, ActionDescription};
 use crate::settings::InitSystem;
 
@@ -47,10 +48,22 @@ impl ConfigureUpstreamInitService {
             _ => None,
         };
 
-        let configure_init_service =
-            ConfigureInitService::plan(init, start_daemon, service_src, service_dest, service_name)
-                .await
-                .map_err(Self::error)?;
+        let configure_init_service = ConfigureInitService::plan(
+            init,
+            start_daemon,
+            service_src,
+            service_dest,
+            service_name,
+            vec![SocketFile {
+                name: "nix-daemon.socket".into(),
+                src: UnitSrc::Path(
+                    "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket".into(),
+                ),
+                dest: "/etc/systemd/system/nix-daemon.socket".into(),
+            }],
+        )
+        .await
+        .map_err(Self::error)?;
 
         Ok(Self {
             configure_init_service,

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -421,7 +421,16 @@
         "start_daemon": true,
         "ssl_cert_file": null,
         "determinate_nix": false,
-        "service_src": "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service"
+        "service_src": "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service",
+        "socket_files": [
+          {
+            "name": "nix-daemon.socket",
+            "src": {
+              "Path": "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket"
+            },
+            "dest": "/etc/systemd/system/nix-daemon.socket"
+          }
+        ]
       },
       "state": "Uncompleted"
     },

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -392,7 +392,16 @@
         "start_daemon": true,
         "ssl_cert_file": null,
         "determinate_nix": false,
-        "service_src": "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service"
+        "service_src": "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.service",
+        "socket_files": [
+          {
+            "name": "nix-daemon.socket",
+            "src": {
+              "Path": "/nix/var/nix/profiles/default/lib/systemd/system/nix-daemon.socket"
+            },
+            "dest": "/etc/systemd/system/nix-daemon.socket"
+          }
+        ]
       },
       "state": "Uncompleted"
     },

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -436,7 +436,8 @@
         "start_daemon": true,
         "ssl_cert_file": null,
         "determinate_nix": false,
-        "service_src": "/nix/var/nix/profiles/default/Library/LaunchDaemons/org.nixos.nix-daemon.plist"
+        "service_src": "/nix/var/nix/profiles/default/Library/LaunchDaemons/org.nixos.nix-daemon.plist",
+        "socket_files": []
       },
       "state": "Uncompleted"
     },


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
