### PR TITLE
flake: remove unnecessary checkpolicy overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,19 +121,6 @@
           };
         in
         rec {
-          # NOTE(cole-h): fixes build -- nixpkgs updated libsepol to 3.7 but didn't update
-          # checkpolicy to 3.7, checkpolicy links against libsepol, and libsepol 3.7 changed
-          # something in the API so checkpolicy 3.6 failed to build against libsepol 3.7
-          # Can be removed once https://github.com/NixOS/nixpkgs/pull/335146 merges.
-          checkpolicy = prev.checkpolicy.overrideAttrs ({ ... }: rec {
-            version = "3.7";
-
-            src = final.fetchurl {
-              url = "https://github.com/SELinuxProject/selinux/releases/download/${version}/checkpolicy-${version}.tar.gz";
-              sha256 = "sha256-/T4ZJUd9SZRtERaThmGvRMH4bw1oFGb9nwLqoGACoH8=";
-            };
-          });
-
           nix-installer = naerskLib.buildPackage sharedAttrs;
         } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "x86_64-linux") rec {
           default = nix-installer-static;


### PR DESCRIPTION
It's been fixed in the Nixpkgs we use so, no need anymore.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
