### PR TITLE
warn users to declare a `WORKDIR` in a `Dockerfile` before adding flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ For containers (without an init):
 > sudo -i nix run nixpkgs#hello
 > ```
 
+> [!WARNING]
+> If you want to add a `flake.nix`, first declare a working directory (such as `/src`) in your `Dockerfile`.
+> You cannot lock a flake placed at the docker image root (`/`) ([see details](https://github.com/DeterminateSystems/nix-installer/issues/1066)).
+> You would get a `file '/dev/full' has an unsupported type` during the docker build.
+>
+> ```dockerfile
+> # append this to the below dockerfiles
+> WORKDIR /src
+> # now flakes will work
+> RUN nix flake init
+> RUN nix flake lock
+> ```
+
 ```dockerfile
 # Dockerfile
 FROM ubuntu:latest


### PR DESCRIPTION
##### Description

I stubbed my toe again on https://github.com/DeterminateSystems/nix-installer/issues/1066 (`file '/dev/full' has an unsupported type`).

This should help other people making the same mistake.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

don't this this is relevant; it's just docs.