### PR TITLE
fixup: don't fail when trying to remove a file that no longer exists in more places

### DIFF
--- a/src/action/base/create_or_insert_into_file.rs
+++ b/src/action/base/create_or_insert_into_file.rs
@@ -1,7 +1,8 @@
 use nix::unistd::{chown, Group, User};
 
-use crate::action::{
-    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+use crate::{
+    action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
+    util::OnMissing,
 };
 use rand::Rng;
 use std::{
@@ -10,7 +11,7 @@ use std::{
     path::{Path, PathBuf},
 };
 use tokio::{
-    fs::{remove_file, File, OpenOptions},
+    fs::{File, OpenOptions},
     io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
 };
 use tracing::{span, Span};
@@ -367,7 +368,7 @@ impl Action for CreateOrInsertIntoFile {
         }
 
         if file_contents.is_empty() {
-            remove_file(&path)
+            crate::util::remove_file(&path, OnMissing::Ignore)
                 .await
                 .map_err(|e| ActionErrorKind::Remove(path.to_owned(), e))
                 .map_err(Self::error)?;

--- a/src/action/base/create_or_merge_nix_config.rs
+++ b/src/action/base/create_or_merge_nix_config.rs
@@ -5,14 +5,12 @@ use std::{
 
 use nix_config_parser::NixConfig;
 use rand::Rng;
-use tokio::{
-    fs::{remove_file, OpenOptions},
-    io::AsyncWriteExt,
-};
+use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 use tracing::{span, Span};
 
-use crate::action::{
-    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+use crate::{
+    action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
+    util::OnMissing,
 };
 
 pub(crate) const TRUSTED_USERS_CONF_NAME: &str = "trusted-users";
@@ -457,7 +455,7 @@ impl Action for CreateOrMergeNixConfig {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        remove_file(&self.path)
+        crate::util::remove_file(&self.path, OnMissing::Ignore)
             .await
             .map_err(|e| Self::error(ActionErrorKind::Remove(self.path.to_owned(), e)))?;
 

--- a/src/action/macos/create_determinate_volume_service.rs
+++ b/src/action/macos/create_determinate_volume_service.rs
@@ -5,15 +5,12 @@ use std::{
     path::{Path, PathBuf},
     process::Stdio,
 };
-use tokio::{
-    fs::{remove_file, OpenOptions},
-    io::AsyncWriteExt,
-    process::Command,
-};
+use tokio::{fs::OpenOptions, io::AsyncWriteExt, process::Command};
 
 use crate::{
     action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
     execute_command,
+    util::OnMissing,
 };
 
 use super::DARWIN_LAUNCHD_DOMAIN;
@@ -178,7 +175,7 @@ impl Action for CreateDeterminateVolumeService {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        remove_file(&self.path)
+        crate::util::remove_file(&self.path, OnMissing::Ignore)
             .await
             .map_err(|e| Self::error(ActionErrorKind::Remove(self.path.to_owned(), e)))?;
 

--- a/src/action/macos/create_nix_hook_service.rs
+++ b/src/action/macos/create_nix_hook_service.rs
@@ -2,15 +2,12 @@ use serde::{Deserialize, Serialize};
 use tracing::{span, Span};
 
 use std::{path::PathBuf, process::Stdio};
-use tokio::{
-    fs::{remove_file, OpenOptions},
-    io::AsyncWriteExt,
-    process::Command,
-};
+use tokio::{fs::OpenOptions, io::AsyncWriteExt, process::Command};
 
 use crate::{
     action::{Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction},
     execute_command,
+    util::OnMissing,
 };
 
 use super::DARWIN_LAUNCHD_DOMAIN;
@@ -159,7 +156,7 @@ impl Action for CreateNixHookService {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        remove_file(&self.path)
+        crate::util::remove_file(&self.path, OnMissing::Ignore)
             .await
             .map_err(|e| Self::error(ActionErrorKind::Remove(self.path.to_owned(), e)))?;
 

--- a/src/action/macos/create_volume_service.rs
+++ b/src/action/macos/create_volume_service.rs
@@ -5,11 +5,7 @@ use std::{
     path::{Path, PathBuf},
     process::Stdio,
 };
-use tokio::{
-    fs::{remove_file, OpenOptions},
-    io::AsyncWriteExt,
-    process::Command,
-};
+use tokio::{fs::OpenOptions, io::AsyncWriteExt, process::Command};
 
 use crate::{
     action::{
@@ -17,6 +13,7 @@ use crate::{
         ActionTag, StatefulAction,
     },
     execute_command,
+    util::OnMissing,
 };
 
 use super::get_disk_info_for_label;
@@ -248,7 +245,7 @@ impl Action for CreateVolumeService {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        remove_file(&self.path)
+        crate::util::remove_file(&self.path, OnMissing::Ignore)
             .await
             .map_err(|e| Self::error(ActionErrorKind::Remove(self.path.to_owned(), e)))?;
 


### PR DESCRIPTION
##### Description

Closes https://github.com/DeterminateSystems/nix-installer/issues/1402.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
