### PR TITLE
Go faster (use namespace macos runners)

### DIFF
--- a/.github/workflows/build-aarch64-darwin.yml
+++ b/.github/workflows/build-aarch64-darwin.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-aarch64-darwin:
     name: Build aarch64 Darwin (static)
-    runs-on: macos-latest-xlarge
+    runs-on: namespace-profile-mac-m2-12c28g
     concurrency: ${{ inputs.cache-key }}
     permissions:
       id-token: "write"

--- a/.github/workflows/build-x86_64-darwin.yml
+++ b/.github/workflows/build-x86_64-darwin.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-x86_64-darwin:
     name: Build x86_64 Darwin (static)
-    runs-on: macos-13-large
+    runs-on: namespace-profile-mac-m2-12c28g
     concurrency: ${{ inputs.cache-key }}
     permissions:
       id-token: "write"


### PR DESCRIPTION
##### Description

Note I intentionally leave the "Run" checks phase to use the GH macs, to be certain they work on GH macs.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
