### PR TITLE
Graham/fh 638 determinate nix in nix installer

### DIFF
--- a/.github/workflows/propose-release.yml
+++ b/.github/workflows/propose-release.yml
@@ -7,7 +7,7 @@ on:
       version:
         type: string
         required: true
-      nix-version:
+      determinate-nix-version:
         type: string
         required: true
 
@@ -35,6 +35,6 @@ jobs:
         done
         git commit -m "Update test fixtures with the new nix-installer version" || true
 
-        sed -i 's#https://flakehub.com/f/DeterminateSystems/nix/=.*";#https://flakehub.com/f/DeterminateSystems/nix/=${{ inputs.nix-version }}";#' ./flake.nix
+        sed -i 's#https://flakehub.com/f/DeterminateSystems/nix-src/=.*";#https://flakehub.com/f/DeterminateSystems/nix-src/=${{ inputs.determinate-nix-version }}";#' ./flake.nix
         git add flake.nix
-        git commit -m "Update Nix release to ${{ inputs.nix-version }}" || true
+        git commit -m "Update Determinate Nix release to ${{ inputs.determinate-nix-version }}" || true

--- a/flake.lock
+++ b/flake.lock
@@ -173,16 +173,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1740619588,
-        "narHash": "sha256-37Ik5iZ3sdzQUvN2Yfzs/0bnMQfPKZHOsj+Z4DPtSMM=",
-        "rev": "1b00094110a60b45070f3cb0bdaa2e8dcccaaadd",
-        "revCount": 19477,
+        "lastModified": 1741200539,
+        "narHash": "sha256-RMjfUd6iyKhZVe53VEY6+Q+6F55x+1Y+J4kDu2NoNgU=",
+        "rev": "ad264674e6e65d653d95ef97e1678c1a95594b78",
+        "revCount": 19492,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-priv/0.38.1/01954516-d627-74ad-86ab-bd2a81023555/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.0.0/019567bb-bf5a-729e-87f6-b10e7a3346fd/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/nix-priv/%2A"
+        "url": "https://flakehub.com/f/DeterminateSystems/nix-src/%2A"
       }
     },
     "nixpkgs": {

--- a/flake.lock
+++ b/flake.lock
@@ -115,7 +115,6 @@
       "inputs": {
         "nixpkgs-lib": [
           "nix",
-          "nix",
           "nixpkgs"
         ]
       },
@@ -136,20 +135,16 @@
     "git-hooks-nix": {
       "inputs": {
         "flake-compat": [
-          "nix",
           "nix"
         ],
         "gitignore": [
-          "nix",
           "nix"
         ],
         "nixpkgs": [
           "nix",
-          "nix",
           "nixpkgs"
         ],
         "nixpkgs-stable": [
-          "nix",
           "nix",
           "nixpkgs"
         ]
@@ -170,24 +165,6 @@
     },
     "nix": {
       "inputs": {
-        "nix": "nix_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1739472715,
-        "narHash": "sha256-FgYKJpZ968mt6J3u24Z5BF6NFOnywXXA+oyYdSG7eZQ=",
-        "rev": "863dd700c8dc95659f02f79b58d6b9f742e268b1",
-        "revCount": 121,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix/2.26.2/019500b6-1e78-7abd-add4-156f5b16305b/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/nix/%3D2.26.2"
-      }
-    },
-    "nix_2": {
-      "inputs": {
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
@@ -196,16 +173,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1739376598,
-        "narHash": "sha256-EOnBPe+ydQ0/P5ZyWnFekvpyUxMcmh2rnP9yNFi/EqU=",
-        "rev": "b3e92048335d88553c1d6bbcf280e95b9a1b5a75",
-        "revCount": 19173,
+        "lastModified": 1740619588,
+        "narHash": "sha256-37Ik5iZ3sdzQUvN2Yfzs/0bnMQfPKZHOsj+Z4DPtSMM=",
+        "rev": "1b00094110a60b45070f3cb0bdaa2e8dcccaaadd",
+        "revCount": 19477,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.26.2/0194fbd7-e2ec-7193-93a9-05ae757e79a1/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-priv/0.38.1/01954516-d627-74ad-86ab-bd2a81023555/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nix/%3D2.26.2"
+        "url": "https://flakehub.com/f/DeterminateSystems/nix-priv/%2A"
       }
     },
     "nixpkgs": {
@@ -258,26 +235,12 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1737569578,
-        "narHash": "sha256-6qY0pk2QmUtBT9Mywdvif0i/CLVgpCjMUn6g9vB+f3M=",
-        "rev": "47addd76727f42d351590c905d9d1905ca895b82",
-        "revCount": 713515,
+        "lastModified": 1740828860,
+        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
+        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
+        "revCount": 761040,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.713515%2Brev-47addd76727f42d351590c905d9d1905ca895b82/019492a5-b67d-7a0e-b59f-a5e554d48a53/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
-        "revCount": 758135,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.758135%2Brev-0196c0175e9191c474c26ab5548db27ef5d34b05/01953839-1448-7ac9-964f-d8908c675395/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.761040%2Brev-303bd8071377433a2d8f76e684ec773d70c5b642/01955708-d762-7dc9-81c4-f4d96f66e256/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -290,7 +253,7 @@
         "determinate": "determinate",
         "flake-compat": "flake-compat",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     crane.url = "github:ipetkov/crane/v0.20.0";
 
     nix = {
-      url = "https://flakehub.com/f/DeterminateSystems/nix/=2.26.2";
+      url = "https://flakehub.com/f/DeterminateSystems/nix-priv/*";
       # Omitting `inputs.nixpkgs.follows = "nixpkgs";` on purpose
     };
 
@@ -49,7 +49,7 @@
 
       nixTarballs = forAllSystems ({ system, ... }:
         inputs.nix.tarballs_direct.${system}
-          or "${inputs.nix.checks."${system}".binaryTarball}/nix-${inputs.nix.packages."${system}".default.version}-${system}.tar.xz");
+          or "${inputs.nix.packages."${system}".binaryTarball}/nix-${inputs.nix.packages."${system}".default.version}-${system}.tar.xz");
 
       optionalPathToDeterminateNixd = system: if builtins.elem system systemsSupportedByDeterminateNixd then "${inputs.determinate.packages.${system}.default}/bin/determinate-nixd" else null;
 
@@ -109,7 +109,7 @@
             name = "nix-install-shell";
 
             RUST_SRC_PATH = "${pkgs.rustPlatform.rustcSrc}/library";
-            NIX_TARBALL_URL = "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-${stdenv.hostPlatform.system}.tar.xz";
+            NIX_TARBALL_URL = "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-${pkgs.stdenv.hostPlatform.system}.tar.xz";
             DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd system;
 

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,7 @@
             name = "nix-install-shell";
 
             RUST_SRC_PATH = "${pkgs.rustPlatform.rustcSrc}/library";
+            NIX_TARBALL_URL = "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-${stdenv.hostPlatform.system}.tar.xz";
             DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd system;
 

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,7 @@
 
           env = sharedAttrs.env // {
             RUSTFLAGS = "--cfg tokio_unstable";
+            NIX_TARBALL_URL = "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-${pkgs.stdenv.hostPlatform.system}.tar.xz";
             DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${stdenv.hostPlatform.system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd stdenv.hostPlatform.system;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
 
           env = sharedAttrs.env // {
             RUSTFLAGS = "--cfg tokio_unstable";
-            NIX_INSTALLER_TARBALL_PATH = nixTarballs.${stdenv.hostPlatform.system};
+            DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${stdenv.hostPlatform.system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd stdenv.hostPlatform.system;
           };
         });
@@ -109,7 +109,7 @@
             name = "nix-install-shell";
 
             RUST_SRC_PATH = "${pkgs.rustPlatform.rustcSrc}/library";
-            NIX_INSTALLER_TARBALL_PATH = nixTarballs.${system};
+            DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd system;
 
             nativeBuildInputs = with pkgs; [ ];

--- a/flake.nix
+++ b/flake.nix
@@ -89,7 +89,7 @@
 
           env = sharedAttrs.env // {
             RUSTFLAGS = "--cfg tokio_unstable";
-            DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${stdenv.hostPlatform.system};
+            NIX_INSTALLER_TARBALL_PATH = nixTarballs.${stdenv.hostPlatform.system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd stdenv.hostPlatform.system;
           };
         });
@@ -109,7 +109,7 @@
             name = "nix-install-shell";
 
             RUST_SRC_PATH = "${pkgs.rustPlatform.rustcSrc}/library";
-            DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${system};
+            NIX_INSTALLER_TARBALL_PATH = nixTarballs.${system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd system;
 
             nativeBuildInputs = with pkgs; [ ];

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     crane.url = "github:ipetkov/crane/v0.20.0";
 
     nix = {
-      url = "https://flakehub.com/f/DeterminateSystems/nix-priv/*";
+      url = "https://flakehub.com/f/DeterminateSystems/nix-src/*";
       # Omitting `inputs.nixpkgs.follows = "nixpkgs";` on purpose
     };
 

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -54,7 +54,7 @@ impl ConfigureNix {
                     settings.ssl_cert_file.clone(),
                     settings.extra_conf.clone(),
                     settings.force,
-                    settings.determinate_nix,
+                    settings.distribution(),
                 )
                 .await
                 .map_err(Self::error)?,

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -56,14 +56,14 @@ impl PlaceNixConfiguration {
             target_lexicon::OperatingSystem::MacOSX { .. }
                 | target_lexicon::OperatingSystem::Darwin
         );
-        let configured_ssl_cert_file = if distribution == Distribution::Determinate && is_macos {
+        let configured_ssl_cert_file = if distribution == Distribution::DeterminateNix && is_macos {
             // On macOS, determinate-nixd will handle configuring the ssl-cert-file option for Nix
             None
         } else {
             ssl_cert_file
         };
 
-        let standard_nix_config = if distribution != Distribution::Determinate {
+        let standard_nix_config = if distribution != Distribution::DeterminateNix {
             let maybe_trusted_users = extra_conf.settings().get(TRUSTED_USERS_CONF_NAME);
 
             Some(Self::setup_standard_config(maybe_trusted_users).await?)

--- a/src/action/common/provision_determinate_nixd.rs
+++ b/src/action/common/provision_determinate_nixd.rs
@@ -23,7 +23,7 @@ pub struct ProvisionDeterminateNixd {
 impl ProvisionDeterminateNixd {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan() -> Result<StatefulAction<Self>, ActionError> {
-        crate::settings::DETERMINATE_NIXD_BINARY
+        crate::distribution::DETERMINATE_NIXD_BINARY
             .ok_or_else(|| Self::error(ActionErrorKind::DeterminateNixUnavailable))?;
 
         let this = Self {
@@ -61,7 +61,7 @@ impl Action for ProvisionDeterminateNixd {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
-        let bytes = crate::settings::DETERMINATE_NIXD_BINARY
+        let bytes = crate::distribution::DETERMINATE_NIXD_BINARY
             .ok_or_else(|| Self::error(ActionErrorKind::DeterminateNixUnavailable))?;
 
         crate::util::remove_file(&self.binary_location, OnMissing::Ignore)

--- a/src/action/common/provision_nix.rs
+++ b/src/action/common/provision_nix.rs
@@ -30,6 +30,7 @@ impl ProvisionNix {
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn plan(settings: &CommonSettings) -> Result<StatefulAction<Self>, ActionError> {
         let fetch_nix = FetchAndUnpackNix::plan(
+            settings.distribution(),
             settings.nix_package_url.clone(),
             PathBuf::from(SCRATCH_DIR),
             settings.proxy.clone(),

--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -7,9 +7,6 @@ use tokio::process::Command;
 use tracing::{span, Span};
 
 use super::{create_fstab_entry::CreateFstabEntry, DARWIN_LAUNCHD_DOMAIN};
-use crate::action::macos::{
-    BootstrapLaunchctlService, CreateDeterminateVolumeService, KickstartLaunchctlService,
-};
 use crate::action::{
     base::{create_or_insert_into_file, CreateDirectory, CreateOrInsertIntoFile},
     common::place_nix_configuration::NIX_CONF_FOLDER,
@@ -18,6 +15,12 @@ use crate::action::{
         UnmountApfsVolume,
     },
     Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
+use crate::{
+    action::macos::{
+        BootstrapLaunchctlService, CreateDeterminateVolumeService, KickstartLaunchctlService,
+    },
+    distribution::Distribution,
 };
 
 pub const VOLUME_MOUNT_SERVICE_NAME: &str = "systems.determinate.nix-store";
@@ -90,7 +93,8 @@ impl CreateDeterminateNixVolume {
             .await
             .map_err(Self::error)?;
 
-        let encrypt_volume = EncryptApfsVolume::plan(true, disk, &name, &create_volume).await?;
+        let encrypt_volume =
+            EncryptApfsVolume::plan(Distribution::Determinate, disk, &name, &create_volume).await?;
 
         let setup_volume_daemon = CreateDeterminateVolumeService::plan(
             VOLUME_MOUNT_SERVICE_DEST,

--- a/src/action/macos/create_determinate_nix_volume.rs
+++ b/src/action/macos/create_determinate_nix_volume.rs
@@ -94,7 +94,8 @@ impl CreateDeterminateNixVolume {
             .map_err(Self::error)?;
 
         let encrypt_volume =
-            EncryptApfsVolume::plan(Distribution::Determinate, disk, &name, &create_volume).await?;
+            EncryptApfsVolume::plan(Distribution::DeterminateNix, disk, &name, &create_volume)
+                .await?;
 
         let setup_volume_daemon = CreateDeterminateVolumeService::plan(
             VOLUME_MOUNT_SERVICE_DEST,

--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -1,10 +1,13 @@
-use crate::action::{
-    base::{create_or_insert_into_file, CreateOrInsertIntoFile},
-    macos::{
-        BootstrapLaunchctlService, CreateApfsVolume, CreateSyntheticObjects, EnableOwnership,
-        EncryptApfsVolume, UnmountApfsVolume,
+use crate::{
+    action::{
+        base::{create_or_insert_into_file, CreateOrInsertIntoFile},
+        macos::{
+            BootstrapLaunchctlService, CreateApfsVolume, CreateSyntheticObjects, EnableOwnership,
+            EncryptApfsVolume, UnmountApfsVolume,
+        },
+        Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
     },
-    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+    distribution::Distribution,
 };
 use std::{
     path::{Path, PathBuf},
@@ -48,6 +51,7 @@ impl CreateNixVolume {
         name: String,
         case_sensitive: bool,
         encrypt: bool,
+        distribution: Distribution,
     ) -> Result<StatefulAction<Self>, ActionError> {
         let disk = disk.as_ref();
         let create_or_append_synthetic_conf = CreateOrInsertIntoFile::plan(
@@ -82,7 +86,7 @@ impl CreateNixVolume {
             .map_err(Self::error)?;
 
         let encrypt_volume = if encrypt {
-            Some(EncryptApfsVolume::plan(false, disk, &name, &create_volume).await?)
+            Some(EncryptApfsVolume::plan(distribution, disk, &name, &create_volume).await?)
         } else {
             None
         };

--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -226,7 +226,7 @@ impl Action for EncryptApfsVolume {
             "/usr/bin/security",
         ]);
 
-        if self.distribution == Distribution::Determinate {
+        if self.distribution == Distribution::DeterminateNix {
             cmd.args(["-T", "/usr/local/bin/determinate-nixd"]);
         }
 

--- a/src/cli/subcommand/install/determinate.rs
+++ b/src/cli/subcommand/install/determinate.rs
@@ -8,6 +8,12 @@ use crate::planner::BuiltinPlanner;
 
 const PRE_PKG_SUGGEST: &str = "For a more robust Nix installation, use the Determinate package for macOS: https://dtr.mn/determinate-nix";
 
+const INSTALL_DETERMINATE_NIX_PROMPT: &str = "\
+Install Determinate Nix?\
+\
+Selecting 'no' will install Nix from NixOS.org, without automated garbage collection and enterprise certificate support.\
+";
+
 const DETERMINATE_MSG_EXPLAINER: &str = "\
 Determinate Nix is Determinate Systems' validated and secure downstream Nix distribution for enterprises. \
 It comes bundled with Determinate Nixd, a helpful daemon that automates some otherwise-unpleasant aspects of using Nix, such as garbage collection, and enables you to easily authenticate with FlakeHub.
@@ -39,7 +45,7 @@ pub(crate) async fn prompt_for_determinate<T: Feedback>(
         let base_prompt = feedback
             .get_feature_ptr_payload::<String>("dni-det-msg-interactive-prompt-ptr")
             .await
-            .unwrap_or("Install Determinate Nix?".into());
+            .unwrap_or(INSTALL_DETERMINATE_NIX_PROMPT.into());
 
         let mut explanation: Option<String> = None;
 

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -1,0 +1,5 @@
+#[derive(Copy, Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum Distribution {
+    Nix,
+    Determinate,
+}

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -1,5 +1,64 @@
+use std::str::FromStr;
+
+use crate::settings::UrlOrPath;
+
 #[derive(Copy, Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Distribution {
     Nix,
     Determinate,
 }
+
+impl Distribution {
+    pub fn tarball_location_or(&self, user_preference: &Option<UrlOrPath>) -> TarballLocation {
+        if let Some(pref) = user_preference {
+            return TarballLocation::UrlOrPath(pref.clone());
+        }
+
+        self.tarball_location()
+    }
+
+    pub fn tarball_location(&self) -> TarballLocation {
+        match self {
+            Distribution::Nix => TarballLocation::UrlOrPath(
+                UrlOrPath::from_str(NIX_TARBALL_URL)
+                    .expect("Fault: the built-in Nix tarball URL does not parse."),
+            ),
+            Distribution::Determinate => {
+                TarballLocation::InMemory(
+                    DETERMINATE_NIX_TARBALL_PATH.expect("Fault: this build of Determinate Nix Installer is not equipped to install Determinate Nix."),
+                    DETERMINATE_NIX_TARBALL.expect("Fault: this build of Determinate Nix Installer is not equipped to install Determinate Nix.")
+                )
+            },
+        }
+    }
+}
+
+pub enum TarballLocation {
+    UrlOrPath(UrlOrPath),
+    InMemory(&'static str, &'static [u8]),
+}
+
+pub const NIX_TARBALL_URL: &str = Some(env!("NIX_TARBALL_URL"));
+
+#[cfg(feature = "determinate-nix")]
+pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = Some(env!("DETERMINATE_NIX_TARBALL_PATH"));
+#[cfg(feature = "determinate-nix")]
+/// The DETERMINATE_NIX_TARBALL environment variable should point to a target-appropriate
+/// Determinate Nix installation tarball, like determinate-nix-2.21.2-aarch64-darwin.tar.xz.
+/// The contents are embedded in the resulting binary.
+pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> =
+    Some(include_bytes!(env!("DETERMINATE_NIX_TARBALL_PATH")));
+
+#[cfg(feature = "determinate-nix")]
+/// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
+/// static build of the Determinate Nixd binary. The contents are embedded in the resulting
+/// binary if the determinate-nix feature is turned on.
+pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> =
+    Some(include_bytes!(env!("DETERMINATE_NIXD_BINARY_PATH")));
+
+#[cfg(not(feature = "determinate-nix"))]
+pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> = None;
+#[cfg(not(feature = "determinate-nix"))]
+pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> = None;
+#[cfg(not(feature = "determinate-nix"))]
+pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = None;

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -38,7 +38,7 @@ pub enum TarballLocation {
     InMemory(&'static str, &'static [u8]),
 }
 
-pub const NIX_TARBALL_URL: &str = Some(env!("NIX_TARBALL_URL"));
+pub const NIX_TARBALL_URL: &str = env!("NIX_TARBALL_URL");
 
 #[cfg(feature = "determinate-nix")]
 pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = Some(env!("DETERMINATE_NIX_TARBALL_PATH"));

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -5,7 +5,7 @@ use crate::settings::UrlOrPath;
 #[derive(Copy, Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Distribution {
     Nix,
-    Determinate,
+    DeterminateNix,
 }
 
 impl Distribution {
@@ -23,7 +23,7 @@ impl Distribution {
                 UrlOrPath::from_str(NIX_TARBALL_URL)
                     .expect("Fault: the built-in Nix tarball URL does not parse."),
             ),
-            Distribution::Determinate => {
+            Distribution::DeterminateNix => {
                 TarballLocation::InMemory(
                     DETERMINATE_NIX_TARBALL_PATH.expect("Fault: this build of Determinate Nix Installer is not equipped to install Determinate Nix."),
                     DETERMINATE_NIX_TARBALL.expect("Fault: this build of Determinate Nix Installer is not equipped to install Determinate Nix.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod action;
 pub mod cli;
 #[cfg(feature = "diagnostics")]
 pub mod diagnostics;
+mod distribution;
 mod error;
 pub mod feedback;
 mod nixenv;

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -58,7 +58,7 @@ impl Planner for Linux {
                 .boxed(),
         );
 
-        if self.settings.distribution() == Distribution::Determinate {
+        if self.settings.distribution() == Distribution::DeterminateNix {
             plan.push(
                 ProvisionDeterminateNixd::plan()
                     .await
@@ -91,7 +91,7 @@ impl Planner for Linux {
                 ProvisionSelinux::plan(
                     FHS_SELINUX_POLICY_PATH.into(),
                     match self.settings.distribution() {
-                        Distribution::Determinate => DETERMINATE_SELINUX_POLICY_PP_CONTENT,
+                        Distribution::DeterminateNix => DETERMINATE_SELINUX_POLICY_PP_CONTENT,
                         Distribution::Nix => SELINUX_POLICY_PP_CONTENT,
                     },
                 )
@@ -109,7 +109,7 @@ impl Planner for Linux {
         );
 
         match self.settings.distribution() {
-            Distribution::Determinate => {
+            Distribution::DeterminateNix => {
                 plan.push(
                     ConfigureDeterminateNixdInitService::plan(
                         self.init.init,

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -17,6 +17,7 @@ use crate::{
         },
         StatefulAction,
     },
+    distribution::Distribution,
     error::HasExpectedErrors,
     planner::{Planner, PlannerError},
     settings::{CommonSettings, InitSettings, InitSystem, InstallSettingsError},
@@ -57,7 +58,7 @@ impl Planner for Linux {
                 .boxed(),
         );
 
-        if self.settings.determinate_nix {
+        if self.settings.distribution() == Distribution::Determinate {
             plan.push(
                 ProvisionDeterminateNixd::plan()
                     .await
@@ -89,10 +90,9 @@ impl Planner for Linux {
             plan.push(
                 ProvisionSelinux::plan(
                     FHS_SELINUX_POLICY_PATH.into(),
-                    if self.settings.determinate_nix {
-                        DETERMINATE_SELINUX_POLICY_PP_CONTENT
-                    } else {
-                        SELINUX_POLICY_PP_CONTENT
+                    match self.settings.distribution() {
+                        Distribution::Determinate => DETERMINATE_SELINUX_POLICY_PP_CONTENT,
+                        Distribution::Nix => SELINUX_POLICY_PP_CONTENT,
                     },
                 )
                 .await
@@ -108,20 +108,26 @@ impl Planner for Linux {
                 .boxed(),
         );
 
-        if self.settings.determinate_nix {
-            plan.push(
-                ConfigureDeterminateNixdInitService::plan(self.init.init, self.init.start_daemon)
+        match self.settings.distribution() {
+            Distribution::Determinate => {
+                plan.push(
+                    ConfigureDeterminateNixdInitService::plan(
+                        self.init.init,
+                        self.init.start_daemon,
+                    )
                     .await
                     .map_err(PlannerError::Action)?
                     .boxed(),
-            );
-        } else {
-            plan.push(
-                ConfigureUpstreamInitService::plan(self.init.init, self.init.start_daemon)
-                    .await
-                    .map_err(PlannerError::Action)?
-                    .boxed(),
-            );
+                );
+            },
+            Distribution::Nix => {
+                plan.push(
+                    ConfigureUpstreamInitService::plan(self.init.init, self.init.start_daemon)
+                        .await
+                        .map_err(PlannerError::Action)?
+                        .boxed(),
+                );
+            },
         }
         plan.push(
             RemoveDirectory::plan(crate::settings::SCRATCH_DIR)

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -145,7 +145,8 @@ impl Planner for Macos {
     }
 
     async fn plan(&self) -> Result<Vec<StatefulAction<Box<dyn Action>>>, PlannerError> {
-        if self.use_ec2_instance_store && self.settings.distribution() != Distribution::Determinate
+        if self.use_ec2_instance_store
+            && self.settings.distribution() != Distribution::DeterminateNix
         {
             return Err(PlannerError::Ec2InstanceStoreRequiresDeterminateNix);
         }
@@ -165,7 +166,7 @@ impl Planner for Macos {
         // however this match accounts for Determinate Nix so the receipt indicates encrypt: true.
         // This is a goofy thing to do, but it is in an attempt to make a more globally coherent plan / receipt.
         let encrypt = match (self.settings.distribution(), self.encrypt) {
-            (Distribution::Determinate, _) => true,
+            (Distribution::DeterminateNix, _) => true,
             (_, Some(choice)) => {
                 if let Some(diskutil_info) =
                     crate::action::macos::get_disk_info_for_label(&self.volume_label)
@@ -219,7 +220,7 @@ impl Planner for Macos {
 
         let mut plan = vec![];
 
-        if self.settings.distribution() == Distribution::Determinate {
+        if self.settings.distribution() == Distribution::DeterminateNix {
             plan.push(
                 ProvisionDeterminateNixd::plan()
                     .await
@@ -229,7 +230,7 @@ impl Planner for Macos {
         }
 
         match self.settings.distribution() {
-            Distribution::Determinate => {
+            Distribution::DeterminateNix => {
                 plan.push(
                     CreateDeterminateNixVolume::plan(
                         root_disk.unwrap(), /* We just ensured it was populated */
@@ -305,7 +306,7 @@ impl Planner for Macos {
         }
 
         match self.settings.distribution() {
-            Distribution::Determinate => {
+            Distribution::DeterminateNix => {
                 plan.push(
                     ConfigureDeterminateNixdInitService::plan(InitSystem::Launchd, true)
                         .await

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -7,6 +7,7 @@ use which::which;
 
 use super::ShellProfileLocations;
 use crate::action::common::provision_nix::NIX_STORE_LOCATION;
+use crate::distribution::Distribution;
 use crate::planner::HasExpectedErrors;
 
 mod profile_queries;
@@ -144,7 +145,8 @@ impl Planner for Macos {
     }
 
     async fn plan(&self) -> Result<Vec<StatefulAction<Box<dyn Action>>>, PlannerError> {
-        if self.use_ec2_instance_store && !self.settings.determinate_nix {
+        if self.use_ec2_instance_store && self.settings.distribution() != Distribution::Determinate
+        {
             return Err(PlannerError::Ec2InstanceStoreRequiresDeterminateNix);
         }
 
@@ -162,9 +164,9 @@ impl Planner for Macos {
         // The encrypt variable isn't used in Determinate Nix since we have our own plan step for it,
         // however this match accounts for Determinate Nix so the receipt indicates encrypt: true.
         // This is a goofy thing to do, but it is in an attempt to make a more globally coherent plan / receipt.
-        let encrypt = match (self.settings.determinate_nix, self.encrypt) {
-            (true, _) => true,
-            (false, Some(choice)) => {
+        let encrypt = match (self.settings.distribution(), self.encrypt) {
+            (Distribution::Determinate, _) => true,
+            (_, Some(choice)) => {
                 if let Some(diskutil_info) =
                     crate::action::macos::get_disk_info_for_label(&self.volume_label)
                         .await
@@ -181,7 +183,7 @@ impl Planner for Macos {
                     choice
                 }
             },
-            (false, None) => {
+            (_, None) => {
                 let root_disk_is_encrypted = {
                     let output = Command::new("/usr/bin/fdesetup")
                         .arg("isactive")
@@ -217,7 +219,7 @@ impl Planner for Macos {
 
         let mut plan = vec![];
 
-        if self.settings.determinate_nix {
+        if self.settings.distribution() == Distribution::Determinate {
             plan.push(
                 ProvisionDeterminateNixd::plan()
                     .await
@@ -226,31 +228,35 @@ impl Planner for Macos {
             );
         }
 
-        if self.settings.determinate_nix {
-            plan.push(
-                CreateDeterminateNixVolume::plan(
-                    root_disk.unwrap(), /* We just ensured it was populated */
-                    self.volume_label.clone(),
-                    self.case_sensitive,
-                    self.settings.force,
-                    self.use_ec2_instance_store,
-                )
-                .await
-                .map_err(PlannerError::Action)?
-                .boxed(),
-            );
-        } else {
-            plan.push(
-                CreateNixVolume::plan(
-                    root_disk.unwrap(), /* We just ensured it was populated */
-                    self.volume_label.clone(),
-                    self.case_sensitive,
-                    encrypt,
-                )
-                .await
-                .map_err(PlannerError::Action)?
-                .boxed(),
-            );
+        match self.settings.distribution() {
+            Distribution::Determinate => {
+                plan.push(
+                    CreateDeterminateNixVolume::plan(
+                        root_disk.unwrap(), /* We just ensured it was populated */
+                        self.volume_label.clone(),
+                        self.case_sensitive,
+                        self.settings.force,
+                        self.use_ec2_instance_store,
+                    )
+                    .await
+                    .map_err(PlannerError::Action)?
+                    .boxed(),
+                );
+            },
+            Distribution::Nix => {
+                plan.push(
+                    CreateNixVolume::plan(
+                        root_disk.unwrap(), /* We just ensured it was populated */
+                        self.volume_label.clone(),
+                        self.case_sensitive,
+                        encrypt,
+                        self.settings.distribution(),
+                    )
+                    .await
+                    .map_err(PlannerError::Action)?
+                    .boxed(),
+                );
+            },
         }
 
         plan.push(
@@ -298,21 +304,25 @@ impl Planner for Macos {
             );
         }
 
-        if self.settings.determinate_nix {
-            plan.push(
-                ConfigureDeterminateNixdInitService::plan(InitSystem::Launchd, true)
-                    .await
-                    .map_err(PlannerError::Action)?
-                    .boxed(),
-            );
-        } else {
-            plan.push(
-                ConfigureUpstreamInitService::plan(InitSystem::Launchd, true)
-                    .await
-                    .map_err(PlannerError::Action)?
-                    .boxed(),
-            );
+        match self.settings.distribution() {
+            Distribution::Determinate => {
+                plan.push(
+                    ConfigureDeterminateNixdInitService::plan(InitSystem::Launchd, true)
+                        .await
+                        .map_err(PlannerError::Action)?
+                        .boxed(),
+                );
+            },
+            Distribution::Nix => {
+                plan.push(
+                    ConfigureUpstreamInitService::plan(InitSystem::Launchd, true)
+                        .await
+                        .map_err(PlannerError::Action)?
+                        .boxed(),
+                );
+            },
         }
+
         plan.push(
             RemoveDirectory::plan(crate::settings::SCRATCH_DIR)
                 .await

--- a/src/planner/ostree.rs
+++ b/src/planner/ostree.rs
@@ -177,7 +177,7 @@ impl Planner for Ostree {
                 .boxed(),
         );
 
-        if self.settings.distribution() == Distribution::Determinate {
+        if self.settings.distribution() == Distribution::DeterminateNix {
             plan.push(
                 ProvisionDeterminateNixd::plan()
                     .await
@@ -209,7 +209,7 @@ impl Planner for Ostree {
             plan.push(
                 ProvisionSelinux::plan(
                     "/etc/nix-installer/selinux/packages/nix.pp".into(),
-                    if self.settings.distribution() == Distribution::Determinate {
+                    if self.settings.distribution() == Distribution::DeterminateNix {
                         DETERMINATE_SELINUX_POLICY_PP_CONTENT
                     } else {
                         SELINUX_POLICY_PP_CONTENT

--- a/src/planner/ostree.rs
+++ b/src/planner/ostree.rs
@@ -11,6 +11,7 @@ use crate::{
         },
         StatefulAction,
     },
+    distribution::Distribution,
     error::HasExpectedErrors,
     planner::{Planner, PlannerError},
     settings::{CommonSettings, InitSystem, InstallSettingsError},
@@ -176,7 +177,7 @@ impl Planner for Ostree {
                 .boxed(),
         );
 
-        if self.settings.determinate_nix {
+        if self.settings.distribution() == Distribution::Determinate {
             plan.push(
                 ProvisionDeterminateNixd::plan()
                     .await
@@ -208,7 +209,7 @@ impl Planner for Ostree {
             plan.push(
                 ProvisionSelinux::plan(
                     "/etc/nix-installer/selinux/packages/nix.pp".into(),
-                    if self.settings.determinate_nix {
+                    if self.settings.distribution() == Distribution::Determinate {
                         DETERMINATE_SELINUX_POLICY_PP_CONTENT
                     } else {
                         SELINUX_POLICY_PP_CONTENT

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -113,6 +113,7 @@ use crate::{
         },
         Action, StatefulAction,
     },
+    distribution::Distribution,
     planner::{Planner, PlannerError},
     settings::{CommonSettings, InitSystem, InstallSettingsError},
     BuiltinPlanner,
@@ -343,7 +344,7 @@ impl Planner for SteamDeck {
             )
         }
 
-        if self.settings.determinate_nix {
+        if self.settings.distribution() == Distribution::Determinate {
             actions.push(
                 ProvisionDeterminateNixd::plan()
                     .await

--- a/src/planner/steam_deck.rs
+++ b/src/planner/steam_deck.rs
@@ -344,7 +344,7 @@ impl Planner for SteamDeck {
             )
         }
 
-        if self.settings.distribution() == Distribution::Determinate {
+        if self.settings.distribution() == Distribution::DeterminateNix {
             actions.push(
                 ProvisionDeterminateNixd::plan()
                     .await

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,11 +15,17 @@ pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
 pub const DEFAULT_NIX_BUILD_USER_GROUP_NAME: &str = "nixbld";
 
-pub const NIX_TARBALL_PATH: &str = env!("NIX_INSTALLER_TARBALL_PATH");
-/// The NIX_INSTALLER_TARBALL_PATH environment variable should point to a target-appropriate
-/// Nix installation tarball, like nix-2.21.2-aarch64-darwin.tar.xz. The contents are embedded
-/// in the resulting binary.
-pub const NIX_TARBALL: &[u8] = include_bytes!(env!("NIX_INSTALLER_TARBALL_PATH"));
+pub const NIX_TARBALL_URL: &str =
+    "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-x86_64-linux.tar.xz";
+
+#[cfg(feature = "determinate-nix")]
+pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = Some(env!("DETERMINATE_NIX_TARBALL_PATH"));
+#[cfg(feature = "determinate-nix")]
+/// The DETERMINATE_NIX_TARBALL environment variable should point to a target-appropriate
+/// Determinate Nix installation tarball, like determinate-nix-2.21.2-aarch64-darwin.tar.xz.
+/// The contents are embedded in the resulting binary.
+pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> =
+    Some(include_bytes!(env!("DETERMINATE_NIX_TARBALL_PATH")));
 
 #[cfg(feature = "determinate-nix")]
 /// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
@@ -29,10 +35,11 @@ pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> =
     Some(include_bytes!(env!("DETERMINATE_NIXD_BINARY_PATH")));
 
 #[cfg(not(feature = "determinate-nix"))]
-/// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
-/// static build of the Determinate Nixd binary. The contents are embedded in the resulting
-/// binary if the determinate-nix feature is turned on.
 pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> = None;
+#[cfg(not(feature = "determinate-nix"))]
+pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> = None;
+#[cfg(not(feature = "determinate-nix"))]
+pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = None;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,17 +13,11 @@ pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
 pub const DEFAULT_NIX_BUILD_USER_GROUP_NAME: &str = "nixbld";
 
-pub const NIX_TARBALL_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-x86_64-linux.tar.xz";
-
-#[cfg(feature = "determinate-nix")]
-pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = Some(env!("DETERMINATE_NIX_TARBALL_PATH"));
-#[cfg(feature = "determinate-nix")]
-/// The DETERMINATE_NIX_TARBALL environment variable should point to a target-appropriate
-/// Determinate Nix installation tarball, like determinate-nix-2.21.2-aarch64-darwin.tar.xz.
-/// The contents are embedded in the resulting binary.
-pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> =
-    Some(include_bytes!(env!("DETERMINATE_NIX_TARBALL_PATH")));
+pub const NIX_TARBALL_PATH: &str = env!("NIX_INSTALLER_TARBALL_PATH");
+/// The NIX_INSTALLER_TARBALL_PATH environment variable should point to a target-appropriate
+/// Nix installation tarball, like nix-2.21.2-aarch64-darwin.tar.xz. The contents are embedded
+/// in the resulting binary.
+pub const NIX_TARBALL: &[u8] = include_bytes!(env!("NIX_INSTALLER_TARBALL_PATH"));
 
 #[cfg(feature = "determinate-nix")]
 /// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
@@ -33,11 +27,10 @@ pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> =
     Some(include_bytes!(env!("DETERMINATE_NIXD_BINARY_PATH")));
 
 #[cfg(not(feature = "determinate-nix"))]
+/// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
+/// static build of the Determinate Nixd binary. The contents are embedded in the resulting
+/// binary if the determinate-nix feature is turned on.
 pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> = None;
-#[cfg(not(feature = "determinate-nix"))]
-pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> = None;
-#[cfg(not(feature = "determinate-nix"))]
-pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = None;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -15,32 +15,6 @@ pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
 pub const DEFAULT_NIX_BUILD_USER_GROUP_NAME: &str = "nixbld";
 
-pub const NIX_TARBALL_URL: &str =
-    "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-x86_64-linux.tar.xz";
-
-#[cfg(feature = "determinate-nix")]
-pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = Some(env!("DETERMINATE_NIX_TARBALL_PATH"));
-#[cfg(feature = "determinate-nix")]
-/// The DETERMINATE_NIX_TARBALL environment variable should point to a target-appropriate
-/// Determinate Nix installation tarball, like determinate-nix-2.21.2-aarch64-darwin.tar.xz.
-/// The contents are embedded in the resulting binary.
-pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> =
-    Some(include_bytes!(env!("DETERMINATE_NIX_TARBALL_PATH")));
-
-#[cfg(feature = "determinate-nix")]
-/// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
-/// static build of the Determinate Nixd binary. The contents are embedded in the resulting
-/// binary if the determinate-nix feature is turned on.
-pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> =
-    Some(include_bytes!(env!("DETERMINATE_NIXD_BINARY_PATH")));
-
-#[cfg(not(feature = "determinate-nix"))]
-pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> = None;
-#[cfg(not(feature = "determinate-nix"))]
-pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> = None;
-#[cfg(not(feature = "determinate-nix"))]
-pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = None;
-
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum InitSystem {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,6 +9,8 @@ use clap::{
 };
 use url::Url;
 
+use crate::distribution::Distribution;
+
 pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
 pub const DEFAULT_NIX_BUILD_USER_GROUP_NAME: &str = "nixbld";
@@ -318,6 +320,14 @@ impl CommonSettings {
         map.insert("skip_nix_conf".into(), serde_json::to_value(skip_nix_conf)?);
 
         Ok(map)
+    }
+
+    pub fn distribution(&self) -> Distribution {
+        if self.determinate_nix {
+            Distribution::Determinate
+        } else {
+            Distribution::Nix
+        }
     }
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,11 +13,17 @@ pub const SCRATCH_DIR: &str = "/nix/temp-install-dir";
 
 pub const DEFAULT_NIX_BUILD_USER_GROUP_NAME: &str = "nixbld";
 
-pub const NIX_TARBALL_PATH: &str = env!("NIX_INSTALLER_TARBALL_PATH");
-/// The NIX_INSTALLER_TARBALL_PATH environment variable should point to a target-appropriate
-/// Nix installation tarball, like nix-2.21.2-aarch64-darwin.tar.xz. The contents are embedded
-/// in the resulting binary.
-pub const NIX_TARBALL: &[u8] = include_bytes!(env!("NIX_INSTALLER_TARBALL_PATH"));
+pub const NIX_TARBALL_URL: &str =
+    "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-x86_64-linux.tar.xz";
+
+#[cfg(feature = "determinate-nix")]
+pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = Some(env!("DETERMINATE_NIX_TARBALL_PATH"));
+#[cfg(feature = "determinate-nix")]
+/// The DETERMINATE_NIX_TARBALL environment variable should point to a target-appropriate
+/// Determinate Nix installation tarball, like determinate-nix-2.21.2-aarch64-darwin.tar.xz.
+/// The contents are embedded in the resulting binary.
+pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> =
+    Some(include_bytes!(env!("DETERMINATE_NIX_TARBALL_PATH")));
 
 #[cfg(feature = "determinate-nix")]
 /// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
@@ -27,10 +33,11 @@ pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> =
     Some(include_bytes!(env!("DETERMINATE_NIXD_BINARY_PATH")));
 
 #[cfg(not(feature = "determinate-nix"))]
-/// The DETERMINATE_NIXD_BINARY_PATH environment variable should point to a target-appropriate
-/// static build of the Determinate Nixd binary. The contents are embedded in the resulting
-/// binary if the determinate-nix feature is turned on.
 pub const DETERMINATE_NIXD_BINARY: Option<&[u8]> = None;
+#[cfg(not(feature = "determinate-nix"))]
+pub const DETERMINATE_NIX_TARBALL: Option<&[u8]> = None;
+#[cfg(not(feature = "determinate-nix"))]
+pub const DETERMINATE_NIX_TARBALL_PATH: Option<&str> = None;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -305,7 +305,7 @@ impl CommonSettings {
 
     pub fn distribution(&self) -> Distribution {
         if self.determinate_nix {
-            Distribution::Determinate
+            Distribution::DeterminateNix
         } else {
             Distribution::Nix
         }

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -23,7 +23,8 @@
             "url_or_path": null,
             "dest": "/nix/temp-install-dir",
             "proxy": null,
-            "ssl_cert_file": null
+            "ssl_cert_file": null,
+            "distribution": "Nix"
           },
           "state": "Completed"
         },

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -61,7 +61,8 @@
             "url_or_path": null,
             "dest": "/nix/temp-install-dir",
             "proxy": null,
-            "ssl_cert_file": null
+            "ssl_cert_file": null,
+            "distribution": "Nix"
           },
           "state": "Completed"
         },

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -99,7 +99,8 @@
             "url_or_path": null,
             "dest": "/nix/temp-install-dir",
             "proxy": null,
-            "ssl_cert_file": null
+            "ssl_cert_file": null,
+            "distribution": "Nix"
           },
           "state": "Completed"
         },


### PR DESCRIPTION
##### Description

Switch over to Determinate Nix as the embedded tarball, and download the Nix tarball from NixOS upon request. Refactor the "determinate" switching to use a "Distribution" enum to make the code a bit less wack. Also updates the built-in Determinate prompt text to be more clear.

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
