### PR TITLE
repair sequoia: sort group members by the numbers in their name

### DIFF
--- a/src/cli/subcommand/repair.rs
+++ b/src/cli/subcommand/repair.rs
@@ -272,8 +272,33 @@ impl CommandExecute for Repair {
                     group_plist
                 };
 
-                let expected_users = group_plist
-                    .group_membership
+                let mut group_members = group_plist.group_membership;
+                group_members.sort_by(|a, b| {
+                    let a = a
+                        .trim_start_matches(|c: char| !c.is_numeric())
+                        .parse::<u32>()
+                        .unwrap_or_else(|_| {
+                            tracing::warn!(
+                                member = a,
+                                "Group member had no numbers in their name?"
+                            );
+                            0
+                        });
+                    let b = b
+                        .trim_start_matches(|c: char| !c.is_numeric())
+                        .parse::<u32>()
+                        .unwrap_or_else(|_| {
+                            tracing::warn!(
+                                member = b,
+                                "Group member had no numbers in their name?"
+                            );
+                            0
+                        });
+
+                    a.cmp(&b)
+                });
+
+                let expected_users = group_members
                     .into_iter()
                     .enumerate()
                     .map(|(idx, name)| ((idx + 1) as u32, name))


### PR DESCRIPTION
It's possbile that the output of the dscl command has the group members out-of-order.

##### Description

Fixes https://github.com/DeterminateSystems/nix-installer/issues/1447.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
