### PR TITLE
Allow user override of the nix store volume name

### DIFF
--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -42,7 +42,7 @@ impl EncryptApfsVolume {
         command.args(["find-generic-password", "-a"]);
         command.arg(&name);
         command.arg("-s");
-        command.arg("Nix Store");
+        command.arg(&name);
         command.arg("-l");
         command.arg(format!("{} encryption password", disk.display()));
         command.arg("-D");
@@ -186,7 +186,7 @@ impl Action for EncryptApfsVolume {
             "-a",
             self.name.as_str(),
             "-s",
-            "Nix Store",
+            self.name.as_str(),
             "-l",
             format!("{} encryption password", disk_str).as_str(),
             "-D",

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -37,7 +37,7 @@ impl EncryptApfsVolume {
     ) -> Result<StatefulAction<Self>, ActionError> {
         let name = name.as_ref().to_owned();
         let disk = disk.as_ref().to_path_buf();
-
+        println!("Volume name is {0}", name);
         let mut command = Command::new("/usr/bin/security");
         command.args(["find-generic-password", "-a"]);
         command.arg(&name);

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -227,6 +227,7 @@ impl Planner for Macos {
         }
 
         if self.settings.determinate_nix {
+            println!("Creating determinate nix volume {0}", self.volume_label);
             plan.push(
                 CreateDeterminateNixVolume::plan(
                     root_disk.unwrap(), /* We just ensured it was populated */

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -353,8 +353,6 @@ impl Planner for Macos {
             serde_json::to_value(case_sensitive)?,
         );
 
-        println!("Settings: {0}", map);
-
         Ok(map)
     }
 

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -139,7 +139,7 @@ impl Planner for Macos {
             root_disk: Some(default_root_disk().await?),
             case_sensitive: false,
             encrypt: None,
-            volume_label: "Nix Store".into(),
+            volume_label: "Nixxie".into(),
         })
     }
 

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -67,7 +67,7 @@ pub struct Macos {
     /// The label for the created APFS volume
     #[cfg_attr(
         feature = "cli",
-        clap(long, default_value = "Nix Store", env = "NIX_INSTALLER_VOLUME_LABEL")
+        clap(long, default_value = "Nixxie", env = "NIX_INSTALLER_VOLUME_LABEL")
     )]
     pub volume_label: String,
     /// The root disk of the target
@@ -339,6 +339,7 @@ impl Planner for Macos {
         } = self;
         let mut map = HashMap::default();
 
+
         map.extend(settings.settings()?);
         map.insert("volume_encrypt".into(), serde_json::to_value(encrypt)?);
         map.insert("volume_label".into(), serde_json::to_value(volume_label)?);
@@ -351,6 +352,8 @@ impl Planner for Macos {
             "case_sensitive".into(),
             serde_json::to_value(case_sensitive)?,
         );
+
+        println!("Settings: {0}", map);
 
         Ok(map)
     }

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -228,6 +228,7 @@ impl Planner for Macos {
 
         if self.settings.determinate_nix {
             println!("Creating determinate nix volume {0}", self.volume_label);
+            println!("Installer volume label: {}", std::env::var("NIX_INSTALLER_VOLUME_LABEL").unwrap_or_default());
             plan.push(
                 CreateDeterminateNixVolume::plan(
                     root_disk.unwrap(), /* We just ensured it was populated */


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
