### PR TITLE
Persist files added to /etc past system updates for SteamOS 3.6+

### DIFF
--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -261,8 +261,7 @@ impl Planner for SteamDeck {
                 /etc/profile.d/nix.sh\n\
                 /etc/systemd/system/nix-daemon.socket\n\
                 /etc/tmpfiles.d/nix-daemon.conf\n\
-            ",
-                persistence = persistence.display(),
+                ",
             );
             let create_atomic_update_unit = CreateFile::plan(
                 "/etc/atomic-update.conf.d/nix.conf",
@@ -274,7 +273,7 @@ impl Planner for SteamDeck {
             )
             .await
             .map_err(PlannerError::Action)?;
-            actions.push(create_bind_mount_unit.boxed());
+            actions.push(create_atomic_update_unit.boxed());
         } else {
             let revert_clean_streamos_nix_offload = RevertCleanSteamosNixOffload::plan()
                 .await

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -254,10 +254,10 @@ impl Planner for SteamDeck {
             .map_err(PlannerError::Action)?;
             actions.push(create_bind_mount_unit.boxed());
         } else {
-            let revert_clean_streamos_nix_offload = RevertCleanSteamosNixOffload::plan()
+            let revert_clean_steamos_nix_offload = RevertCleanSteamosNixOffload::plan()
                 .await
                 .map_err(PlannerError::Action)?;
-            actions.push(revert_clean_streamos_nix_offload.boxed());
+            actions.push(revert_clean_steamos_nix_offload.boxed());
 
             let ensure_steamos_nix_directory = EnsureSteamosNixDirectory::plan()
                 .await

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -253,6 +253,28 @@ impl Planner for SteamDeck {
             .await
             .map_err(PlannerError::Action)?;
             actions.push(create_bind_mount_unit.boxed());
+
+            let create_atomic_update_buf = format!(
+                "\
+                /etc/fish/conf.d/nix.fish\n\
+                /etc/nix/**\n\
+                /etc/profile.d/nix.sh\n\
+                /etc/systemd/system/nix-daemon.socket\n\
+                /etc/tmpfiles.d/nix-daemon.conf\n\
+            ",
+                persistence = persistence.display(),
+            );
+            let create_atomic_update_unit = CreateFile::plan(
+                "/etc/atomic-update.conf.d/nix.conf",
+                None,
+                None,
+                0o0644,
+                create_atomic_update_buf,
+                false,
+            )
+            .await
+            .map_err(PlannerError::Action)?;
+            actions.push(create_bind_mount_unit.boxed());
         } else {
             let revert_clean_streamos_nix_offload = RevertCleanSteamosNixOffload::plan()
                 .await

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -253,27 +253,6 @@ impl Planner for SteamDeck {
             .await
             .map_err(PlannerError::Action)?;
             actions.push(create_bind_mount_unit.boxed());
-
-            let create_atomic_update_buf = format!(
-                "\
-                /etc/fish/conf.d/nix.fish\n\
-                /etc/nix/**\n\
-                /etc/profile.d/nix.sh\n\
-                /etc/systemd/system/nix-daemon.socket\n\
-                /etc/tmpfiles.d/nix-daemon.conf\n\
-                ",
-            );
-            let create_atomic_update_unit = CreateFile::plan(
-                "/etc/atomic-update.conf.d/nix.conf",
-                None,
-                None,
-                0o0644,
-                create_atomic_update_buf,
-                false,
-            )
-            .await
-            .map_err(PlannerError::Action)?;
-            actions.push(create_atomic_update_unit.boxed());
         } else {
             let revert_clean_streamos_nix_offload = RevertCleanSteamosNixOffload::plan()
                 .await
@@ -289,6 +268,27 @@ impl Planner for SteamDeck {
                 .await
                 .map_err(PlannerError::Action)?;
             actions.push(start_nix_mount.boxed());
+        }
+
+        if std::path::Path::new("/etc/atomic-update.conf.d").exists() {
+            let create_atomic_update_buf = "\
+                /etc/fish/conf.d/nix.fish\n\
+                /etc/nix/**\n\
+                /etc/profile.d/nix.sh\n\
+                /etc/systemd/system/nix-daemon.socket\n\
+                /etc/tmpfiles.d/nix-daemon.conf\n\
+            ";
+            let create_atomic_update_unit = CreateFile::plan(
+                "/etc/atomic-update.conf.d/nix-installer.conf",
+                None,
+                None,
+                0o0644,
+                create_atomic_update_buf.to_string(),
+                false,
+            )
+            .await
+            .map_err(PlannerError::Action)?;
+            actions.push(create_atomic_update_unit.boxed());
         }
 
         let ensure_symlinked_units_resolve_buf = "\

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -58,7 +58,7 @@
     {
       "action": {
         "action_name": "create_file",
-        "path": "/etc/atomic-update.conf.d/nix.conf",
+        "path": "/etc/atomic-update.conf.d/nix-installer.conf",
         "user": null,
         "group": null,
         "mode": 420,

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -57,6 +57,18 @@
     },
     {
       "action": {
+        "action_name": "create_file",
+        "path": "/etc/atomic-update.conf.d/nix.conf",
+        "user": null,
+        "group": null,
+        "mode": 420,
+        "buf": "/etc/fish/conf.d/nix.fish\n/etc/nix/**\n/etc/profile.d/nix.sh\n/etc/systemd/system/nix-daemon.socket\n/etc/tmpfiles.d/nix-daemon.conf\n",
+        "force": false
+      },
+      "state": "Completed"
+    },
+    {
+      "action": {
         "action_name": "start_systemd_unit",
         "unit": "nix.mount",
         "enable": false


### PR DESCRIPTION
##### Description

As of SteamOS 3.6, only files under `/etc` specifically allowed are persisted during system updates. 

The Determinate Systems installer has a Planner target for the Steam Deck, and performs the Nixpkgs setup as a multi-user installation. However, it does not currently create the allowlist needed for the install to survive system updates and breaks as a result.

This PR adds in this allowlist for the Determinate Systems installer as helpfully defined in [this comment on NixOS/nix#7173](https://github.com/NixOS/nix/issues/7173).

##### Checklist

- [x] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
