### PR TITLE
Update README: remove `$` from the installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix 
 Or, to download a platform specific Installer binary yourself:
 
 ```bash
-$ curl -sL -o nix-installer https://install.determinate.systems/nix/nix-installer-x86_64-linux
-$ chmod +x nix-installer
-$ ./nix-installer
+curl -sL -o nix-installer https://install.determinate.systems/nix/nix-installer-x86_64-linux
+chmod +x nix-installer
+./nix-installer
 ```
 
 `nix-installer` installs Nix by following a _plan_ made by a _planner_. Review the available planners:


### PR DESCRIPTION
Remove `$`s from shell snippet because they break copy/paste into a terminal
