### PR TITLE
flake: migrate to crane, unpin Nixpkgs, use static builds on Darwin

### DIFF
--- a/.github/workflows/build-aarch64-darwin.yml
+++ b/.github/workflows/build-aarch64-darwin.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-aarch64-darwin:
-    name: Build aarch64 Darwin
+    name: Build aarch64 Darwin (static)
     runs-on: macos-latest-xlarge
     concurrency: ${{ inputs.cache-key }}
     permissions:
@@ -27,7 +27,7 @@ jobs:
           use-gha-cache: false
       - name: Build the installer
         run: |
-          nix build .#packages.aarch64-darwin.nix-installer -L
+          nix build .#packages.aarch64-darwin.nix-installer-static -L
           cp result/bin/nix-installer .
       - name: Create GitHub cache from build artifacts
         uses: actions/cache/save@v3

--- a/.github/workflows/build-x86_64-darwin.yml
+++ b/.github/workflows/build-x86_64-darwin.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-x86_64-darwin:
-    name: Build x86_64 Darwin
+    name: Build x86_64 Darwin (static)
     runs-on: macos-13-large
     concurrency: ${{ inputs.cache-key }}
     permissions:
@@ -27,7 +27,7 @@ jobs:
           use-gha-cache: false
       - name: Build the installer
         run: |
-          nix build .#packages.x86_64-darwin.nix-installer -L
+          nix build .#packages.x86_64-darwin.nix-installer-static -L
           cp result/bin/nix-installer .
       - name: Create GitHub cache from build artifacts
         uses: actions/cache/save@v3

--- a/flake.lock
+++ b/flake.lock
@@ -290,16 +290,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1730200266,
-        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
-        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
-        "revCount": 698755,
+        "lastModified": 1736344531,
+        "narHash": "sha256-8YVQ9ZbSfuUk2bUf2KRj60NRraLPKPS0Q4QFTbc+c2c=",
+        "rev": "bffc22eb12172e6db3c5dde9e3e5628f8e3e7912",
+        "revCount": 735357,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.698755%2Brev-807e9154dcb16384b1b765ebe9cd2bba2ac287fd/0192e144-1d3e-76b9-af9e-0f71e483f976/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.735357%2Brev-bffc22eb12172e6db3c5dde9e3e5628f8e3e7912/01944a39-fb6e-750e-bd59-7f4aea4c0739/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/%3D0.1.698755"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.tar.gz"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1734808813,
+        "narHash": "sha256-3aH/0Y6ajIlfy7j52FGZ+s4icVX0oHhqBzRdlOeztqg=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "72e2d02dbac80c8c86bf6bf3e785536acf8ee926",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.20.0",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "determinate": {
       "inputs": {
         "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
@@ -63,26 +79,6 @@
       "original": {
         "type": "file",
         "url": "https://install.determinate.systems/determinate-nixd/tag/v0.2.6/x86_64-linux"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1732689334,
-        "narHash": "sha256-yKI1KiZ0+bvDvfPTQ1ZT3oP/nIu3jPYm4dnbRd6hYg4=",
-        "rev": "a8a983027ca02b363dfc82fbe3f7d9548a8d3dce",
-        "revCount": 2090,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2090%2Brev-a8a983027ca02b363dfc82fbe3f7d9548a8d3dce/0193814c-7c19-7c1a-a29e-27c7d7c19316/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/nix-community/fenix/0.1.1584.tar.gz"
       }
     },
     "flake-compat": {
@@ -186,26 +182,6 @@
         "owner": "libgit2",
         "ref": "v1.8.1",
         "repo": "libgit2",
-        "type": "github"
-      }
-    },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733346208,
-        "narHash": "sha256-a4WZp1xQkrnA4BbnKrzJNr+dYoQr5Xneh2syJoddFyE=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "378614f37a6bee5a3f2ef4f825a73d948d3ae921",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
         "type": "github"
       }
     },
@@ -328,29 +304,11 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "determinate": "determinate",
-        "fenix": "fenix",
         "flake-compat": "flake-compat",
-        "naersk": "naersk",
         "nix": "nix",
         "nixpkgs": "nixpkgs_3"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1732633904,
-        "narHash": "sha256-7VKcoLug9nbAN2txqVksWHHJplqK9Ou8dXjIZAIYSGc=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "8d5e91c94f80c257ce6dbdfba7bd63a5e8a03fa6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -181,16 +181,9 @@
 
       packages = forAllSystems ({ system, pkgs, ... }:
         {
-          inherit (pkgs) nix-installer;
-        } // nixpkgs.lib.optionalAttrs (system == "x86_64-linux") {
-          inherit (pkgs) nix-installer-static;
-          default = pkgs.nix-installer-static;
-        } // nixpkgs.lib.optionalAttrs (system == "aarch64-linux") {
-          inherit (pkgs) nix-installer-static;
+          inherit (pkgs) nix-installer nix-installer-static;
           default = pkgs.nix-installer-static;
         } // nixpkgs.lib.optionalAttrs (pkgs.stdenv.isDarwin) {
-          default = pkgs.nix-installer;
-
           determinate-nixd = pkgs.runCommand "determinate-nixd-link" { } ''
             ln -s ${optionalPathToDeterminateNixd system} $out
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
 
       optionalPathToDeterminateNixd = system: if builtins.elem system systemsSupportedByDeterminateNixd then "${inputs.determinate.packages.${system}.default}/bin/determinate-nixd" else null;
 
-      installerPackage = { lib, pkgs, stdenv, buildPackages, darwin }:
+      installerPackage = { pkgs, stdenv, buildPackages }:
         let
           craneLib = crane.mkLib pkgs;
           sharedAttrs = {
@@ -65,12 +65,6 @@
 
             # Required to link build scripts.
             pkgsBuildBuild = [ buildPackages.stdenv.cc ];
-
-            nativeBuildInputs = [ ];
-            buildInputs = [ ] ++ lib.optionals (stdenv.isDarwin) (with darwin.apple_sdk.frameworks; [
-              SystemConfiguration
-              darwin.libiconv
-            ]);
 
             env = {
               # For whatever reason, these don’t seem to get set
@@ -139,11 +133,6 @@
               check.check-clippy
               editorconfig-checker
             ]
-            ++ lib.optionals (pkgs.stdenv.isDarwin) (with pkgs; [
-              libiconv
-              darwin.apple_sdk.frameworks.Security
-              darwin.apple_sdk.frameworks.SystemConfiguration
-            ])
             ++ lib.optionals (pkgs.stdenv.isLinux) (with pkgs; [
               checkpolicy
               semodule-utils

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   description = "The Determinate Nix Installer";
 
   inputs = {
-    # The very next version and beyond we get SIGBUS on uninstall
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/=0.1.698755";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.tar.gz";
 
     crane.url = "github:ipetkov/crane/v0.20.0";
 

--- a/flake.nix
+++ b/flake.nix
@@ -121,16 +121,14 @@
             '';
           };
         in
-        rec {
+        {
           nix-installer = naerskLib.buildPackage sharedAttrs;
-        } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "x86_64-linux") rec {
-          default = nix-installer-static;
+        } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "x86_64-linux") {
           nix-installer-static = naerskLib.buildPackage
             (sharedAttrs // {
               CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
             });
-        } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "aarch64-linux") rec {
-          default = nix-installer-static;
+        } // nixpkgs.lib.optionalAttrs (prev.stdenv.system == "aarch64-linux") {
           nix-installer-static = naerskLib.buildPackage
             (sharedAttrs // {
               CARGO_BUILD_TARGET = "aarch64-unknown-linux-musl";

--- a/flake.nix
+++ b/flake.nix
@@ -70,20 +70,21 @@
               SystemConfiguration
               final.darwin.libiconv
             ]);
-
-            RUSTFLAGS = "--cfg tokio_unstable";
-            cargoTestExtraArgs = "--all";
-
-            NIX_INSTALLER_TARBALL_PATH = nixTarballs.${final.stdenv.system};
-            DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd final.stdenv.system;
-
           };
           installerAttrs = sharedAttrs // {
             cargoArtifacts = craneLib.buildDepsOnly sharedAttrs;
 
+            cargoTestExtraArgs = "--all";
+
             postInstall = ''
               cp nix-installer.sh $out/bin/nix-installer.sh
             '';
+
+            env = {
+              RUSTFLAGS = "--cfg tokio_unstable";
+              NIX_INSTALLER_TARBALL_PATH = nixTarballs.${final.stdenv.system};
+              DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd final.stdenv.system;
+            };
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -59,8 +59,6 @@
         let
           craneLib = crane.mkLib final;
           sharedAttrs = {
-            pname = "nix-installer";
-            version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
             src = builtins.path {
               name = "nix-installer-source";
               path = self;

--- a/flake.nix
+++ b/flake.nix
@@ -81,10 +81,6 @@
           installerAttrs = sharedAttrs // {
             cargoArtifacts = craneLib.buildDepsOnly sharedAttrs;
 
-            preBuild = ''
-              # logRun "cargo clippy --all-targets --all-features -- -D warnings"
-            '';
-
             postInstall = ''
               cp nix-installer.sh $out/bin/nix-installer.sh
             '';

--- a/nix/check.nix
+++ b/nix/check.nix
@@ -1,4 +1,4 @@
-{ pkgs, toolchain }:
+{ pkgs }:
 
 let
   inherit (pkgs) writeShellApplication;
@@ -8,7 +8,7 @@ in
   # Format
   check-rustfmt = (writeShellApplication {
     name = "check-rustfmt";
-    runtimeInputs = [ toolchain ];
+    runtimeInputs = with pkgs; [ cargo rustfmt ];
     text = "cargo fmt --check";
   });
 


### PR DESCRIPTION
##### Description

This should fix the macOS uninstallation bug, as well as simplifying the flake and making the static builds more robust on all platforms. See the commit messages for details, justifications, and potential caveats.

---

**Note:** This work was funded by Determinate Systems.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check` *(minus `hydraJobs`, which looked like it’d take all year – caveat emptor)*
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
