### PR TITLE
Wait longer for /nix to exist on macOS

### DIFF
--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -237,29 +237,9 @@ impl Action for CreateDeterminateNixVolume {
             )));
         }
 
-        let mut retry_tokens: usize = 50;
-        loop {
-            let mut command = Command::new("/usr/sbin/diskutil");
-            command.args(["info", "/nix"]);
-            command.stderr(std::process::Stdio::null());
-            command.stdout(std::process::Stdio::null());
-            tracing::trace!(%retry_tokens, command = ?command.as_std(), "Checking for Nix Store mount path existence");
-            let output = command
-                .output()
-                .await
-                .map_err(|e| ActionErrorKind::command(&command, e))
-                .map_err(Self::error)?;
-            if output.status.success() {
-                break;
-            } else if retry_tokens == 0 {
-                return Err(Self::error(ActionErrorKind::command_output(
-                    &command, output,
-                )));
-            } else {
-                retry_tokens = retry_tokens.saturating_sub(1);
-            }
-            tokio::time::sleep(Duration::from_millis(100)).await;
-        }
+        crate::action::macos::wait_for_nix_store_dir()
+            .await
+            .map_err(Self::error)?;
 
         self.setup_volume_daemon
             .try_execute()

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -108,9 +108,10 @@ pub(crate) async fn service_is_disabled(
     Ok(is_disabled)
 }
 
+/// Waits for the Nix Store mountpoint to exist, up to `retry_tokens * 100ms` amount of time.
 #[tracing::instrument]
 pub(crate) async fn wait_for_nix_store_dir() -> Result<(), ActionErrorKind> {
-    let mut retry_tokens: usize = 50;
+    let mut retry_tokens: usize = 150;
     loop {
         let mut command = Command::new("/usr/sbin/diskutil");
         command.args(["info", "/nix"]);


### PR DESCRIPTION
##### Description

Hopefully fixes #1140.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
