### PR TITLE
Graham/fh 463 determinatepkg failed to mount nix store

### DIFF
--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -337,10 +337,8 @@ impl Action for CreateDeterminateNixVolume {
                 "Not reverting encrypt_volume step (which would delete the disk encryption \
                 password) because deleting the volume failed"
             );
-        } else {
-            if let Err(err) = self.encrypt_volume.try_revert().await {
-                errors.push(err);
-            }
+        } else if let Err(err) = self.encrypt_volume.try_revert().await {
+            errors.push(err);
         }
 
         // Purposefully not reversed

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -310,10 +310,8 @@ impl Action for CreateNixVolume {
                     "Not reverting encrypt_volume step (which would delete the disk encryption \
                     password) because deleting the volume failed"
                 );
-            } else {
-                if let Err(err) = encrypt_volume.try_revert().await {
-                    errors.push(err);
-                }
+            } else if let Err(err) = encrypt_volume.try_revert().await {
+                errors.push(err);
             }
         }
 

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -173,7 +173,7 @@ impl Action for EncryptApfsVolume {
 
         let disk_str = &self.disk.to_str().expect("Could not turn disk into string"); /* Should not reasonably ever fail */
 
-        let mut retry_tokens: usize = 60;
+        let mut retry_tokens: usize = 10;
         loop {
             let mut command = Command::new("/usr/sbin/diskutil");
             command.process_group(0);


### PR DESCRIPTION
##### Description

Retry mounting the volume post-encryption a few times, given additional user errors at this step.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
