### PR TITLE
Update the upstream Nix version on release proposal

### DIFF
--- a/.github/workflows/propose-release.yml
+++ b/.github/workflows/propose-release.yml
@@ -10,6 +10,9 @@ on:
       determinate-nix-version:
         type: string
         required: true
+      upstream-nix-version:
+        type: string
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}
@@ -36,5 +39,6 @@ jobs:
         git commit -m "Update test fixtures with the new nix-installer version" || true
 
         sed -i 's#https://flakehub.com/f/DeterminateSystems/nix-src/=.*";#https://flakehub.com/f/DeterminateSystems/nix-src/=${{ inputs.determinate-nix-version }}";#' ./flake.nix
+        sed -i 's#https://releases.nixos.org/nix/nix-.*/nix-.*-";#https://releases.nixos.org/nix/nix-${{ inputs.upstream-nix-version }}/nix-${{ inputs.upstream-nix-version }}-";#' ./flake.nix
         git add flake.nix
         git commit -m "Update Determinate Nix release to ${{ inputs.determinate-nix-version }}" || true

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
     , ...
     } @ inputs:
     let
+      nix_tarball_url_prefix = "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-";
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       systemsSupportedByDeterminateNixd = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
 
@@ -89,7 +90,7 @@
 
           env = sharedAttrs.env // {
             RUSTFLAGS = "--cfg tokio_unstable";
-            NIX_TARBALL_URL = "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-${pkgs.stdenv.hostPlatform.system}.tar.xz";
+            NIX_TARBALL_URL = "${nix_tarball_url_prefix}${pkgs.stdenv.hostPlatform.system}.tar.xz";
             DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${stdenv.hostPlatform.system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd stdenv.hostPlatform.system;
           };
@@ -110,7 +111,7 @@
             name = "nix-install-shell";
 
             RUST_SRC_PATH = "${pkgs.rustPlatform.rustcSrc}/library";
-            NIX_TARBALL_URL = "https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-${pkgs.stdenv.hostPlatform.system}.tar.xz";
+            NIX_TARBALL_URL = "${nix_tarball_url_prefix}${pkgs.stdenv.hostPlatform.system}.tar.xz";
             DETERMINATE_NIX_TARBALL_PATH = nixTarballs.${system};
             DETERMINATE_NIXD_BINARY_PATH = optionalPathToDeterminateNixd system;
 


### PR DESCRIPTION
##### Description

~for after #1503 merges~

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
