### PR TITLE
ConfigureInitService: retry kickstart on macos

### DIFF
--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -279,16 +279,9 @@ impl Action for ConfigureInitService {
                 }
 
                 if *start_daemon {
-                    execute_command(
-                        Command::new("launchctl")
-                            .process_group(0)
-                            .arg("kickstart")
-                            .arg("-k")
-                            .arg(format!("{domain}/{service}"))
-                            .stdin(std::process::Stdio::null()),
-                    )
-                    .await
-                    .map_err(Self::error)?;
+                    crate::action::macos::retry_kickstart(domain, service)
+                        .await
+                        .map_err(Self::error)?;
                 }
             },
             InitSystem::Systemd => {

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -149,7 +149,7 @@ pub(crate) async fn wait_for_nix_store_dir() -> Result<(), ActionErrorKind> {
     Ok(())
 }
 
-/// Wait for `launchctl bootstrap {domain} {service}` to succeed up to `retry_tokens * 500ms` amount
+/// Wait for `launchctl bootstrap {domain} {service_path}` to succeed up to `retry_tokens * 500ms` amount
 /// of time.
 #[tracing::instrument]
 pub(crate) async fn retry_bootstrap(
@@ -205,7 +205,7 @@ pub(crate) async fn retry_bootstrap(
     Ok(())
 }
 
-/// Wait for `launchctl bootout {domain} {service_path}` to succeed up to `retry_tokens * 500ms` amount
+/// Wait for `launchctl bootout {domain}/{service_name}` to succeed up to `retry_tokens * 500ms` amount
 /// of time.
 #[tracing::instrument]
 pub(crate) async fn retry_bootout(domain: &str, service_name: &str) -> Result<(), ActionErrorKind> {

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -257,3 +257,43 @@ pub(crate) async fn retry_bootout(domain: &str, service_name: &str) -> Result<()
 
     Ok(())
 }
+
+/// Wait for `launchctl kickstart {domain}/{service_name}` to succeed up to `retry_tokens * 500ms` amount
+/// of time.
+#[tracing::instrument]
+pub(crate) async fn retry_kickstart(
+    domain: &str,
+    service_name: &str,
+) -> Result<(), ActionErrorKind> {
+    let service_identifier = [domain, service_name].join("/");
+
+    let mut retry_tokens: usize = 10;
+    loop {
+        let mut command = Command::new("launchctl");
+        command.process_group(0);
+        command.arg("kickstart");
+        command.arg("-k");
+        command.arg(&service_identifier);
+        command.stdin(std::process::Stdio::null());
+        command.stderr(std::process::Stdio::null());
+        command.stdout(std::process::Stdio::null());
+        tracing::debug!(%retry_tokens, command = ?command.as_std(), "Waiting for kickstart to succeed");
+
+        let output = command
+            .output()
+            .await
+            .map_err(|e| ActionErrorKind::command(&command, e))?;
+
+        if output.status.success() {
+            break;
+        } else if retry_tokens == 0 {
+            return Err(ActionErrorKind::command_output(&command, output))?;
+        } else {
+            retry_tokens = retry_tokens.saturating_sub(1);
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/1344.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
