### PR TITLE
setup_default_profile: don't substitute

### DIFF
--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -118,6 +118,7 @@ impl Action for SetupDefaultProfile {
         execute_command(
             Command::new(nix_pkg.join("bin/nix-env"))
                 .process_group(0)
+                .args(["--option", "substitute", "false"])
                 .arg("-i")
                 .arg(&nix_pkg)
                 .stdin(std::process::Stdio::null())
@@ -138,6 +139,7 @@ impl Action for SetupDefaultProfile {
         execute_command(
             Command::new(nix_pkg.join("bin/nix-env"))
                 .process_group(0)
+                .args(["--option", "substitute", "false"])
                 .arg("-i")
                 .arg(&nss_ca_cert_pkg)
                 .stdin(std::process::Stdio::null())

--- a/src/self_test.rs
+++ b/src/self_test.rs
@@ -105,7 +105,7 @@ impl Shell {
             .as_millis();
 
         command.arg(format!(
-            r#"nix build --no-link --expr 'derivation {{ name = "self-test-{executable}-{timestamp_millis}"; system = "{SYSTEM}"; builder = "/bin/sh"; args = ["-c" "echo hello > \$out"]; }}'"#
+            r#"nix build --option substitute false --no-link --expr 'derivation {{ name = "self-test-{executable}-{timestamp_millis}"; system = "{SYSTEM}"; builder = "/bin/sh"; args = ["-c" "echo hello > \$out"]; }}'"#
         ));
         let command_str = format!("{:?}", command.as_std());
 


### PR DESCRIPTION
We already have everything we need, so substitution is not necessary
(and makes it slower in our VM tests without networking).

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
