### PR TITLE
CreateDirectory: use /sbin/mount on macOS

### DIFF
--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -326,12 +326,13 @@ async fn path_is_mountpoint(path: &Path) -> Result<bool, ActionErrorKind> {
             Some(destination_and_options) => destination_and_options,
             None => continue,
         };
-        // Each line on Linux looks like `portal on /run/user/1000/doc type fuse.portal (rw,nosuid,nodev,relatime,user_id=1000,group_id=100)`
-        #[cfg(target_os = "linux")]
-        let split_token = "type";
-        // Each line on MacOS looks like `/dev/disk3s6 on /System/Volumes/VM (apfs, local, noexec, journaled, noatime, nobrowse)`
-        #[cfg(target_os = "macos")]
-        let split_token = "(";
+
+        let split_token = match OperatingSystem::host() {
+            // Each line on MacOS looks like `/dev/disk3s6 on /System/Volumes/VM (apfs, local, noexec, journaled, noatime, nobrowse)`
+            OperatingSystem::MacOSX { .. } | OperatingSystem::Darwin => "(",
+            // Each line on Linux looks like `portal on /run/user/1000/doc type fuse.portal (rw,nosuid,nodev,relatime,user_id=1000,group_id=100)`
+            _ => "type",
+        };
 
         if let Some(mount_path) = destination_and_options.rsplit(split_token).last() {
             let trimmed = mount_path.trim();


### PR DESCRIPTION
Some users report `mount` not being found in PATH when using
Terminal.app (even though I can't reproduce this).

##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/1021.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1160.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
