### PR TITLE
Fix bootout errors on macOS once and for all

### DIFF
--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -180,10 +180,6 @@ impl Action for ConfigureDeterminateNixdInitService {
     }
 }
 
-#[non_exhaustive]
-#[derive(Debug, thiserror::Error)]
-pub enum ConfigureDeterminateNixDaemonServiceError {}
-
 #[derive(Deserialize, Clone, Debug, Serialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct DeterminateNixDaemonPlist {

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -312,17 +312,6 @@ impl Action for ConfigureInitService {
                     .as_ref()
                     .expect("service_dest should be defined for systemd");
 
-                if *start_daemon {
-                    execute_command(
-                        Command::new("systemctl")
-                            .process_group(0)
-                            .arg("daemon-reload")
-                            .stdin(std::process::Stdio::null()),
-                    )
-                    .await
-                    .map_err(Self::error)?;
-                }
-
                 // The goal state is the `socket` enabled and active, the service not enabled and stopped (it activates via socket activation)
                 let mut any_socket_was_active = false;
                 for SocketFile { name, .. } in socket_files.iter() {

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -116,23 +116,6 @@ impl ConfigureInitService {
                 if which::which("systemctl").is_err() {
                     return Err(Self::error(ActionErrorKind::SystemdMissing));
                 }
-
-                if let (Some(service_src), Some(service_dest)) =
-                    (service_src.as_ref(), service_dest.as_ref())
-                {
-                    Self::check_if_systemd_unit_exists(
-                        &UnitSrc::Path(service_src.to_path_buf()),
-                        service_dest,
-                    )
-                    .await
-                    .map_err(Self::error)?;
-                }
-
-                for SocketFile { src, dest, .. } in socket_files.iter() {
-                    Self::check_if_systemd_unit_exists(src, dest)
-                        .await
-                        .map_err(Self::error)?;
-                }
             },
             InitSystem::None => {
                 // Nothing here, no init system

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -512,7 +512,6 @@ impl Action for ConfigureInitService {
                     self.service_name
                         .as_ref()
                         .expect("service_name should be set for launchd"),
-                    service_dest,
                 )
                 .await
                 {

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -326,8 +326,8 @@ impl Action for ConfigureInitService {
                     };
                 }
 
-                tracing::trace!(src = TMPFILES_SRC, dest = TMPFILES_DEST, "Symlinking");
                 if !Path::new(TMPFILES_DEST).exists() {
+                    tracing::trace!(src = TMPFILES_SRC, dest = TMPFILES_DEST, "Symlinking");
                     tokio::fs::symlink(TMPFILES_SRC, TMPFILES_DEST)
                         .await
                         .map_err(|e| {

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -139,7 +139,7 @@ impl Action for BootstrapLaunchctlService {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &self.service, &self.path)
+        crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &self.service)
             .await
             .map_err(Self::error)?;
 

--- a/src/action/macos/create_determinate_volume_service.rs
+++ b/src/action/macos/create_determinate_volume_service.rs
@@ -139,7 +139,7 @@ impl Action for CreateDeterminateVolumeService {
         } = self;
 
         if *needs_bootout {
-            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, mount_service_label, path)
+            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, mount_service_label)
                 .await
                 .map_err(Self::error)?;
         }

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -127,7 +127,7 @@ impl Action for CreateNixHookService {
         } = self;
 
         if *needs_bootout {
-            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, service_label, path)
+            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, service_label)
                 .await
                 .map_err(Self::error)?;
         }

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -186,7 +186,7 @@ impl Action for CreateVolumeService {
         } = self;
 
         if *needs_bootout {
-            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, mount_service_label, path)
+            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, mount_service_label)
                 .await
                 .map_err(Self::error)?;
         }

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -199,16 +199,14 @@ pub(crate) async fn retry_bootstrap(
 /// Wait for `launchctl bootout {domain} {service_path}` to succeed up to `retry_tokens * 500ms` amount
 /// of time.
 #[tracing::instrument]
-pub(crate) async fn retry_bootout(
-    domain: &str,
-    service_name: &str,
-    service_path: &Path,
-) -> Result<(), ActionErrorKind> {
+pub(crate) async fn retry_bootout(domain: &str, service_name: &str) -> Result<(), ActionErrorKind> {
+    let service_identifier = [domain, service_name].join("/");
+
     let check_service_running = execute_command(
         Command::new("launchctl")
             .process_group(0)
             .arg("print")
-            .arg([domain, service_name].join("/"))
+            .arg(&service_identifier)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped()),
@@ -226,8 +224,7 @@ pub(crate) async fn retry_bootout(
         let mut command = Command::new("launchctl");
         command.process_group(0);
         command.arg("bootout");
-        command.arg(domain);
-        command.arg(service_path);
+        command.arg(&service_identifier);
         command.stdin(std::process::Stdio::null());
         command.stderr(std::process::Stdio::null());
         command.stdout(std::process::Stdio::null());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -47,7 +47,7 @@ impl CommandExecute for NixInstallerCli {
             NixInstallerSubcommand::Plan(plan) => plan.execute().await,
             NixInstallerSubcommand::SelfTest(self_test) => self_test.execute().await,
             NixInstallerSubcommand::Install(install) => install.execute().await,
-            NixInstallerSubcommand::Repair(restore_shell) => restore_shell.execute().await,
+            NixInstallerSubcommand::Repair(repair) => repair.execute().await,
             NixInstallerSubcommand::Uninstall(revert) => revert.execute().await,
         }
     }

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -25,6 +25,8 @@ use crate::{
     Action, BuiltinPlanner,
 };
 
+pub const FHS_SELINUX_POLICY_PATH: &str = "/usr/share/selinux/packages/nix.pp";
+
 /// A planner for traditional, mutable Linux systems like Debian, RHEL, or Arch
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "cli", derive(clap::Parser))]
@@ -92,7 +94,7 @@ impl Planner for Linux {
         if has_selinux {
             plan.push(
                 ProvisionSelinux::plan(
-                    "/usr/share/selinux/packages/nix.pp".into(),
+                    FHS_SELINUX_POLICY_PATH.into(),
                     if self.settings.determinate_nix {
                         DETERMINATE_SELINUX_POLICY_PP_CONTENT
                     } else {


### PR DESCRIPTION
...I hope.

Also includes some cleanups that makes life better.

##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/1234.
Fixes https://github.com/DeterminateSystems/nix-installer/issues/1230.
Fixes https://github.com/DeterminateSystems/nix-installer/issues/1209.
Fixes https://github.com/DeterminateSystems/nix-installer/issues/1187.
Fixes https://github.com/DeterminateSystems/nix-installer/issues/1172.
Fixes https://github.com/DeterminateSystems/nix-installer/issues/1168.
Fixes https://github.com/DeterminateSystems/nix-installer/issues/1078.
Fixes https://github.com/DeterminateSystems/nix-installer/issues/926.
Fixes https://github.com/DeterminateSystems/nix-installer/issues/892.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
