### PR TITLE
ci: always validate that Release checks were successful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,7 @@ jobs:
     name: Run x86_64 Linux release checks
     runs-on: ubuntu-latest
     needs: [run-x86_64-linux-release-check-matrix]
-    if: contains(github.ref, 'release-') || contains(github.head_ref, 'release-')
+    if: (contains(github.ref, 'release-') || contains(github.head_ref, 'release-')) && always()
     steps:
       - run: "true"
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,7 +602,7 @@ jobs:
     name: Run x86_64 Linux release check matrix
     runs-on: UbuntuLatest64Cores256GX86
     needs: [lints, build-x86_64-linux]
-    if: contains(github.ref, 'release-') || contains(github.head_ref, 'release-')
+    if: startsWith(github.ref, 'release-') || startsWith(github.head_ref, 'release-')
     strategy:
       matrix:
         command:
@@ -642,7 +642,7 @@ jobs:
     name: Run x86_64 Linux release checks
     runs-on: ubuntu-latest
     needs: [run-x86_64-linux-release-check-matrix]
-    if: (contains(github.ref, 'release-') || contains(github.head_ref, 'release-')) && always()
+    if: (startsWith(github.ref, 'release-') || startsWith(github.head_ref, 'release-')) && always()
     steps:
       - run: "true"
       - run: |


### PR DESCRIPTION
When "needs" jobs fail, they'll make any jobs that depend on them be "skipped". "Skipped" jobs count as a success for the purposes of required checks. We always want this final step to run, even if the "needs" jobs failed (so that this "omnibus" check will halt merging if the "needs" jobs fail).

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
