### PR TITLE
ConfigureNix: place nix.conf before setting up the default Nix profile

### DIFF
--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -169,16 +169,16 @@ impl Action for ConfigureNix {
             configure_shell_profile,
         } = self;
 
-        setup_default_profile
-            .try_execute()
-            .await
-            .map_err(Self::error)?;
         if let Some(place_nix_configuration) = place_nix_configuration {
             place_nix_configuration
                 .try_execute()
                 .await
                 .map_err(Self::error)?;
         }
+        setup_default_profile
+            .try_execute()
+            .await
+            .map_err(Self::error)?;
         if let Some(configure_shell_profile) = configure_shell_profile {
             configure_shell_profile
                 .try_execute()


### PR DESCRIPTION
##### Description

Closes #1305.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
