### PR TITLE
Explicitly pass 'daemon' to determinate-nixd

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,12 +17,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1725049969,
-        "narHash": "sha256-hU7e8tuhxi3jQxJXsqaG+zhhNodV3oVzp9FxzOnuEbY=",
-        "rev": "54bcee31752428b7a69200be76e7c357723ae2de",
-        "revCount": 89,
+        "lastModified": 1726165658,
+        "narHash": "sha256-FSKbT3I6ldMowJ4cazPzOa3fIez8a85zpDPWE8WCnN8=",
+        "rev": "9f210e6a8d0d0465dd70d14d0d80bcfefea0cddc",
+        "revCount": 93,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.89%2Brev-54bcee31752428b7a69200be76e7c357723ae2de/0191a4ff-ffd4-7774-abcf-bf93c97c71c8/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.93%2Brev-9f210e6a8d0d0465dd70d14d0d80bcfefea0cddc/0191e780-480e-74fd-b6d5-a737ac399aff/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -32,37 +32,37 @@
     "determinate-nixd-aarch64-darwin": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-PE5iOUHttLNVnoW/HU2CJbIxDhwvpqM7ZehNxo8G45Q=",
+        "narHash": "sha256-1SsjyQHWUzKV44hZhNOAZVZqlh2mm2ngWIU9nr951XQ=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/fb88a079cf330e8dfe20f4426a36ee663d7bb47e/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/rev/22f4c6a94ca253849571df4f16cc1aef3f489816/macOS"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/fb88a079cf330e8dfe20f4426a36ee663d7bb47e/macOS"
+        "url": "https://install.determinate.systems/determinate-nixd/rev/22f4c6a94ca253849571df4f16cc1aef3f489816/macOS"
       }
     },
     "determinate-nixd-aarch64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-u1RycvQDu9VevkjHlfiNvbk566em52hDvq+KoLiY7Kg=",
+        "narHash": "sha256-wmKwEgmsbcPWWCpGBksYjdsrx3YKrf6uIBl4ZUXmkJI=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/fb88a079cf330e8dfe20f4426a36ee663d7bb47e/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/rev/22f4c6a94ca253849571df4f16cc1aef3f489816/aarch64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/fb88a079cf330e8dfe20f4426a36ee663d7bb47e/aarch64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/rev/22f4c6a94ca253849571df4f16cc1aef3f489816/aarch64-linux"
       }
     },
     "determinate-nixd-x86_64-linux": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-x4au1LaMr/SqiFcbt1GEq1QAlIf9AB9K0T/AH3AvrjY=",
+        "narHash": "sha256-xaB/sQk2eJRZriHVd/TRiLncqmhoEItapTqvFuJqxIw=",
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/fb88a079cf330e8dfe20f4426a36ee663d7bb47e/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/rev/22f4c6a94ca253849571df4f16cc1aef3f489816/x86_64-linux"
       },
       "original": {
         "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/fb88a079cf330e8dfe20f4426a36ee663d7bb47e/x86_64-linux"
+        "url": "https://install.determinate.systems/determinate-nixd/rev/22f4c6a94ca253849571df4f16cc1aef3f489816/x86_64-linux"
       }
     },
     "fenix": {

--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -188,7 +188,7 @@ pub enum ConfigureDeterminateNixDaemonServiceError {}
 #[serde(rename_all = "PascalCase")]
 pub struct DeterminateNixDaemonPlist {
     label: String,
-    program: String,
+    program_arguments: Vec<String>,
     run_at_load: bool,
     sockets: HashMap<String, Socket>,
     standard_error_path: String,
@@ -223,7 +223,10 @@ fn generate_plist() -> DeterminateNixDaemonPlist {
     DeterminateNixDaemonPlist {
         run_at_load: false,
         label: "systems.determinate.nix-daemon".into(),
-        program: "/usr/local/bin/determinate-nixd".into(),
+        program_arguments: vec![
+            "/usr/local/bin/determinate-nixd".into(),
+            "daemon".into(),
+        ],
         standard_error_path: "/var/log/determinate-nix-daemon.log".into(),
         standard_out_path: "/var/log/determinate-nix-daemon.log".into(),
         soft_resource_limits: ResourceLimits {

--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -223,10 +223,7 @@ fn generate_plist() -> DeterminateNixDaemonPlist {
     DeterminateNixDaemonPlist {
         run_at_load: false,
         label: "systems.determinate.nix-daemon".into(),
-        program_arguments: vec![
-            "/usr/local/bin/determinate-nixd".into(),
-            "daemon".into(),
-        ],
+        program_arguments: vec!["/usr/local/bin/determinate-nixd".into(), "daemon".into()],
         standard_error_path: "/var/log/determinate-nix-daemon.log".into(),
         standard_out_path: "/var/log/determinate-nix-daemon.log".into(),
         soft_resource_limits: ResourceLimits {

--- a/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.service
+++ b/src/action/common/configure_determinate_nixd_init_service/nix-daemon.determinate-nixd.service
@@ -7,7 +7,7 @@ RequiresMountsFor=/nix/var/nix/db
 ConditionPathIsReadWrite=/nix/var/nix/daemon-socket
 
 [Service]
-ExecStart=@/usr/local/bin/determinate-nixd determinate-nixd
+ExecStart=@/usr/local/bin/determinate-nixd determinate-nixd daemon
 KillMode=process
 LimitNOFILE=1048576
 LimitSTACK=64M

--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -222,7 +222,7 @@ impl Action for CreateDeterminateNixVolume {
             .map_err(Self::error)?;
 
         let mut command = Command::new("/usr/local/bin/determinate-nixd");
-        command.args(["--stop-after", "mount"]);
+        command.args(["--stop-after", "mount", "daemon"]);
         command.stderr(std::process::Stdio::piped());
         command.stdout(std::process::Stdio::piped());
         tracing::trace!(command = ?command.as_std(), "Mounting /nix");

--- a/src/action/macos/create_determinate_volume_service.rs
+++ b/src/action/macos/create_determinate_volume_service.rs
@@ -201,6 +201,7 @@ async fn generate_mount_plist(
             "/usr/local/bin/determinate-nixd".into(),
             "--stop-after".into(),
             "mount".into(),
+            "daemon".into(),
         ],
         standard_out_path: "/var/log/determinate-nixd-mount.log".into(),
         standard_error_path: "/var/log/determinate-nixd-mount.log".into(),


### PR DESCRIPTION
##### Description

This was previously implied.

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
