### PR TITLE
Do not pass stdin to login shell in self_test

### DIFF
--- a/src/self_test.rs
+++ b/src/self_test.rs
@@ -114,6 +114,7 @@ impl Shell {
             "Testing Nix install via `{executable}`"
         );
         let output = command
+            .stdin(std::process::Stdio::null())
             .output()
             .await
             .map_err(|error| SelfTestError::Command {


### PR DESCRIPTION
##### Description

If `stdin` is `/dev/tty` -- such as when `nix-installer.sh` is piped into `sh` -- and one of the root user's login shell configuration files includes `mesg n` (as it does in Ubuntu 24.04), then running `bash -l` will modify the write permissions of `/dev/tty`.

Closes #1412.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check` (except hydraJobs because they freeze up my laptop)
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
