### PR TITLE
Bring LimitNOFILE back down to 1024 * 1024 due to the performance impact of too many FDs

### DIFF
--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -227,12 +227,12 @@ fn generate_plist() -> DeterminateNixDaemonPlist {
         standard_error_path: "/var/log/determinate-nix-daemon.log".into(),
         standard_out_path: "/var/log/determinate-nix-daemon.log".into(),
         soft_resource_limits: ResourceLimits {
-            number_of_files: 512 * 1024 * 1024,
+            number_of_files: 1024 * 1024,
             number_of_processes: 1024 * 1024,
             stack: 64 * 1024 * 1024,
         },
         hard_resource_limits: ResourceLimits {
-            number_of_files: 512 * 1024 * 1024,
+            number_of_files: 1024 * 1024,
             number_of_processes: 1024 * 1024,
             stack: 64 * 1024 * 1024,
         },

--- a/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.service
+++ b/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.service
@@ -9,7 +9,7 @@ ConditionPathIsReadWrite=/nix/var/nix/daemon-socket
 [Service]
 ExecStart=@/usr/local/bin/determinate-nixd determinate-nixd
 KillMode=process
-LimitNOFILE=536870912
+LimitNOFILE=1048576
 LimitSTACK=64M
 TasksMax=1048576
 


### PR DESCRIPTION
…ct of too many FDs

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
