### PR TITLE
Don't unmount the Nix store when doing a curing reinstall, plus other nits and cleanup

### DIFF
--- a/src/action/base/create_directory.rs
+++ b/src/action/base/create_directory.rs
@@ -279,7 +279,7 @@ impl Action for CreateDirectory {
                 tracing::debug!("Not cleaning mountpoint `{}`", path.display());
             },
             (false, true, _) | (false, false, true) => {
-                crate::util::remove_dir_all(&path, OnMissing::Error)
+                crate::util::remove_dir_all(path, OnMissing::Error)
                     .await
                     .map_err(|e| ActionErrorKind::Remove(path.clone(), e))
                     .map_err(Self::error)?

--- a/src/action/base/create_file.rs
+++ b/src/action/base/create_file.rs
@@ -260,7 +260,7 @@ impl Action for CreateFile {
             force: _,
         } = self;
 
-        crate::util::remove_file(&path, OnMissing::Ignore)
+        crate::util::remove_file(path, OnMissing::Ignore)
             .await
             .map_err(|e| ActionErrorKind::Remove(path.to_owned(), e))
             .map_err(Self::error)?;

--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -334,6 +334,10 @@ pub async fn delete_user_macos(name: &str) -> Result<(), ActionErrorKind> {
             // These Macs cannot always delete users, as sometimes there is no graphical login
             tracing::warn!("Encountered an exit code 40 with -14120 error while removing user, this is likely because the initial executing user did not have a secure token, or that there was no graphical login session. To delete the user, log in graphically, then run `/usr/bin/dscl . -delete /Users/{}`", name);
         },
+        Some(185) if stderr.contains("-14009 (eDSUnknownNodeName)") => {
+            // The user has already been deleted
+            tracing::debug!("User already deleted: /Users/{}`", name);
+        },
         _ => {
             // Something went wrong
             return Err(ActionErrorKind::command_output(&command, output));

--- a/src/action/linux/provision_selinux.rs
+++ b/src/action/linux/provision_selinux.rs
@@ -125,7 +125,7 @@ impl Action for ProvisionSelinux {
 async fn remove_existing_policy(policy_path: &Path) -> Result<(), ActionErrorKind> {
     execute_command(Command::new("semodule").arg("--remove").arg("nix")).await?;
 
-    crate::util::remove_file(&policy_path, OnMissing::Ignore)
+    crate::util::remove_file(policy_path, OnMissing::Ignore)
         .await
         .map_err(|e| ActionErrorKind::Remove(policy_path.into(), e))?;
 

--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -78,14 +78,12 @@ impl CreateDeterminateNixVolume {
                 .await
                 .map_err(Self::error)?;
 
-            let diskinfo = DiskUtilInfoOutput::for_volume_name(&name)
-                .await
-                .map_err(Self::error)?;
-
-            if Path::new(&diskinfo.parent_whole_disk) == disk
-                && diskinfo.mount_point.as_deref() == Some(Path::new("/nix"))
-            {
-                task.state = crate::action::ActionState::Skipped
+            if let Ok(diskinfo) = DiskUtilInfoOutput::for_volume_name(&name).await {
+                if Path::new(&diskinfo.parent_whole_disk) == disk
+                    && diskinfo.mount_point.as_deref() == Some(Path::new("/nix"))
+                {
+                    task.state = crate::action::ActionState::Skipped
+                }
             }
 
             task

--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -77,7 +77,7 @@ impl CreateDeterminateNixVolume {
             .map_err(Self::error)?;
 
         let unmount_volume = if create_volume.state == crate::action::ActionState::Completed {
-            UnmountApfsVolume::plan_skip_if_already_mounted(disk, name.clone(), "/nix")
+            UnmountApfsVolume::plan_skip_if_already_mounted_to_nix(disk, name.clone())
                 .await
                 .map_err(Self::error)?
         } else {

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -62,13 +62,19 @@ impl CreateNixVolume {
 
         let create_synthetic_objects = CreateSyntheticObjects::plan().await.map_err(Self::error)?;
 
-        let unmount_volume = UnmountApfsVolume::plan(disk, name.clone())
-            .await
-            .map_err(Self::error)?;
-
         let create_volume = CreateApfsVolume::plan(disk, name.clone(), case_sensitive)
             .await
             .map_err(Self::error)?;
+
+        let unmount_volume = if create_volume.state == crate::action::ActionState::Completed {
+            UnmountApfsVolume::plan_skip_if_already_mounted(disk, name.clone(), "/nix")
+                .await
+                .map_err(Self::error)?
+        } else {
+            UnmountApfsVolume::plan(disk, name.clone())
+                .await
+                .map_err(Self::error)?
+        };
 
         let create_fstab_entry = CreateFstabEntry::plan(name.clone(), &create_volume)
             .await

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -67,7 +67,7 @@ impl CreateNixVolume {
             .map_err(Self::error)?;
 
         let unmount_volume = if create_volume.state == crate::action::ActionState::Completed {
-            UnmountApfsVolume::plan_skip_if_already_mounted(disk, name.clone(), "/nix")
+            UnmountApfsVolume::plan_skip_if_already_mounted_to_nix(disk, name.clone())
                 .await
                 .map_err(Self::error)?
         } else {

--- a/src/action/macos/unmount_apfs_volume.rs
+++ b/src/action/macos/unmount_apfs_volume.rs
@@ -36,17 +36,20 @@ impl UnmountApfsVolume {
     ) -> Result<StatefulAction<Self>, ActionError> {
         let diskinfo = DiskUtilInfoOutput::for_volume_name(&name).await;
 
-        let mut task = Self::plan(&disk, name).await?;
+        let task = Self {
+            disk: disk.as_ref().to_owned(),
+            name,
+        };
 
         if let Ok(diskinfo) = diskinfo {
             if Path::new(&diskinfo.parent_whole_disk) == disk.as_ref()
                 && diskinfo.mount_point.as_deref() == Some("/nix".as_ref())
             {
-                task.state = crate::action::ActionState::Skipped
+                return Ok(StatefulAction::skipped(task));
             }
         }
 
-        Ok(task)
+        Ok(task.into())
     }
 }
 

--- a/src/action/macos/unmount_apfs_volume.rs
+++ b/src/action/macos/unmount_apfs_volume.rs
@@ -30,10 +30,9 @@ impl UnmountApfsVolume {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn plan_skip_if_already_mounted(
+    pub async fn plan_skip_if_already_mounted_to_nix(
         disk: impl AsRef<Path>,
         name: String,
-        mount_point: impl AsRef<Path>,
     ) -> Result<StatefulAction<Self>, ActionError> {
         let diskinfo = DiskUtilInfoOutput::for_volume_name(&name).await;
 
@@ -41,7 +40,7 @@ impl UnmountApfsVolume {
 
         if let Ok(diskinfo) = diskinfo {
             if Path::new(&diskinfo.parent_whole_disk) == disk.as_ref()
-                && diskinfo.mount_point.as_deref() == Some(mount_point.as_ref())
+                && diskinfo.mount_point.as_deref() == Some("/nix".as_ref())
             {
                 task.state = crate::action::ActionState::Skipped
             }

--- a/src/action/macos/unmount_apfs_volume.rs
+++ b/src/action/macos/unmount_apfs_volume.rs
@@ -1,4 +1,3 @@
-use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
@@ -57,18 +56,9 @@ impl Action for UnmountApfsVolume {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
         let currently_mounted = {
-            let buf = execute_command(
-                Command::new("/usr/sbin/diskutil")
-                    .process_group(0)
-                    .args(["info", "-plist"])
-                    .arg(&self.name)
-                    .stdin(std::process::Stdio::null()),
-            )
-            .await
-            .map_err(Self::error)?
-            .stdout;
-            let the_plist: DiskUtilInfoOutput =
-                plist::from_reader(Cursor::new(buf)).map_err(Self::error)?;
+            let the_plist = DiskUtilInfoOutput::for_volume_name(&self.name)
+                .await
+                .map_err(Self::error)?;
 
             the_plist.is_mounted()
         };
@@ -97,18 +87,9 @@ impl Action for UnmountApfsVolume {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
         let currently_mounted = {
-            let buf = execute_command(
-                Command::new("/usr/sbin/diskutil")
-                    .process_group(0)
-                    .args(["info", "-plist"])
-                    .arg(&self.name)
-                    .stdin(std::process::Stdio::null()),
-            )
-            .await
-            .map_err(Self::error)?
-            .stdout;
-            let the_plist: DiskUtilInfoOutput =
-                plist::from_reader(Cursor::new(buf)).map_err(Self::error)?;
+            let the_plist = DiskUtilInfoOutput::for_volume_name(&self.name)
+                .await
+                .map_err(Self::error)?;
 
             the_plist.is_mounted()
         };


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
