### PR TITLE
Don't fail the install if marking a user on macOS is killed

### DIFF
--- a/src/action/base/create_user.rs
+++ b/src/action/base/create_user.rs
@@ -328,6 +328,14 @@ async fn create_user_macos(name: &str, uid: u32, gid: u32) -> Result<(), ActionE
         ".",
         "-create",
         &format!("/Users/{name}"),
+        "RealName",
+        name,
+    ])
+    .await?;
+    execute_dscl_retry_on_specific_errors(&[
+        ".",
+        "-create",
+        &format!("/Users/{name}"),
         "IsHidden",
         "1",
     ])
@@ -342,15 +350,6 @@ async fn create_user_macos(name: &str, uid: u32, gid: u32) -> Result<(), ActionE
 
         Err(e)
     })?;
-
-    execute_dscl_retry_on_specific_errors(&[
-        ".",
-        "-create",
-        &format!("/Users/{name}"),
-        "RealName",
-        name,
-    ])
-    .await?;
 
     Ok(())
 }

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -480,12 +480,12 @@ async fn check_suis() -> Result<(), PlannerError> {
             return Ok(());
         },
         [block] => format!(
-            "The following macOS configuration profile includes a 'Restrictions - Media' policy, which interferes with the Nix Store volume:\n\n{}\n\nSee https://determinate.systems/solutions/macos-internal-disk-policy",
+            "The following macOS configuration profile includes a 'Restrictions - Media' policy, which interferes with the Nix Store volume:\n\n{}\n\nSee https://dtr.mn/suis-premount-dissented",
             block
         ),
         blocks => {
             format!(
-                "The following macOS configuration profiles include a 'Restrictions - Media' policy, which interferes with the Nix Store volume:\n\n{}\n\nSee https://determinate.systems/solutions/macos-internal-disk-policy",
+                "The following macOS configuration profiles include a 'Restrictions - Media' policy, which interferes with the Nix Store volume:\n\n{}\n\nSee https://dtr.mn/suis-premount-dissented",
                 blocks.join("\n\n")
             )
         },


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
