### PR TITLE
Move determinate-nixd to /usr/local/bin/determinate-nixd on Linux

### DIFF
--- a/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.service
+++ b/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.service
@@ -7,7 +7,7 @@ RequiresMountsFor=/nix/var/nix/db
 ConditionPathIsReadWrite=/nix/var/nix/daemon-socket
 
 [Service]
-ExecStart=@/nix/determinate/determinate-nixd determinate-nixd
+ExecStart=@/usr/local/bin/determinate-nixd determinate-nixd
 KillMode=process
 LimitNOFILE=1048576
 TasksMax=1048576

--- a/src/action/common/provision_determinate_nixd.rs
+++ b/src/action/common/provision_determinate_nixd.rs
@@ -9,8 +9,7 @@ use crate::action::{
 };
 use crate::settings::InitSystem;
 
-const LINUX_DETERMINATE_NIXD_BINARY_PATH: &str = "/nix/determinate/determinate-nixd";
-const MACOS_DETERMINATE_NIXD_BINARY_PATH: &str = "/usr/local/bin/determinate-nixd";
+const DETERMINATE_NIXD_BINARY_PATH: &str = "/usr/local/bin/determinate-nixd";
 /**
 Provision the determinate-nixd binary
 */
@@ -27,11 +26,7 @@ impl ProvisionDeterminateNixd {
             .ok_or_else(|| Self::error(ActionErrorKind::DeterminateNixUnavailable))?;
 
         let this = Self {
-            binary_location: match init {
-                InitSystem::Launchd => MACOS_DETERMINATE_NIXD_BINARY_PATH.into(),
-                InitSystem::Systemd => LINUX_DETERMINATE_NIXD_BINARY_PATH.into(),
-                InitSystem::None => LINUX_DETERMINATE_NIXD_BINARY_PATH.into(),
-            },
+            binary_location: DETERMINATE_NIXD_BINARY_PATH,
         };
 
         Ok(StatefulAction::uncompleted(this))

--- a/src/action/common/provision_determinate_nixd.rs
+++ b/src/action/common/provision_determinate_nixd.rs
@@ -26,7 +26,7 @@ impl ProvisionDeterminateNixd {
             .ok_or_else(|| Self::error(ActionErrorKind::DeterminateNixUnavailable))?;
 
         let this = Self {
-            binary_location: DETERMINATE_NIXD_BINARY_PATH,
+            binary_location: DETERMINATE_NIXD_BINARY_PATH.into(),
         };
 
         Ok(StatefulAction::uncompleted(this))

--- a/src/action/linux/selinux/determinate-nix.fc
+++ b/src/action/linux/selinux/determinate-nix.fc
@@ -7,7 +7,7 @@
 /nix/var/nix/daemon-socket(/.*)?	system_u:object_r:var_run_t:s0
 /nix/var/nix/profiles(/per-user/[^/]+)?/[^/]+	system_u:object_r:usr_t:s0
 
-/nix/determinate/determinate-nixd	system_u:object_r:bin_t:s0
+/usr/local/bin/determinate-nixd	system_u:object_r:bin_t:s0
 /nix/var/determinate/determinate-nixd.socket	system_u:object_r:var_run_t:s0
 /nix/var/determinate/intake.pipe	system_u:object_r:var_run_t:s0
 /nix/var/determinate/post-build-hook.sh	system_u:object_r:bin_t:s0

--- a/src/action/linux/selinux/determinate-nix.pp
+++ b/src/action/linux/selinux/determinate-nix.pp
@@ -7,7 +7,7 @@
 /nix/var/nix/daemon-socket(/.*)?	system_u:object_r:var_run_t:s0
 /nix/var/nix/profiles(/per-user/[^/]+)?/[^/]+	system_u:object_r:usr_t:s0
 
-/nix/determinate/determinate-nixd	system_u:object_r:bin_t:s0
+/usr/local/bin/determinate-nixd	system_u:object_r:bin_t:s0
 /nix/var/determinate/determinate-nixd.socket	system_u:object_r:var_run_t:s0
 /nix/var/determinate/intake.pipe	system_u:object_r:var_run_t:s0
 /nix/var/determinate/post-build-hook.sh	system_u:object_r:bin_t:s0


### PR DESCRIPTION
We put it there on macOS so it is present even if the Nix Store volume isn't mounted yet. Putting it in a diferent place on Linux has created confusion and a hard-to-document setup.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
