### PR TITLE
Failing to send diagnostics should not fail the install

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -163,7 +163,14 @@ impl DiagnosticData {
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn send(
+    pub async fn send(self, action: DiagnosticAction, status: DiagnosticStatus) {
+        if let Err(e) = self.send_impl(action, status).await {
+            tracing::debug!(?e, "Failed to send diagnostics");
+        }
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn send_impl(
         self,
         action: DiagnosticAction,
         status: DiagnosticStatus,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -188,7 +188,7 @@ impl InstallPlan {
                                 crate::diagnostics::DiagnosticAction::Install,
                                 crate::diagnostics::DiagnosticStatus::Cancelled,
                             )
-                            .await?;
+                            .await;
                     }
 
                     return Err(NixInstallerError::Cancelled);
@@ -210,7 +210,7 @@ impl InstallPlan {
                             crate::diagnostics::DiagnosticAction::Install,
                             crate::diagnostics::DiagnosticStatus::Failure,
                         )
-                        .await?;
+                        .await;
                 }
 
                 return Err(err);
@@ -232,7 +232,7 @@ impl InstallPlan {
                         crate::diagnostics::DiagnosticAction::Install,
                         crate::diagnostics::DiagnosticStatus::Failure,
                     )
-                    .await?;
+                    .await;
             }
 
             tracing::warn!("{err:?}")
@@ -245,7 +245,7 @@ impl InstallPlan {
                         crate::diagnostics::DiagnosticAction::Install,
                         crate::diagnostics::DiagnosticStatus::Success,
                     )
-                    .await?;
+                    .await;
             }
         }
 
@@ -360,7 +360,7 @@ impl InstallPlan {
                                 crate::diagnostics::DiagnosticAction::Uninstall,
                                 crate::diagnostics::DiagnosticStatus::Cancelled,
                             )
-                            .await?;
+                            .await;
                     }
                     return Err(NixInstallerError::Cancelled);
                 }
@@ -381,7 +381,7 @@ impl InstallPlan {
                         crate::diagnostics::DiagnosticAction::Uninstall,
                         crate::diagnostics::DiagnosticStatus::Success,
                     )
-                    .await?;
+                    .await;
             }
 
             Ok(())
@@ -396,7 +396,7 @@ impl InstallPlan {
                         crate::diagnostics::DiagnosticAction::Uninstall,
                         crate::diagnostics::DiagnosticStatus::Failure,
                     )
-                    .await?;
+                    .await;
             }
 
             Err(error)


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
