### PR TITLE
Fixup release test matrix re: dnixd

### DIFF
--- a/.github/workflows/build-aarch64-darwin.yml
+++ b/.github/workflows/build-aarch64-darwin.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
       - uses: DeterminateSystems/magic-nix-cache-action@main
         with:
           use-gha-cache: false

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
       - uses: DeterminateSystems/magic-nix-cache-action@main
         with:
           use-gha-cache: false

--- a/.github/workflows/build-x86_64-darwin.yml
+++ b/.github/workflows/build-x86_64-darwin.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
       - uses: DeterminateSystems/magic-nix-cache-action@main
         with:
           use-gha-cache: false

--- a/.github/workflows/build-x86_64-linux.yml
+++ b/.github/workflows/build-x86_64-linux.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
       - uses: DeterminateSystems/magic-nix-cache-action@main
         with:
           use-gha-cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,8 +330,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          extra-conf: |
-            trusted-users = root runner
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -356,7 +354,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          extra-conf: trusted-users = root runner
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -541,8 +538,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          extra-conf: |
-            trusted-users = root runner
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -567,7 +562,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          extra-conf: trusted-users = root runner
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     needs: [lints, build-x86_64-linux]
     strategy:
       matrix:
-        extra-args: ["--determinate", ""]
+        determinate: [true, false]
     permissions:
       id-token: "write"
       contents: "read"
@@ -83,21 +83,20 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
-          extra-args: ${{ matrix.extra-args }}
+          determinate: ${{ matrix.determinate }}
           local-root: install-root/
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+      - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ matrix.extra-args == '--determinate' }}
+            ${{ matrix.determinate }}
           else
             echo "determinate-nixd is not present"
-            ${{ matrix.extra-args != '--determinate' }}
+            ${{ !matrix.determinate }}
           fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
@@ -123,8 +122,7 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
-          extra-args: ${{ matrix.extra-args }}
+          determinate: ${{ matrix.determinate }}
           local-root: install-root/
           logger: pretty
           log-directives: nix_installer=debug
@@ -184,7 +182,7 @@ jobs:
     needs: [lints, build-x86_64-linux]
     strategy:
       matrix:
-        extra-args: ["--determinate", ""]
+        determinate: [true, false]
     permissions:
       id-token: "write"
       contents: "read"
@@ -205,23 +203,22 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: ${{ matrix.determinate }}
           init: none
-          extra-args: ${{ matrix.extra-args }}
           planner: linux
           local-root: install-root/
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+      - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ matrix.extra-args == '--determinate' }}
+            ${{ matrix.determinate }}
           else
             echo "determinate-nixd is not present"
-            ${{ matrix.extra-args != '--determinate' }}
+            ${{ !matrix.determinate }}
           fi
       - name: Ensure daemon was not configured with init
         run: |
@@ -249,10 +246,9 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: ${{ matrix.determinate }}
           init: none
           planner: linux
-          extra-args: ${{ matrix.extra-args }}
           local-root: install-root/
           logger: pretty
           log-directives: nix_installer=debug
@@ -312,7 +308,7 @@ jobs:
     needs: [lints, build-x86_64-darwin]
     strategy:
       matrix:
-        extra-args: ["--determinate", ""]
+        determinate: [true, false]
     permissions:
       id-token: "write"
       contents: "read"
@@ -333,8 +329,7 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
-          extra-args: ${{ matrix.extra-args }}
+          determinate: ${{ matrix.determinate }}
           local-root: install-root/
           logger: pretty
           log-directives: nix_installer=debug
@@ -342,14 +337,14 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
             trusted-users = root runner
-      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+      - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ matrix.extra-args == '--determinate' }}
+            ${{ matrix.determinate }}
           else
             echo "determinate-nixd is not present"
-            ${{ matrix.extra-args != '--determinate' }}
+            ${{ !matrix.determinate }}
           fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
@@ -361,8 +356,7 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
-          extra-args: ${{ matrix.extra-args }}
+          determinate: ${{ matrix.determinate }}
           local-root: install-root/
           logger: pretty
           log-directives: nix_installer=debug
@@ -409,7 +403,7 @@ jobs:
     needs: [lints, build-aarch64-linux]
     strategy:
       matrix:
-        extra-args: ["--determinate", ""]
+        determinate: [true, false]
     permissions:
       id-token: "write"
       contents: "read"
@@ -430,21 +424,20 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
           local-root: install-root/
-          extra-args: ${{ matrix.extra-args }}
+          determinate: ${{ matrix.determinate }}
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+      - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ matrix.extra-args == '--determinate' }}
+            ${{ matrix.determinate }}
           else
             echo "determinate-nixd is not present"
-            ${{ matrix.extra-args != '--determinate' }}
+            ${{ !matrix.determinate }}
           fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
@@ -470,10 +463,9 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
           local-root: install-root/
           logger: pretty
-          extra-args: ${{ matrix.extra-args }}
+          determinate: ${{ matrix.determinate }}
           log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -531,7 +523,7 @@ jobs:
     needs: [lints, build-aarch64-darwin]
     strategy:
       matrix:
-        extra-args: ["--determinate", ""]
+        determinate: [true, false]
     permissions:
       id-token: "write"
       contents: "read"
@@ -552,23 +544,22 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
           local-root: install-root/
-          extra-args: ${{ matrix.extra-args }}
+          determinate: ${{ matrix.determinate }}
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
             trusted-users = root runner
-      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+      - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ matrix.extra-args == '--determinate' }}
+            ${{ matrix.determinate }}
           else
             echo "determinate-nixd is not present"
-            ${{ matrix.extra-args != '--determinate' }}
+            ${{ !matrix.determinate }}
           fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
@@ -580,9 +571,8 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
           local-root: install-root/
-          extra-args: ${{ matrix.extra-args }}
+          determinate: ${{ matrix.determinate }}
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
@@ -648,7 +638,7 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
           local-root: install-root/
           logger: pretty
           log-directives: nix_installer=debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,10 @@ jobs:
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args == '--determinate' }}
           else
             echo "determinate-nixd is not present"
-            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args != '--determinate' }}
           fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
@@ -218,10 +218,10 @@ jobs:
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args == '--determinate' }}
           else
             echo "determinate-nixd is not present"
-            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args != '--determinate' }}
           fi
       - name: Ensure daemon was not configured with init
         run: |
@@ -346,10 +346,10 @@ jobs:
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args == '--determinate' }}
           else
             echo "determinate-nixd is not present"
-            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args != '--determinate' }}
           fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
@@ -441,10 +441,10 @@ jobs:
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args == '--determinate' }}
           else
             echo "determinate-nixd is not present"
-            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args != '--determinate' }}
           fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
@@ -565,10 +565,10 @@ jobs:
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
             echo "determinate-nixd is present"
-            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args == '--determinate' }}
           else
             echo "determinate-nixd is not present"
-            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+            ${{ matrix.extra-args != '--determinate' }}
           fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: nix develop --command shellcheck ./nix-installer.sh
 
   run-x86_64-linux:
-    name: Run x86_64 Linux
+    name: Run x86_64 Linux${{ matrix.determinate && ' (--determinate)' || ''}}
     runs-on: UbuntuLatest32Cores128G
     needs: [lints, build-x86_64-linux]
     strategy:
@@ -175,7 +175,7 @@ jobs:
           fi
 
   run-x86_64-linux-no-init:
-    name: Run x86_64 Linux (No init)
+    name: Run x86_64 Linux (No init${{ matrix.determinate && ', --determinate' || ''}})
     runs-on: UbuntuLatest32Cores128G
     needs: [lints, build-x86_64-linux]
     strategy:
@@ -299,7 +299,7 @@ jobs:
           fi
 
   run-x86_64-darwin:
-    name: Run x86_64 Darwin
+    name: Run x86_64 Darwin${{ matrix.determinate && ' (--determinate)' || ''}}
     runs-on: macos-13
     needs: [lints, build-x86_64-darwin]
     strategy:
@@ -389,7 +389,7 @@ jobs:
           RUST_BACKTRACE: full
 
   run-aarch64-linux:
-    name: Run aarch64 Linux
+    name: Run aarch64 Linux${{ matrix.determinate && ' (--determinate)' || ''}}
     runs-on: namespace-profile-default-arm64
     needs: [lints, build-aarch64-linux]
     strategy:
@@ -507,7 +507,7 @@ jobs:
           fi
 
   run-aarch64-darwin:
-    name: Run aarch64 Darwin
+    name: Run aarch64 Darwin${{ matrix.determinate && ' (--determinate)' || ''}}
     runs-on: macos-latest-xlarge
     needs: [lints, build-aarch64-darwin]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,15 @@ jobs:
           log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+        run: |
+          if test -x /usr/local/bin/determinate-nixd; then
+            echo "determinate-nixd is present"
+            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+          else
+            echo "determinate-nixd is not present"
+            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+          fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
         env:
@@ -205,6 +214,15 @@ jobs:
           log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+        run: |
+          if test -x /usr/local/bin/determinate-nixd; then
+            echo "determinate-nixd is present"
+            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+          else
+            echo "determinate-nixd is not present"
+            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+          fi
       - name: Ensure daemon was not configured with init
         run: |
           if systemctl is-active nix-daemon.socket; then
@@ -324,6 +342,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
             trusted-users = root runner
+      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+        run: |
+          if test -x /usr/local/bin/determinate-nixd; then
+            echo "determinate-nixd is present"
+            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+          else
+            echo "determinate-nixd is not present"
+            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+          fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
         env:
@@ -410,6 +437,15 @@ jobs:
           log-directives: nix_installer=debug
           backtrace: full
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+        run: |
+          if test -x /usr/local/bin/determinate-nixd; then
+            echo "determinate-nixd is present"
+            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+          else
+            echo "determinate-nixd is not present"
+            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+          fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
         env:
@@ -525,6 +561,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
             trusted-users = root runner
+      - name: "Validate dnixd is ${{ (matrix.extra-args == '--determinate') && 'installed' || 'uninstalled' }}"
+        run: |
+          if test -x /usr/local/bin/determinate-nixd; then
+            echo "determinate-nixd is present"
+            ${{ (matrix.extra-args != '--determinate') && 'exit 1' }}
+          else
+            echo "determinate-nixd is not present"
+            ${{ (matrix.extra-args == '--determinate') && 'exit 1' }}
+          fi
       - name: Initial uninstall (without a `nix run` first)
         run: sudo -E /nix/nix-installer uninstall
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -127,7 +126,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -210,7 +208,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -253,7 +250,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -334,7 +330,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
             trusted-users = root runner
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
@@ -361,7 +356,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: trusted-users = root runner
       - name: echo $PATH
         run: echo $PATH
@@ -429,7 +423,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -468,7 +461,6 @@ jobs:
           determinate: ${{ matrix.determinate }}
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -549,7 +541,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: |
             trusted-users = root runner
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
@@ -576,7 +567,6 @@ jobs:
           logger: pretty
           log-directives: nix_installer=debug
           backtrace: full
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           extra-conf: trusted-users = root runner
       - name: echo $PATH
         run: echo $PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
       - uses: DeterminateSystems/magic-nix-cache-action@main
         with:
           use-gha-cache: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,11 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
+          backtrace: full
           determinate: ${{ matrix.determinate }}
           local-root: install-root/
-          logger: pretty
           log-directives: nix_installer=debug
-          backtrace: full
+          logger: pretty
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -121,11 +121,11 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
+          backtrace: full
           determinate: ${{ matrix.determinate }}
           local-root: install-root/
-          logger: pretty
           log-directives: nix_installer=debug
-          backtrace: full
+          logger: pretty
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -201,13 +201,13 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
+          backtrace: full
           determinate: ${{ matrix.determinate }}
           init: none
-          planner: linux
           local-root: install-root/
-          logger: pretty
           log-directives: nix_installer=debug
-          backtrace: full
+          logger: pretty
+          planner: linux
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -243,13 +243,13 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
+          backtrace: full
           determinate: ${{ matrix.determinate }}
           init: none
-          planner: linux
           local-root: install-root/
-          logger: pretty
           log-directives: nix_installer=debug
-          backtrace: full
+          logger: pretty
+          planner: linux
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -325,11 +325,11 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
+          backtrace: full
           determinate: ${{ matrix.determinate }}
           local-root: install-root/
-          logger: pretty
           log-directives: nix_installer=debug
-          backtrace: full
+          logger: pretty
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -349,11 +349,11 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
+          backtrace: full
           determinate: ${{ matrix.determinate }}
           local-root: install-root/
-          logger: pretty
           log-directives: nix_installer=debug
-          backtrace: full
+          logger: pretty
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -415,11 +415,11 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          local-root: install-root/
-          determinate: ${{ matrix.determinate }}
-          logger: pretty
-          log-directives: nix_installer=debug
           backtrace: full
+          determinate: ${{ matrix.determinate }}
+          local-root: install-root/
+          log-directives: nix_installer=debug
+          logger: pretty
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -453,11 +453,11 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          local-root: install-root/
-          logger: pretty
-          determinate: ${{ matrix.determinate }}
-          log-directives: nix_installer=debug
           backtrace: full
+          determinate: ${{ matrix.determinate }}
+          local-root: install-root/
+          log-directives: nix_installer=debug
+          logger: pretty
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -533,11 +533,11 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          local-root: install-root/
-          determinate: ${{ matrix.determinate }}
-          logger: pretty
-          log-directives: nix_installer=debug
           backtrace: full
+          determinate: ${{ matrix.determinate }}
+          local-root: install-root/
+          log-directives: nix_installer=debug
+          logger: pretty
       - name: "Validate dnixd is ${{ matrix.determinate && 'installed' || 'uninstalled' }}"
         run: |
           if test -x /usr/local/bin/determinate-nixd; then
@@ -557,11 +557,11 @@ jobs:
       - name: Repeated install
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          local-root: install-root/
-          determinate: ${{ matrix.determinate }}
-          logger: pretty
-          log-directives: nix_installer=debug
           backtrace: full
+          determinate: ${{ matrix.determinate }}
+          local-root: install-root/
+          log-directives: nix_installer=debug
+          logger: pretty
       - name: echo $PATH
         run: echo $PATH
       - name: Test `nix` with `$GITHUB_PATH`
@@ -622,11 +622,11 @@ jobs:
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:
+          backtrace: full
           determinate: true
           local-root: install-root/
-          logger: pretty
           log-directives: nix_installer=debug
-          backtrace: full
+          logger: pretty
       - uses: DeterminateSystems/magic-nix-cache-action@main
         with:
           use-gha-cache: false

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         with:
-          flakehub: true
+          determinate: true
       - name: Enable Magic Nix Cache
         uses: DeterminateSystems/magic-nix-cache-action@main
         with:


### PR DESCRIPTION
##### Description

We were passing `flakehub: true`, now we're only passing `determinate: true` in the `determinate` matrix case.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
