### PR TITLE
Remove support for i686-linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ The `nix-installer` has successfully completed over 2,000,000 installs in a numb
 | WSL2 (x86_64 & aarch64)    | ✓ (via [systemd]) |      ✓      |      Stable       |
 | Podman Linux Containers    | ✓ (via [systemd]) |      ✓      |      Stable       |
 | Docker Containers          |                   |      ✓      |      Stable       |
-| Linux (i686)               | ✓ (via [systemd]) |      ✓      |     Unstable      |
 
 > [!NOTE]
 > On **MacOS only**, removing users and/or groups may fail if there are no users who are logged in graphically.

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
     , ...
     } @ inputs:
     let
-      supportedSystems = [ "i686-linux" "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       systemsSupportedByDeterminateNixd = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
 
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: (forSystem system f));
@@ -65,8 +65,6 @@
           stable.rust-src
         ] ++ nixpkgs.lib.optionals (system == "x86_64-linux") [
           targets.x86_64-unknown-linux-musl.stable.rust-std
-        ] ++ nixpkgs.lib.optionals (system == "i686-linux") [
-          targets.i686-unknown-linux-musl.stable.rust-std
         ] ++ nixpkgs.lib.optionals (system == "aarch64-linux") [
           targets.aarch64-unknown-linux-musl.stable.rust-std
         ]);
@@ -148,12 +146,6 @@
           nix-installer-static = naerskLib.buildPackage
             (sharedAttrs // {
               CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
-            });
-        } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "i686-linux") rec {
-          default = nix-installer-static;
-          nix-installer-static = naerskLib.buildPackage
-            (sharedAttrs // {
-              CARGO_BUILD_TARGET = "i686-unknown-linux-musl";
             });
         } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "aarch64-linux") rec {
           default = nix-installer-static;
@@ -239,9 +231,6 @@
         {
           inherit (pkgs) nix-installer;
         } // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
-          inherit (pkgs) nix-installer-static;
-          default = pkgs.nix-installer-static;
-        } // nixpkgs.lib.optionalAttrs (system == "i686-linux") {
           inherit (pkgs) nix-installer-static;
           default = pkgs.nix-installer-static;
         } // nixpkgs.lib.optionalAttrs (system == "aarch64-linux") {

--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -213,10 +213,6 @@ get_architecture() {
             _cputype=x86_64
             ;;
 
-        i686)
-            _cputype=i686
-            ;;
-
         *)
             err "unknown CPU type: $_cputype"
             ;;

--- a/src/self_test.rs
+++ b/src/self_test.rs
@@ -93,8 +93,6 @@ impl Shell {
 
         #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
         const SYSTEM: &str = "x86_64-linux";
-        #[cfg(all(target_os = "linux", target_arch = "x86"))]
-        const SYSTEM: &str = "x86-linux";
         #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
         const SYSTEM: &str = "aarch64-linux";
         #[cfg(all(target_os = "macos", target_arch = "x86_64"))]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,22 +21,14 @@ pub const NIX_TARBALL_PATH: &str = env!("NIX_INSTALLER_TARBALL_PATH");
 /// in the resulting binary.
 pub const NIX_TARBALL: &[u8] = include_bytes!(env!("NIX_INSTALLER_TARBALL_PATH"));
 
-#[cfg(all(
-    feature = "determinate-nix",
-    // Determinate Nix is available on everything but i686-linux, so set the bytes
-    not(all(target_os = "linux", target_arch = "x86"))
-))]
+#[cfg(feature = "determinate-nix")]
 /// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
 /// static build of the Determinate Nixd binary. The contents are embedded in the resulting
 /// binary if the determinate-nix feature is turned on.
 pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> =
     Some(include_bytes!(env!("DETERMINATE_NIXD_BINARY_PATH")));
 
-#[cfg(not(all(
-    feature = "determinate-nix",
-    // Determinate Nix is not available on i686-linux, so default it to None
-    not(all(target_os = "linux", target_arch = "x86"))
-)))]
+#[cfg(not(feature = "determinate-nix"))]
 /// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
 /// static build of the Determinate Nixd binary. The contents are embedded in the resulting
 /// binary if the determinate-nix feature is turned on.


### PR DESCRIPTION
For more information, see our blog post on the topic: https://determinate.systems/posts/nix-installer-i686-linux/

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
