### PR TITLE
Don't hardcode the path

### DIFF
--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -42,7 +42,7 @@ impl EncryptApfsVolume {
         command.args(["find-generic-password", "-a"]);
         command.arg(&name);
         command.arg("-s");
-        command.arg("Nix Store");
+        command.arg(&name);
         command.arg("-l");
         command.arg(format!("{} encryption password", disk.display()));
         command.arg("-D");
@@ -186,7 +186,7 @@ impl Action for EncryptApfsVolume {
             "-a",
             self.name.as_str(),
             "-s",
-            "Nix Store",
+            self.name.as_str(),
             "-l",
             format!("{} encryption password", disk_str).as_str(),
             "-D",


### PR DESCRIPTION
##### Description

Fixes #1296

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
