### PR TITLE
macos: always pass `-a "${VOLUME}"` and `-s "Nix Store"`

### DIFF
--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -258,7 +258,7 @@ async fn generate_mount_plist(
     // The official Nix scripts uppercase the UUID, so we do as well for compatibility.
     let uuid_string = uuid.to_string().to_uppercase();
     let mount_command = if encrypt {
-        let encrypted_command = format!("/usr/bin/security find-generic-password -s {apfs_volume_label_with_quotes} -w |  /usr/sbin/diskutil apfs unlockVolume {apfs_volume_label_with_quotes} -mountpoint {mount_point:?} -stdinpassphrase");
+        let encrypted_command = format!("/usr/bin/security find-generic-password -a {apfs_volume_label_with_quotes} -s \"Nix Store\" -w |  /usr/sbin/diskutil apfs unlockVolume {apfs_volume_label_with_quotes} -mountpoint {mount_point:?} -stdinpassphrase");
         vec!["/bin/sh".into(), "-c".into(), encrypted_command]
     } else {
         vec![

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -251,7 +251,7 @@ impl Action for EncryptApfsVolume {
                 "-a",
                 self.name.as_str(),
                 "-s",
-                self.name.as_str(),
+                "Nix Store",
                 "-l",
                 format!("{} encryption password", disk_str).as_str(),
                 "-D",


### PR DESCRIPTION
##### Description

`/usr/bin/security {add,find,delete}-generic-password` accepts both `-a account` and `-s service` parameters as password lookup keys. Always pass `-a "${VOLUME}"` and `-s "Nix Store"`. With this change, installation succeeds even with `--encrypt` set to `true` and `--volume-label` set to any value deviating from `Nix Store`.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
