### PR TITLE
Various logic fixups in preparation for phased uninstall

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -270,7 +270,7 @@ impl Action for ConfigureInitService {
                         Command::new("launchctl")
                             .process_group(0)
                             .arg("enable")
-                            .arg(&format!("{domain}/{service}"))
+                            .arg(format!("{domain}/{service}"))
                             .stdin(std::process::Stdio::null()),
                     )
                     .await
@@ -283,7 +283,7 @@ impl Action for ConfigureInitService {
                             .process_group(0)
                             .arg("kickstart")
                             .arg("-k")
-                            .arg(&format!("{domain}/{service}"))
+                            .arg(format!("{domain}/{service}"))
                             .stdin(std::process::Stdio::null()),
                     )
                     .await

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -33,7 +33,6 @@ impl BootstrapLaunchctlService {
             command.process_group(0);
             command.arg("print");
             command.arg(format!("{DARWIN_LAUNCHD_DOMAIN}/{service}"));
-            command.arg("-plist");
             command.stdin(std::process::Stdio::null());
             command.stdout(std::process::Stdio::piped());
             command.stderr(std::process::Stdio::piped());

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -100,7 +100,7 @@ impl Action for BootstrapLaunchctlService {
                 Command::new("launchctl")
                     .process_group(0)
                     .arg("enable")
-                    .arg(&format!("{DARWIN_LAUNCHD_DOMAIN}/{service}"))
+                    .arg(format!("{DARWIN_LAUNCHD_DOMAIN}/{service}"))
                     .stdin(std::process::Stdio::null()),
             )
             .await

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -48,15 +48,6 @@ impl BootstrapLaunchctlService {
             .await
             .map_err(Self::error)?;
 
-        if is_present && !is_disabled {
-            return Ok(StatefulAction::completed(Self {
-                service,
-                path,
-                is_present,
-                is_disabled,
-            }));
-        }
-
         Ok(StatefulAction::uncompleted(Self {
             service,
             path,
@@ -116,11 +107,15 @@ impl Action for BootstrapLaunchctlService {
             .map_err(Self::error)?;
         }
 
-        if !*is_present {
-            crate::action::macos::retry_bootstrap(DARWIN_LAUNCHD_DOMAIN, service, path)
+        if *is_present {
+            crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, service)
                 .await
                 .map_err(Self::error)?;
         }
+
+        crate::action::macos::retry_bootstrap(DARWIN_LAUNCHD_DOMAIN, service, path)
+            .await
+            .map_err(Self::error)?;
 
         Ok(())
     }

--- a/src/action/macos/create_determinate_volume_service.rs
+++ b/src/action/macos/create_determinate_volume_service.rs
@@ -47,7 +47,7 @@ impl CreateDeterminateVolumeService {
 
         // If the service is currently loaded or running, we need to unload it during execute (since we will then recreate it and reload it)
         // This `launchctl` command may fail if the service isn't loaded
-        let check_loaded_output = execute_command(
+        let check_loaded = execute_command(
             Command::new("launchctl")
                 .arg("print")
                 .arg(format!(
@@ -61,7 +61,7 @@ impl CreateDeterminateVolumeService {
         .await
         .ok();
 
-        if check_loaded_output.is_some() {
+        if check_loaded.is_some() {
             tracing::debug!(
                 "Detected loaded service `{}` which needs unload before replacing `{}`",
                 this.mount_service_label,

--- a/src/action/macos/create_determinate_volume_service.rs
+++ b/src/action/macos/create_determinate_volume_service.rs
@@ -1,15 +1,19 @@
 use serde::{Deserialize, Serialize};
 use tracing::{span, Span};
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+};
 use tokio::{
     fs::{remove_file, OpenOptions},
     io::AsyncWriteExt,
     process::Command,
 };
 
-use crate::action::{
-    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+use crate::{
+    action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
+    execute_command,
 };
 
 use super::DARWIN_LAUNCHD_DOMAIN;
@@ -43,27 +47,27 @@ impl CreateDeterminateVolumeService {
 
         // If the service is currently loaded or running, we need to unload it during execute (since we will then recreate it and reload it)
         // This `launchctl` command may fail if the service isn't loaded
-        let mut check_loaded_command = Command::new("launchctl");
-        check_loaded_command.arg("print");
-        check_loaded_command.arg(format!("system/{}", this.mount_service_label));
-        tracing::trace!(
-            command = format!("{:?}", check_loaded_command.as_std()),
-            "Executing"
-        );
-        let check_loaded_output = check_loaded_command
-            .status()
-            .await
-            .map_err(|e| ActionErrorKind::command(&check_loaded_command, e))
-            .map_err(Self::error)?;
+        let check_loaded_output = execute_command(
+            Command::new("launchctl")
+                .arg("print")
+                .arg(format!(
+                    "{DARWIN_LAUNCHD_DOMAIN}/{}",
+                    this.mount_service_label
+                ))
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .await
+        .ok();
 
-        this.needs_bootout = check_loaded_output.success();
-
-        if this.needs_bootout {
+        if check_loaded_output.is_some() {
             tracing::debug!(
                 "Detected loaded service `{}` which needs unload before replacing `{}`",
                 this.mount_service_label,
                 this.path.display(),
             );
+            this.needs_bootout = true;
         }
 
         if this.path.exists() {

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -38,7 +38,7 @@ impl CreateNixHookService {
 
         // If the service is currently loaded or running, we need to unload it during execute (since we will then recreate it and reload it)
         // This `launchctl` command may fail if the service isn't loaded
-        let check_loaded_output = execute_command(
+        let check_loaded = execute_command(
             Command::new("launchctl")
                 .arg("print")
                 .arg(format!("{DARWIN_LAUNCHD_DOMAIN}/{}", this.service_label))
@@ -49,7 +49,7 @@ impl CreateNixHookService {
         .await
         .ok();
 
-        if check_loaded_output.is_some() {
+        if check_loaded.is_some() {
             tracing::debug!(
                 "Detected loaded service `{}` which needs unload before replacing `{}`",
                 this.service_label,

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -1,15 +1,16 @@
 use serde::{Deserialize, Serialize};
 use tracing::{span, Span};
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::Stdio};
 use tokio::{
     fs::{remove_file, OpenOptions},
     io::AsyncWriteExt,
     process::Command,
 };
 
-use crate::action::{
-    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+use crate::{
+    action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
+    execute_command,
 };
 
 use super::DARWIN_LAUNCHD_DOMAIN;
@@ -37,26 +38,24 @@ impl CreateNixHookService {
 
         // If the service is currently loaded or running, we need to unload it during execute (since we will then recreate it and reload it)
         // This `launchctl` command may fail if the service isn't loaded
-        let mut check_loaded_command = Command::new("launchctl");
-        check_loaded_command.process_group(0);
-        check_loaded_command.arg("print");
-        check_loaded_command.arg(format!("system/{}", this.service_label));
-        tracing::trace!(
-            command = format!("{:?}", check_loaded_command.as_std()),
-            "Executing"
-        );
-        let check_loaded_output = check_loaded_command
-            .output()
-            .await
-            .map_err(|e| ActionErrorKind::command(&check_loaded_command, e))
-            .map_err(Self::error)?;
-        this.needs_bootout = check_loaded_output.status.success();
-        if this.needs_bootout {
+        let check_loaded_output = execute_command(
+            Command::new("launchctl")
+                .arg("print")
+                .arg(format!("{DARWIN_LAUNCHD_DOMAIN}/{}", this.service_label))
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        )
+        .await
+        .ok();
+
+        if check_loaded_output.is_some() {
             tracing::debug!(
                 "Detected loaded service `{}` which needs unload before replacing `{}`",
                 this.service_label,
                 this.path.display(),
             );
+            this.needs_bootout = true;
         }
 
         if this.path.exists() {

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -13,7 +13,7 @@ use crate::action::{
     ActionTag, StatefulAction,
 };
 
-use super::get_uuid_for_label;
+use super::get_disk_info_for_label;
 
 /** Create a plist for a `launchctl` service to mount the given `apfs_volume_label` on the given `mount_point`.
  */
@@ -75,15 +75,15 @@ impl CreateVolumeService {
         if this.path.exists() {
             let discovered_plist: LaunchctlMountPlist =
                 plist::from_file(&this.path).map_err(Self::error)?;
-            match get_uuid_for_label(&this.apfs_volume_label)
+            match get_disk_info_for_label(&this.apfs_volume_label)
                 .await
                 .map_err(Self::error)?
             {
-                Some(uuid) => {
+                Some(disk_info) => {
                     let expected_plist = generate_mount_plist(
                         &this.mount_service_label,
                         &this.apfs_volume_label,
-                        uuid,
+                        disk_info.volume_uuid,
                         &this.mount_point,
                         encrypt,
                     )
@@ -191,7 +191,7 @@ impl Action for CreateVolumeService {
                 .map_err(Self::error)?;
         }
 
-        let uuid = match get_uuid_for_label(apfs_volume_label)
+        let disk_info = match get_disk_info_for_label(apfs_volume_label)
             .await
             .map_err(Self::error)?
         {
@@ -205,7 +205,7 @@ impl Action for CreateVolumeService {
         let generated_plist = generate_mount_plist(
             mount_service_label,
             apfs_volume_label,
-            uuid,
+            disk_info.volume_uuid,
             mount_point,
             *encrypt,
         )

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -57,7 +57,7 @@ impl CreateVolumeService {
 
         // If the service is currently loaded or running, we need to unload it during execute (since we will then recreate it and reload it)
         // This `launchctl` command may fail if the service isn't loaded
-        let check_loaded_output = execute_command(
+        let check_loaded = execute_command(
             Command::new("launchctl")
                 .arg("print")
                 .arg(format!(
@@ -71,7 +71,7 @@ impl CreateVolumeService {
         .await
         .ok();
 
-        if check_loaded_output.is_some() {
+        if check_loaded.is_some() {
             tracing::debug!(
                 "Detected loaded service `{}` which needs unload before replacing `{}`",
                 this.mount_service_label,

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -72,10 +72,27 @@ impl EncryptApfsVolume {
                 name, disk,
             )));
         } else if planned_create_apfs_volume.state == ActionState::Completed {
-            // The user has a volume already created, but a password not set. This means we probably can't decrypt the volume.
-            return Err(Self::error(
-                EncryptApfsVolumeError::MissingPasswordForExistingVolume(name, disk),
-            ));
+            #[derive(serde::Deserialize)]
+            #[serde(rename_all = "PascalCase")]
+            struct DiskUtilDiskInfoOutput {
+                file_vault: bool,
+            }
+
+            let output =
+                execute_command(Command::new("/usr/sbin/diskutil").args(["info", "-plist", &name]))
+                    .await
+                    .map_err(Self::error)?;
+
+            let parsed: DiskUtilDiskInfoOutput =
+                plist::from_bytes(&output.stdout).map_err(Self::error)?;
+
+            // The user has an already-encrypted volume, but we couldn't retrieve the password. We won't
+            // be able to decrypt the volume.
+            if parsed.file_vault {
+                return Err(Self::error(
+                    EncryptApfsVolumeError::MissingPasswordForExistingVolume(name, disk),
+                ));
+            }
         }
 
         // Ensure if the disk already exists, that it's encrypted
@@ -88,18 +105,12 @@ impl EncryptApfsVolume {
             plist::from_bytes(&output.stdout).map_err(Self::error)?;
         for container in parsed.containers {
             for volume in container.volumes {
-                if volume.name.as_ref() == Some(&name) {
-                    if volume.encryption {
-                        return Err(Self::error(
-                            EncryptApfsVolumeError::ExistingVolumeNotEncrypted(name, disk),
-                        ));
-                    } else {
-                        return Ok(StatefulAction::completed(Self {
-                            determinate_nix,
-                            disk,
-                            name,
-                        }));
-                    }
+                if volume.name.as_ref() == Some(&name) && volume.file_vault {
+                    return Ok(StatefulAction::completed(Self {
+                        determinate_nix,
+                        disk,
+                        name,
+                    }));
                 }
             }
         }

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -86,8 +86,8 @@ impl EncryptApfsVolume {
             let parsed: DiskUtilDiskInfoOutput =
                 plist::from_bytes(&output.stdout).map_err(Self::error)?;
 
-            // The user has an already-encrypted volume, but we couldn't retrieve the password. We won't
-            // be able to decrypt the volume.
+            // The user has an already-encrypted volume, but we couldn't retrieve the password.
+            // We won't be able to decrypt the volume.
             if parsed.file_vault {
                 return Err(Self::error(
                     EncryptApfsVolumeError::MissingPasswordForExistingVolume(name, disk),

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -44,7 +44,7 @@ impl EncryptApfsVolume {
         command.arg("-s");
         command.arg("Nix Store");
         command.arg("-l");
-        command.arg(&format!("{} encryption password", disk.display()));
+        command.arg(format!("{} encryption password", disk.display()));
         command.arg("-D");
         command.arg("Encrypted volume password");
         command.process_group(0);

--- a/src/action/macos/kickstart_launchctl_service.rs
+++ b/src/action/macos/kickstart_launchctl_service.rs
@@ -53,7 +53,7 @@ impl KickstartLaunchctlService {
             for output_line in output_string.lines() {
                 let output_line_trimmed = output_line.trim();
                 if output_line_trimmed.starts_with("state") {
-                    if output_line_trimmed.contains("running") {
+                    if !output_line_trimmed.contains("not running") {
                         service_started = true;
                     }
                     break;

--- a/src/action/macos/kickstart_launchctl_service.rs
+++ b/src/action/macos/kickstart_launchctl_service.rs
@@ -7,6 +7,7 @@ use tracing::{span, Span};
 use crate::action::{ActionError, ActionErrorKind, ActionTag, StatefulAction};
 
 use crate::action::{Action, ActionDescription};
+use crate::execute_command;
 
 /**
 Bootstrap and kickstart an APFS volume
@@ -19,29 +20,26 @@ pub struct KickstartLaunchctlService {
 }
 
 impl KickstartLaunchctlService {
-    #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn plan(
-        domain: impl AsRef<str>,
-        service: impl AsRef<str>,
-    ) -> Result<StatefulAction<Self>, ActionError> {
-        let domain = domain.as_ref().to_string();
-        let service = service.as_ref().to_string();
+    #[tracing::instrument(level = "debug")]
+    pub async fn plan(domain: &str, service: &str) -> Result<StatefulAction<Self>, ActionError> {
+        let domain = domain.to_string();
+        let service = service.to_string();
 
         let mut service_exists = false;
         let mut service_started = false;
-        let mut command = Command::new("launchctl");
-        command.process_group(0);
-        command.arg("print");
-        command.arg(&service);
-        command.arg("-plist");
-        command.stdin(std::process::Stdio::null());
-        command.stdout(std::process::Stdio::piped());
-        command.stderr(std::process::Stdio::piped());
-        let output = command
-            .output()
-            .await
-            .map_err(|e| Self::error(ActionErrorKind::command(&command, e)))?;
-        if output.status.success() {
+        let output = execute_command(
+            Command::new("launchctl")
+                .process_group(0)
+                .arg("print")
+                .arg(format!("{domain}/{service}"))
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped()),
+        )
+        .await
+        .ok();
+
+        if let Some(output) = output {
             service_exists = true;
 
             let output_string = String::from_utf8(output.stdout).map_err(Self::error)?;
@@ -97,14 +95,12 @@ impl Action for KickstartLaunchctlService {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
-        let Self { domain, service } = self;
-
         let mut retry_tokens: usize = 10;
         loop {
             let mut command = Command::new("launchctl");
             command.process_group(0);
             command.args(["kickstart", "-k"]);
-            command.arg(format!("{domain}/{service}"));
+            command.arg(format!("{}/{}", self.domain, self.service));
             command.stdin(std::process::Stdio::null());
             command.stderr(std::process::Stdio::null());
             command.stdout(std::process::Stdio::null());

--- a/src/os/darwin/diskutil.rs
+++ b/src/os/darwin/diskutil.rs
@@ -34,7 +34,7 @@ pub struct DiskUtilApfsContainer {
 #[serde(rename_all = "PascalCase")]
 pub struct DiskUtilApfsListVolume {
     pub name: Option<String>,
-    pub encryption: bool,
+    pub file_vault: bool,
 }
 
 #[derive(serde::Deserialize, Clone, Debug)]


### PR DESCRIPTION
##### Description

None of this changes the receipt or anything, so we could merge it now and release it if we have to.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
