### PR TITLE
Create /nix/var/determinate in startup

### DIFF
--- a/src/action/common/provision_determinate_nixd.rs
+++ b/src/action/common/provision_determinate_nixd.rs
@@ -9,6 +9,7 @@ use crate::action::{
 };
 
 const DETERMINATE_NIXD_BINARY_PATH: &str = "/usr/local/bin/determinate-nixd";
+const DETERMINATE_NIXD_SOCKET_DIRECTORY: &str = "/nix/var/determinate";
 /**
 Provision the determinate-nixd binary
 */
@@ -16,6 +17,7 @@ Provision the determinate-nixd binary
 #[serde(tag = "action_name", rename = "provision_determinate_nixd")]
 pub struct ProvisionDeterminateNixd {
     binary_location: PathBuf,
+    socket_directory: PathBuf,
 }
 
 impl ProvisionDeterminateNixd {
@@ -26,6 +28,7 @@ impl ProvisionDeterminateNixd {
 
         let this = Self {
             binary_location: DETERMINATE_NIXD_BINARY_PATH.into(),
+            socket_directory: DETERMINATE_NIXD_SOCKET_DIRECTORY.into(),
         };
 
         Ok(StatefulAction::uncompleted(this))
@@ -75,6 +78,11 @@ impl Action for ProvisionDeterminateNixd {
                 .map_err(|e| ActionErrorKind::CreateDirectory(parent.into(), e))
                 .map_err(Self::error)?;
         }
+
+        create_dir_all(&self.socket_directory)
+            .await
+            .map_err(|e| ActionErrorKind::CreateDirectory(self.socket_directory.clone(), e))
+            .map_err(Self::error)?;
 
         tokio::fs::write(&self.binary_location, bytes)
             .await


### PR DESCRIPTION
Our systemd unit for determinate-nixd.socket has a condition that /nix/var/determinate is read/writable. However, it doesn't exist out of the box until nix-daemon starts.

If you let the daemon start without this socket unit being started, determinate-nixd will create that directory and then put the socket there.

However, if you try to socket activate over determinate-nixd (like loging in to a pipeline) it will fail.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
