### PR TITLE
Don't delete encryption password until volume deletion succeeds

### DIFF
--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -301,37 +301,44 @@ impl Action for CreateDeterminateNixVolume {
         let mut errors = vec![];
 
         if let Err(err) = self.enable_ownership.try_revert().await {
-            errors.push(err)
-        };
+            errors.push(err);
+        }
+
         if let Err(err) = self.kickstart_launchctl_service.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.bootstrap_volume.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.setup_volume_daemon.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.encrypt_volume.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.create_fstab_entry.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
 
         if let Err(err) = self.unmount_volume.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.create_volume.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
 
         // Purposefully not reversed
         if let Err(err) = self.create_or_append_synthetic_conf.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.create_synthetic_objects.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
 
         if let Err(err) = self.create_directory.try_revert().await {

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -273,40 +273,46 @@ impl Action for CreateNixVolume {
         let mut errors = vec![];
 
         if let Err(err) = self.enable_ownership.try_revert().await {
-            errors.push(err)
-        };
+            errors.push(err);
+        }
+
         if let Err(err) = self.kickstart_launchctl_service.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.bootstrap_volume.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.setup_volume_daemon.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
 
         if let Some(encrypt_volume) = &mut self.encrypt_volume {
             if let Err(err) = encrypt_volume.try_revert().await {
-                errors.push(err)
+                errors.push(err);
             }
         }
+
         if let Err(err) = self.create_fstab_entry.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
 
         if let Err(err) = self.unmount_volume.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.create_volume.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
 
         // Purposefully not reversed
         if let Err(err) = self.create_or_append_synthetic_conf.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
+
         if let Err(err) = self.create_synthetic_objects.try_revert().await {
-            errors.push(err)
+            errors.push(err);
         }
 
         if errors.is_empty() {

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -288,12 +288,6 @@ impl Action for CreateNixVolume {
             errors.push(err);
         }
 
-        if let Some(encrypt_volume) = &mut self.encrypt_volume {
-            if let Err(err) = encrypt_volume.try_revert().await {
-                errors.push(err);
-            }
-        }
-
         if let Err(err) = self.create_fstab_entry.try_revert().await {
             errors.push(err);
         }
@@ -302,8 +296,25 @@ impl Action for CreateNixVolume {
             errors.push(err);
         }
 
+        let mut revert_create_volume_failed = false;
         if let Err(err) = self.create_volume.try_revert().await {
+            revert_create_volume_failed = true;
             errors.push(err);
+        }
+
+        // Intentionally happens after the create_volume step so we can avoid deleting the
+        // encryption password if volume deletion failed
+        if let Some(encrypt_volume) = &mut self.encrypt_volume {
+            if revert_create_volume_failed {
+                tracing::debug!(
+                    "Not reverting encrypt_volume step (which would delete the disk encryption \
+                    password) because deleting the volume failed"
+                );
+            } else {
+                if let Err(err) = encrypt_volume.try_revert().await {
+                    errors.push(err);
+                }
+            }
         }
 
         // Purposefully not reversed


### PR DESCRIPTION
##### Description
If the encryption key is deleted, the volume is useless until the user figures out they have to delete it. It is not safe for us to decide to delete it.

Instead, we should not delete the encryption key until we are confident the volume itself was deleted.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
