### PR TITLE
nix-installer: Fixup propose-release: explicitly set version in the fixtures

### DIFF
--- a/.github/workflows/propose-release.yml
+++ b/.github/workflows/propose-release.yml
@@ -28,7 +28,7 @@ jobs:
       extra-commands-early: |
         for fname in $(find ./tests/fixtures -name '*.json'); do
           cat "$fname" \
-            | jq '.version = $version' --arg version "$version" \
+            | jq '.version = $version' --arg version "${{ inputs.version }}" \
             > "$fname.next"
           mv "$fname.next" "$fname"
           git add "$fname"


### PR DESCRIPTION
##### Description

d'oh.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
