### PR TITLE
FetchAndUnpackNix: remove destination if it already exists

### DIFF
--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -164,7 +164,6 @@ impl Action for FetchAndUnpackNix {
 
         // TODO(@Hoverbear): Pick directory
         tracing::trace!("Unpacking tar.xz");
-        let dest_clone = self.dest.clone();
 
         let decoder = xz2::read::XzDecoder::new(bytes.reader());
         let mut archive = tar::Archive::new(decoder);
@@ -172,7 +171,7 @@ impl Action for FetchAndUnpackNix {
         archive.set_preserve_mtime(true);
         archive.set_unpack_xattrs(true);
         archive
-            .unpack(&dest_clone)
+            .unpack(&self.dest)
             .map_err(FetchUrlError::Unarchive)
             .map_err(Self::error)?;
 

--- a/src/action/base/fetch_and_unpack_nix.rs
+++ b/src/action/base/fetch_and_unpack_nix.rs
@@ -8,6 +8,7 @@ use crate::{
     action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
     parse_ssl_cert,
     settings::UrlOrPath,
+    util::OnMissing,
 };
 
 /**
@@ -164,6 +165,15 @@ impl Action for FetchAndUnpackNix {
 
         // TODO(@Hoverbear): Pick directory
         tracing::trace!("Unpacking tar.xz");
+
+        // NOTE(cole-h): If the destination exists (because maybe a previous install failed), we
+        // want to remove it so that tar doesn't complain with:
+        //     trying to unpack outside of destination path: /nix/temp-install-dir
+        if self.dest.exists() {
+            crate::util::remove_dir_all(&self.dest, OnMissing::Ignore)
+                .await
+                .map_err(|e| Self::error(ActionErrorKind::Remove(self.dest.clone(), e)))?;
+        }
 
         let decoder = xz2::read::XzDecoder::new(bytes.reader());
         let mut archive = tar::Archive::new(decoder);


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
