### PR TITLE
ConfigureInitService: remove dest files on revert (if they exist)

### DIFF
--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -162,20 +162,6 @@ impl Action for ConfigureDeterminateNixdInitService {
     async fn revert(&mut self) -> Result<(), ActionError> {
         self.configure_init_service.try_revert().await?;
 
-        let file_to_remove = match self.init {
-            InitSystem::Launchd => Some(DARWIN_NIXD_DAEMON_DEST),
-            InitSystem::Systemd => Some(LINUX_NIXD_DAEMON_DEST),
-            InitSystem::None => None,
-        };
-
-        if let Some(file_to_remove) = file_to_remove {
-            tracing::trace!(path = %file_to_remove, "Removing");
-            tokio::fs::remove_file(file_to_remove)
-                .await
-                .map_err(|e| ActionErrorKind::Remove(file_to_remove.into(), e))
-                .map_err(Self::error)?;
-        }
-
         Ok(())
     }
 }


### PR DESCRIPTION
##### Description

Builds on top of https://github.com/DeterminateSystems/nix-installer/pull/1257.
Closes https://github.com/DeterminateSystems/nix-installer/issues/989.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
