### PR TITLE
Re-own /nix/var to 0:0, except for the per-user profiles

### DIFF
--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -266,7 +266,7 @@ async fn ensure_nix_var_ownership() -> Result<(), ActionErrorKind> {
         .filter_map(|entry| match entry {
             Ok(entry) => Some(entry),
             Err(e) => {
-                tracing::warn!(%e, "Enumerating /nix/var");
+                tracing::warn!(%e, "Failed to get entry in /nix/var");
                 None
             },
         })
@@ -276,7 +276,7 @@ async fn ensure_nix_var_ownership() -> Result<(), ActionErrorKind> {
                 tracing::warn!(
                     path = %entry.path().to_string_lossy(),
                     %e,
-                    "Reading ownership and mode data"
+                    "Failed to read ownership and mode data"
                 );
                 None
             },
@@ -290,7 +290,7 @@ async fn ensure_nix_var_ownership() -> Result<(), ActionErrorKind> {
             Some((entry, metadata))
         });
     for (entry, _metadata) in entryiter {
-        tracing::info!(
+        tracing::debug!(
             path = %entry.path().to_string_lossy(),
             "Re-owning path to 0:0"
         );

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -85,12 +85,6 @@ impl Action for ProvisionNix {
                 "Will update existing files in the Nix Store to use the Nix build group ID {nix_store_gid}"
             )],
         ));
-        buf.push(ActionDescription::new(
-            "Synchronize /nix/var ownership".to_string(),
-            vec![format!(
-                "Will update existing files in /nix/var to be owned by User ID 0, Group ID 0"
-            )],
-        ));
 
         buf
     }
@@ -121,8 +115,6 @@ impl Action for ProvisionNix {
         ensure_nix_store_group(self.nix_store_gid)
             .await
             .map_err(Self::error)?;
-
-        ensure_nix_var_ownership().await.map_err(Self::error)?;
 
         Ok(())
     }
@@ -235,73 +227,5 @@ async fn ensure_nix_store_group(desired_nix_build_group_id: u32) -> Result<(), A
         }
     }
 
-    Ok(())
-}
-
-/// Everything under /nix/var (with two deprecated exceptions below) should be owned by 0:0.
-///
-/// * /nix/var/nix/profiles/per-user/*
-/// * /nix/var/nix/gcroots/per-user/*
-///
-/// This function walks /nix/var and makes sure that is true.
-async fn ensure_nix_var_ownership() -> Result<(), ActionErrorKind> {
-    let entryiter = walkdir::WalkDir::new("/nix/var")
-        .follow_links(false)
-        .same_file_system(true)
-        .contents_first(true)
-        .into_iter()
-        .filter_entry(|entry| {
-            let parent = entry.path().parent();
-
-            if parent == Some(std::path::Path::new("/nix/var/nix/profiles/per-user"))
-                || parent == Some(std::path::Path::new("/nix/var/nix/gcroots/per-user"))
-            {
-                // False means do *not* descend into this directory
-                // ...which we don't want to do, because the per-user subdirectories are usually owned by that user.
-                return false;
-            }
-
-            true
-        })
-        .filter_map(|entry| match entry {
-            Ok(entry) => Some(entry),
-            Err(e) => {
-                tracing::warn!(%e, "Failed to get entry in /nix/var");
-                None
-            },
-        })
-        .filter_map(|entry| match entry.metadata() {
-            Ok(metadata) => Some((entry, metadata)),
-            Err(e) => {
-                tracing::warn!(
-                    path = %entry.path().to_string_lossy(),
-                    %e,
-                    "Failed to read ownership and mode data"
-                );
-                None
-            },
-        })
-        .filter_map(|(entry, metadata)| {
-            // Dirents that are already 0:0 are to be skipped
-            if metadata.uid() == 0 && metadata.gid() == 0 {
-                return None;
-            }
-
-            Some((entry, metadata))
-        });
-    for (entry, _metadata) in entryiter {
-        tracing::debug!(
-            path = %entry.path().to_string_lossy(),
-            "Re-owning path to 0:0"
-        );
-
-        if let Err(e) = std::os::unix::fs::lchown(entry.path(), Some(0), Some(0)) {
-            tracing::warn!(
-                path = %entry.path().to_string_lossy(),
-                %e,
-                "Failed to set the owner:group to 0:0"
-            );
-        }
-    }
     Ok(())
 }


### PR DESCRIPTION
Some users are seeing installation failures because /nix/var has corrupted permissions.

I ran:

```
sudo chgrp 99 /nix/var
sudo chgrp -R 99 /nix/var/log
```

and made sure I had a profile directory:

![CleanShot 2024-12-04 at 16 06 28@2x](https://github.com/user-attachments/assets/50924ed2-18b3-4462-a415-42a0d8500893)


then got:

![CleanShot 2024-12-04 at 16 01 31@2x](https://github.com/user-attachments/assets/6d423e5e-3e34-4e8e-8f21-8bc267525b5f)

and confirmed my per-user directory was not changed.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
