### PR TITLE
Minor macOS fixups

### DIFF
--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -41,7 +41,7 @@ impl BootstrapLaunchctlService {
                 .await
                 .map_err(|e| Self::error(ActionErrorKind::command(&command, e)))?;
             // We presume that success means it's found
-            command_output.status.success() || command_output.status.code() == Some(37)
+            command_output.status.success()
         };
 
         let is_disabled = service_is_disabled(DARWIN_LAUNCHD_DOMAIN, &service)

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -19,6 +19,7 @@ use super::{
 };
 
 pub const NIX_VOLUME_MOUNTD_DEST: &str = "/Library/LaunchDaemons/org.nixos.darwin-store.plist";
+pub const NIX_VOLUME_MOUNTD_NAME: &str = "org.nixos.darwin-store";
 
 /// Create an APFS volume
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
@@ -88,7 +89,7 @@ impl CreateNixVolume {
 
         let setup_volume_daemon = CreateVolumeService::plan(
             NIX_VOLUME_MOUNTD_DEST,
-            "org.nixos.darwin-store",
+            NIX_VOLUME_MOUNTD_NAME,
             name.clone(),
             "/nix",
             encrypt,
@@ -97,11 +98,11 @@ impl CreateNixVolume {
         .map_err(Self::error)?;
 
         let bootstrap_volume =
-            BootstrapLaunchctlService::plan("org.nixos.darwin-store", NIX_VOLUME_MOUNTD_DEST)
+            BootstrapLaunchctlService::plan(NIX_VOLUME_MOUNTD_NAME, NIX_VOLUME_MOUNTD_DEST)
                 .await
                 .map_err(Self::error)?;
         let kickstart_launchctl_service =
-            KickstartLaunchctlService::plan(DARWIN_LAUNCHD_DOMAIN, "org.nixos.darwin-store")
+            KickstartLaunchctlService::plan(DARWIN_LAUNCHD_DOMAIN, NIX_VOLUME_MOUNTD_NAME)
                 .await
                 .map_err(Self::error)?;
         let enable_ownership = EnableOwnership::plan("/nix").await.map_err(Self::error)?;


### PR DESCRIPTION
##### Description

Extracted from https://github.com/DeterminateSystems/nix-installer/pull/1147. These changes don't change the receipt format and are thus safe to merge as-is without a minor version bump.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
