### PR TITLE
confirmation prompts: abort with unique messages

### DIFF
--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -233,7 +233,10 @@ impl CommandExecute for Install {
                     PromptChoice::Yes => break,
                     PromptChoice::Explain => currently_explaining = true,
                     PromptChoice::No => {
-                        interaction::clean_exit_with_message("Not continuing with an installation. Bye!").await
+                        interaction::clean_exit_with_message(
+                            "Okay, not continuing with the installation. Bye!",
+                        )
+                        .await
                     },
                 }
             }

--- a/src/cli/subcommand/install.rs
+++ b/src/cli/subcommand/install.rs
@@ -233,7 +233,7 @@ impl CommandExecute for Install {
                     PromptChoice::Yes => break,
                     PromptChoice::Explain => currently_explaining = true,
                     PromptChoice::No => {
-                        interaction::clean_exit_with_message("Okay, didn't do anything! Bye!").await
+                        interaction::clean_exit_with_message("Not continuing with an installation. Bye!").await
                     },
                 }
             }

--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -171,7 +171,7 @@ impl CommandExecute for Repair {
                     PromptChoice::Yes => break,
                     PromptChoice::No => {
                         crate::cli::interaction::clean_exit_with_message(
-                            "Okay, didn't do anything! Bye!",
+                            "Not continuing with a repair. Bye!",
                         )
                         .await
                     },

--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -171,7 +171,7 @@ impl CommandExecute for Repair {
                     PromptChoice::Yes => break,
                     PromptChoice::No => {
                         crate::cli::interaction::clean_exit_with_message(
-                            "Not continuing with a repair. Bye!",
+                            "Okay, not continuing with the repair. Bye!",
                         )
                         .await
                     },

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -177,7 +177,7 @@ impl CommandExecute for Uninstall {
                     PromptChoice::Yes => break,
                     PromptChoice::Explain => currently_explaining = true,
                     PromptChoice::No => {
-                        interaction::clean_exit_with_message("Okay, didn't do anything! Bye!").await
+                        interaction::clean_exit_with_message("Not continuing with an uninstall. Bye!").await
                     },
                 }
             }

--- a/src/cli/subcommand/uninstall.rs
+++ b/src/cli/subcommand/uninstall.rs
@@ -177,7 +177,10 @@ impl CommandExecute for Uninstall {
                     PromptChoice::Yes => break,
                     PromptChoice::Explain => currently_explaining = true,
                     PromptChoice::No => {
-                        interaction::clean_exit_with_message("Not continuing with an uninstall. Bye!").await
+                        interaction::clean_exit_with_message(
+                            "Okay, not continuing with the uninstallation. Bye!",
+                        )
+                        .await
                     },
                 }
             }


### PR DESCRIPTION
If an install is attempted, it fails near the end, and an uninstall is declined by the user, state specifically that an uninstall was not done, don't report that nothing was done.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
