### PR TITLE
Prune CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,12 +389,3 @@ To cut a release:
 * Once you are certain the release is good, `cargo publish` it
   + **Warning:** While you can re-release Github releases, it is not possible to do the same on `crates.io`
 * Create a PR bumping the version up one minor in the `Cargo.toml` and fixture JSON files, adding `-unreleased` at the end (`v0.0.2-unreleased`)
-
-# Who maintains `nix-installer` and why?
-
-`nix-installer` is maintained by [Determinate Systems](https://determinate.systems/) in
-an effort to explore Nix installer ideas.
-
-Determinate Systems has no plans to monetize or relicense `nix-installer`. If your
-enterprise requires a support contact in order to adopt a tool, please contact
-Determinate Systems and something can be worked out.


### PR DESCRIPTION
Drop the note about who maintains it and why:


> an effort to explore Nix installer ideas

Outdated. We have the best installer, and it isn't an exploration anymore.

> Determinate Systems has no plans to monetize

We don't.

> or relicense `nix-installer`.

We can't, since we don't have a CLA.

> If your enterprise requires a support contact in order to adopt a tool, please contact Determinate Systems and something can be worked out.

We don't/won't do this. Companies and enterprises can become customers of Determinate Systems for FlakeHub and get all our goodies. We're not selling ad-hoc consulting services like this would suggest.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
