### PR TITLE
nixd.determinate-nixd.socket: Let systemd create the socket's parent directories

### DIFF
--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -195,6 +195,12 @@ let
     install-determinate = {
       install = nix-installer-install-determinate;
       check = ''
+        if ! systemctl is-active determinate-nixd.socket; then
+          echo "determinate-nixd.socket is not active"
+          sudo journalctl -eu determinate-nixd.socket
+          exit 1
+        fi
+
         if ! determinate-nixd status; then
           echo "determinate-nixd is not working"
           sudo journalctl -eu determinate-nixd.service

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -195,9 +195,9 @@ let
     install-determinate = {
       install = nix-installer-install-determinate;
       check = installCases.install-default.check + ''
-        if systemctl is-failed determinate-nixd.socket; then
-          echo "determinate-nixd.socket is failed"
-          sudo journalctl -eu determinate-nixd.socket
+        if ! determinate-nixd status; then
+          echo "determinate-nixd is not working"
+          sudo journalctl -eu determinate-nixd.service
           exit 1
         fi
       '';

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -194,13 +194,13 @@ let
     };
     install-determinate = {
       install = nix-installer-install-determinate;
-      check = installCases.install-default.check + ''
+      check = ''
         if ! determinate-nixd status; then
           echo "determinate-nixd is not working"
           sudo journalctl -eu determinate-nixd.service
           exit 1
         fi
-      '';
+      '' + installCases.install-default.check;
       uninstall = installCases.install-default.uninstall;
       uninstallCheck = installCases.install-default.uninstallCheck;
     };

--- a/src/action/common/configure_determinate_nixd_init_service/nixd.determinate-nixd.socket
+++ b/src/action/common/configure_determinate_nixd_init_service/nixd.determinate-nixd.socket
@@ -3,10 +3,10 @@ Description=Determinate Nixd Daemon Socket
 Before=multi-user.target
 RequiresMountsFor=/nix/store
 RequiresMountsFor=/nix/var/determinate
-ConditionPathIsReadWrite=/nix/var/determinate
 
 [Socket]
 FileDescriptorName=determinate-nixd.socket
+DirectoryMode=0755
 ListenStream=/nix/var/determinate/determinate-nixd.socket
 Service=nix-daemon.service
 


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
