### PR TITLE
CreateOrInsertIntoFile: create parent dir if nonexistent

### DIFF
--- a/src/action/base/create_or_insert_into_file.rs
+++ b/src/action/base/create_or_insert_into_file.rs
@@ -203,6 +203,13 @@ impl Action for CreateOrInsertIntoFile {
         // that the final file goes in, so that we can rename it
         // atomically
         let parent_dir = path.parent().expect("File must be in a directory");
+        if !parent_dir.exists() {
+            tokio::fs::create_dir_all(&parent_dir)
+                .await
+                .map_err(|e| ActionErrorKind::CreateDirectory(parent_dir.to_owned(), e))
+                .map_err(Self::error)?;
+        }
+
         let mut temp_file_path = parent_dir.to_owned();
         {
             let mut rng = rand::thread_rng();


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
