### PR TITLE
Raise the NOFILE limit to 512 * 1024 * 1024 after hitting limits talking to caches

### DIFF
--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -225,10 +225,10 @@ fn generate_plist() -> DeterminateNixDaemonPlist {
         standard_error_path: "/var/log/determinate-nix-daemon.log".into(),
         standard_out_path: "/var/log/determinate-nix-daemon.log".into(),
         soft_resource_limits: ResourceLimits {
-            number_of_files: 1048576,
+            number_of_files: 536_870_912,
         },
         hard_resource_limits: ResourceLimits {
-            number_of_files: 1048576 * 2,
+            number_of_files: 536_870_912,
         },
         sockets: HashMap::from([
             (

--- a/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.service
+++ b/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.service
@@ -9,7 +9,7 @@ ConditionPathIsReadWrite=/nix/var/nix/daemon-socket
 [Service]
 ExecStart=@/usr/local/bin/determinate-nixd determinate-nixd
 KillMode=process
-LimitNOFILE=1048576
+LimitNOFILE=536870912
 TasksMax=1048576
 
 [Install]


### PR DESCRIPTION
##### Description

Substituting builds with many inputs may cause the Nix daemon to run out of open files on some platforms. Testing shows raising NOFILE solves the issue.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
