### PR TITLE
FH-360 Retry `launchctl bootstrap` and `launchctl bootout` a few times if it fails

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -275,7 +275,7 @@ impl Action for ConfigureInitService {
                         })?;
                 }
 
-                crate::action::macos::retry_bootstrap(&domain, &service_dest)
+                crate::action::macos::retry_bootstrap(&domain, &service, &service_dest)
                     .await
                     .map_err(Self::error)?;
 
@@ -533,6 +533,9 @@ impl Action for ConfigureInitService {
             InitSystem::Launchd => {
                 crate::action::macos::retry_bootout(
                     DARWIN_LAUNCHD_DOMAIN,
+                    self.service_name
+                        .as_ref()
+                        .expect("service_name should be set for launchd"),
                     self.service_dest
                         .as_ref()
                         .expect("service_dest should be defined for launchd"),

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -276,16 +276,9 @@ impl Action for ConfigureInitService {
                         })?;
                 }
 
-                execute_command(
-                    Command::new("launchctl")
-                        .process_group(0)
-                        .arg("bootstrap")
-                        .arg(domain)
-                        .arg(service_dest)
-                        .stdin(std::process::Stdio::null()),
-                )
-                .await
-                .map_err(Self::error)?;
+                crate::action::macos::retry_bootstrap(&domain, &service_dest)
+                    .await
+                    .map_err(Self::error)?;
 
                 let is_disabled = crate::action::macos::service_is_disabled(domain, service)
                     .await

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -128,16 +128,9 @@ impl Action for BootstrapLaunchctlService {
         }
 
         if !*is_present {
-            execute_command(
-                Command::new("launchctl")
-                    .process_group(0)
-                    .arg("bootstrap")
-                    .arg(domain)
-                    .arg(path)
-                    .stdin(std::process::Stdio::null()),
-            )
-            .await
-            .map_err(Self::error)?;
+            crate::action::macos::retry_bootstrap(&domain, &path)
+                .await
+                .map_err(Self::error)?;
         }
 
         Ok(())

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -118,7 +118,7 @@ impl Action for BootstrapLaunchctlService {
         }
 
         if !*is_present {
-            crate::action::macos::retry_bootstrap(DARWIN_LAUNCHD_DOMAIN, &path)
+            crate::action::macos::retry_bootstrap(DARWIN_LAUNCHD_DOMAIN, &service, &path)
                 .await
                 .map_err(Self::error)?;
         }
@@ -139,7 +139,7 @@ impl Action for BootstrapLaunchctlService {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &self.path)
+        crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &self.service, &self.path)
             .await
             .map_err(Self::error)?;
 

--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -6,7 +6,7 @@ use std::{
 use tokio::process::Command;
 use tracing::{span, Span};
 
-use super::create_fstab_entry::CreateFstabEntry;
+use super::{create_fstab_entry::CreateFstabEntry, DARWIN_LAUNCHD_DOMAIN};
 use crate::action::macos::{
     BootstrapLaunchctlService, CreateDeterminateVolumeService, KickstartLaunchctlService,
 };
@@ -91,15 +91,12 @@ impl CreateDeterminateNixVolume {
         .await
         .map_err(Self::error)?;
 
-        let bootstrap_volume = BootstrapLaunchctlService::plan(
-            "system",
-            VOLUME_MOUNT_SERVICE_NAME,
-            VOLUME_MOUNT_SERVICE_DEST,
-        )
-        .await
-        .map_err(Self::error)?;
+        let bootstrap_volume =
+            BootstrapLaunchctlService::plan(VOLUME_MOUNT_SERVICE_NAME, VOLUME_MOUNT_SERVICE_DEST)
+                .await
+                .map_err(Self::error)?;
         let kickstart_launchctl_service =
-            KickstartLaunchctlService::plan("system", VOLUME_MOUNT_SERVICE_NAME)
+            KickstartLaunchctlService::plan(DARWIN_LAUNCHD_DOMAIN, VOLUME_MOUNT_SERVICE_NAME)
                 .await
                 .map_err(Self::error)?;
 

--- a/src/action/macos/create_determinate_volume_service.rs
+++ b/src/action/macos/create_determinate_volume_service.rs
@@ -134,7 +134,7 @@ impl Action for CreateDeterminateVolumeService {
         } = self;
 
         if *needs_bootout {
-            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &path)
+            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &mount_service_label, &path)
                 .await
                 .map_err(Self::error)?;
         }

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -127,7 +127,7 @@ impl Action for CreateNixHookService {
         } = self;
 
         if *needs_bootout {
-            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &path)
+            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &service_label, &path)
                 .await
                 .map_err(Self::error)?;
         }

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -13,7 +13,10 @@ use std::{
 use tokio::process::Command;
 use tracing::{span, Span};
 
-use super::{create_fstab_entry::CreateFstabEntry, CreateVolumeService, KickstartLaunchctlService};
+use super::{
+    create_fstab_entry::CreateFstabEntry, CreateVolumeService, KickstartLaunchctlService,
+    DARWIN_LAUNCHD_DOMAIN,
+};
 
 pub const NIX_VOLUME_MOUNTD_DEST: &str = "/Library/LaunchDaemons/org.nixos.darwin-store.plist";
 
@@ -87,15 +90,12 @@ impl CreateNixVolume {
         .await
         .map_err(Self::error)?;
 
-        let bootstrap_volume = BootstrapLaunchctlService::plan(
-            "system",
-            "org.nixos.darwin-store",
-            NIX_VOLUME_MOUNTD_DEST,
-        )
-        .await
-        .map_err(Self::error)?;
+        let bootstrap_volume =
+            BootstrapLaunchctlService::plan("org.nixos.darwin-store", NIX_VOLUME_MOUNTD_DEST)
+                .await
+                .map_err(Self::error)?;
         let kickstart_launchctl_service =
-            KickstartLaunchctlService::plan("system", "org.nixos.darwin-store")
+            KickstartLaunchctlService::plan(DARWIN_LAUNCHD_DOMAIN, "org.nixos.darwin-store")
                 .await
                 .map_err(Self::error)?;
         let enable_ownership = EnableOwnership::plan("/nix").await.map_err(Self::error)?;

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -186,7 +186,7 @@ impl Action for CreateVolumeService {
         } = self;
 
         if *needs_bootout {
-            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &path)
+            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &mount_service_label, &path)
                 .await
                 .map_err(Self::error)?;
         }

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -98,6 +98,7 @@ pub(crate) async fn service_is_disabled(
 ) -> Result<bool, ActionErrorKind> {
     let output = execute_command(
         Command::new("launchctl")
+            .process_group(0)
             .arg("print-disabled")
             .arg(domain)
             .stdin(std::process::Stdio::null())
@@ -117,6 +118,7 @@ pub(crate) async fn wait_for_nix_store_dir() -> Result<(), ActionErrorKind> {
     let mut retry_tokens: usize = 150;
     loop {
         let mut command = Command::new("/usr/sbin/diskutil");
+        command.process_group(0);
         command.args(["info", "/nix"]);
         command.stderr(std::process::Stdio::null());
         command.stdout(std::process::Stdio::null());


### PR DESCRIPTION
##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/1107.
Closes https://github.com/DeterminateSystems/nix-installer/issues/824.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1047.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1056.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1067.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1148.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1157.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1099.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
