### PR TITLE
Always pass -a "${VOLUME}" and -s "Nix Store" to macOS volume stuff

### DIFF
--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -19,7 +19,7 @@ use crate::{
     execute_command,
 };
 
-use super::get_disk_info_for_label;
+use super::{get_disk_info_for_label, KEYCHAIN_NIX_STORE_SERVICE};
 
 /** Create a plist for a `launchctl` service to mount the given `apfs_volume_label` on the given `mount_point`.
  */
@@ -265,10 +265,11 @@ async fn generate_mount_plist(
     encrypt: bool,
 ) -> Result<LaunchctlMountPlist, ActionErrorKind> {
     let apfs_volume_label_with_quotes = format!("\"{apfs_volume_label}\"");
+    let nix_store_with_quotes = format!("\"{KEYCHAIN_NIX_STORE_SERVICE}\"");
     // The official Nix scripts uppercase the UUID, so we do as well for compatibility.
     let uuid_string = uuid.to_string().to_uppercase();
     let mount_command = if encrypt {
-        let encrypted_command = format!("/usr/bin/security find-generic-password -a {apfs_volume_label_with_quotes} -s \"Nix Store\" -w |  /usr/sbin/diskutil apfs unlockVolume {apfs_volume_label_with_quotes} -mountpoint {mount_point:?} -stdinpassphrase");
+        let encrypted_command = format!("/usr/bin/security find-generic-password -a {apfs_volume_label_with_quotes} -s {nix_store_with_quotes} -w | /usr/sbin/diskutil apfs unlockVolume {apfs_volume_label_with_quotes} -mountpoint {mount_point:?} -stdinpassphrase");
         vec!["/bin/sh".into(), "-c".into(), encrypted_command]
     } else {
         vec![

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -268,7 +268,7 @@ async fn generate_mount_plist(
     // The official Nix scripts uppercase the UUID, so we do as well for compatibility.
     let uuid_string = uuid.to_string().to_uppercase();
     let mount_command = if encrypt {
-        let encrypted_command = format!("/usr/bin/security find-generic-password -s {apfs_volume_label_with_quotes} -w |  /usr/sbin/diskutil apfs unlockVolume {apfs_volume_label_with_quotes} -mountpoint {mount_point:?} -stdinpassphrase");
+        let encrypted_command = format!("/usr/bin/security find-generic-password -a {apfs_volume_label_with_quotes} -s \"Nix Store\" -w |  /usr/sbin/diskutil apfs unlockVolume {apfs_volume_label_with_quotes} -mountpoint {mount_point:?} -stdinpassphrase");
         vec!["/bin/sh".into(), "-c".into(), encrypted_command]
     } else {
         vec![

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -16,7 +16,7 @@ use std::{
 use tokio::{io::AsyncWriteExt as _, process::Command};
 use tracing::{span, Span};
 
-use super::CreateApfsVolume;
+use super::{CreateApfsVolume, KEYCHAIN_NIX_STORE_SERVICE};
 
 /**
 Encrypt an APFS volume
@@ -44,7 +44,7 @@ impl EncryptApfsVolume {
         command.args(["find-generic-password", "-a"]);
         command.arg(&name);
         command.arg("-s");
-        command.arg("Nix Store");
+        command.arg(KEYCHAIN_NIX_STORE_SERVICE);
         command.arg("-l");
         command.arg(format!("{} encryption password", disk.display()));
         command.arg("-D");
@@ -207,7 +207,7 @@ impl Action for EncryptApfsVolume {
             "-a",
             self.name.as_str(),
             "-s",
-            "Nix Store",
+            KEYCHAIN_NIX_STORE_SERVICE,
             "-l",
             format!("{} encryption password", disk_str).as_str(),
             "-D",
@@ -324,7 +324,7 @@ impl Action for EncryptApfsVolume {
                 "-a",
                 self.name.as_str(),
                 "-s",
-                "Nix Store",
+                KEYCHAIN_NIX_STORE_SERVICE,
                 "-l",
                 format!("{} encryption password", disk_str).as_str(),
                 "-D",

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -324,7 +324,7 @@ impl Action for EncryptApfsVolume {
                 "-a",
                 self.name.as_str(),
                 "-s",
-                self.name.as_str(),
+                "Nix Store",
                 "-l",
                 format!("{} encryption password", disk_str).as_str(),
                 "-D",

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -45,6 +45,7 @@ use crate::execute_command;
 use super::ActionErrorKind;
 
 pub const DARWIN_LAUNCHD_DOMAIN: &str = "system";
+pub const KEYCHAIN_NIX_STORE_SERVICE: &str = "Nix Store";
 
 pub(crate) async fn get_disk_info_for_label(
     apfs_volume_label: &str,


### PR DESCRIPTION
`/usr/bin/security {add,find,delete}-generic-password` accepts both `-a account` and `-s service` parameters as password lookup keys. Always pass `-a "${VOLUME}"` and `-s "Nix Store"`. With this change, installation succeeds even with `--encrypt` set to `true` and `--volume-label` set to any value deviating from `Nix Store`.##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```

---

Closes https://github.com/DeterminateSystems/nix-installer/pull/1236.
Closes https://github.com/DeterminateSystems/nix-installer/pull/1317.
Closes https://github.com/DeterminateSystems/nix-installer/pull/1318.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1296.
Closes https://github.com/DeterminateSystems/nix-installer/issues/1381.

