### PR TITLE
FH-533 Support `diskutil apfs list` not returning a FileVault attribute

### DIFF
--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -107,7 +107,7 @@ impl EncryptApfsVolume {
             plist::from_bytes(&output.stdout).map_err(Self::error)?;
         for container in parsed.containers {
             for volume in container.volumes {
-                if volume.name.as_ref() == Some(&name) && volume.file_vault {
+                if volume.name.as_ref() == Some(&name) && volume.file_vault.unwrap_or(false) {
                     return Ok(StatefulAction::completed(Self {
                         determinate_nix,
                         disk,

--- a/src/os/darwin/diskutil.rs
+++ b/src/os/darwin/diskutil.rs
@@ -56,7 +56,7 @@ pub struct DiskUtilApfsContainer {
 #[serde(rename_all = "PascalCase")]
 pub struct DiskUtilApfsListVolume {
     pub name: Option<String>,
-    pub file_vault: bool,
+    pub file_vault: Option<bool>,
 }
 
 #[derive(serde::Deserialize, Clone, Debug)]


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
