### PR TITLE
CreateOrMergeNixConfig: fix expected nix.conf mode to be 644, not 664

### DIFF
--- a/src/action/base/create_or_merge_nix_config.rs
+++ b/src/action/base/create_or_merge_nix_config.rs
@@ -147,19 +147,6 @@ impl CreateOrMergeNixConfig {
             return Err(Self::error(ActionErrorKind::PathWasNotFile(path)));
         }
 
-        // Does the file have the right permissions?
-        let discovered_mode = metadata.permissions().mode();
-        // We only care about user-group-other permissions
-        let discovered_mode = discovered_mode & 0o777;
-
-        if discovered_mode != NIX_CONF_MODE {
-            return Err(Self::error(ActionErrorKind::PathModeMismatch(
-                path,
-                discovered_mode,
-                NIX_CONF_MODE,
-            )));
-        }
-
         let existing_nix_config = NixConfig::parse_file(&path)
             .map_err(CreateOrMergeNixConfigError::ParseNixConfig)
             .map_err(Self::error)?;

--- a/src/action/base/create_or_merge_nix_config.rs
+++ b/src/action/base/create_or_merge_nix_config.rs
@@ -18,7 +18,7 @@ use crate::action::{
 /// The `nix.conf` configuration names that are safe to merge.
 // FIXME(@cole-h): make configurable by downstream users?
 const MERGEABLE_CONF_NAMES: &[&str] = &["experimental-features"];
-const NIX_CONF_MODE: u32 = 0o664;
+const NIX_CONF_MODE: u32 = 0o644;
 const NIX_CONF_COMMENT_CHAR: char = '#';
 
 #[non_exhaustive]


### PR DESCRIPTION
We had this bug in various places in the past, but I thought I fixed them all. No clue how it showed up again...

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
