### PR TITLE
Perform manual socket cleanup on Mac uninstallation

### DIFF
--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use tokio::process::Command;
 use tracing::{span, Span};
@@ -136,6 +136,9 @@ impl Action for BootstrapLaunchctlService {
         crate::action::macos::retry_bootout(DARWIN_LAUNCHD_DOMAIN, &self.service)
             .await
             .map_err(Self::error)?;
+
+        crate::action::macos::remove_socket_path(Path::new("/var/run/nix-daemon.socket")).await;
+        crate::action::macos::remove_socket_path(Path::new("/var/run/determinate-nixd.socket")).await;
 
         Ok(())
     }

--- a/src/action/macos/bootstrap_launchctl_service.rs
+++ b/src/action/macos/bootstrap_launchctl_service.rs
@@ -138,7 +138,8 @@ impl Action for BootstrapLaunchctlService {
             .map_err(Self::error)?;
 
         crate::action::macos::remove_socket_path(Path::new("/var/run/nix-daemon.socket")).await;
-        crate::action::macos::remove_socket_path(Path::new("/var/run/determinate-nixd.socket")).await;
+        crate::action::macos::remove_socket_path(Path::new("/var/run/determinate-nixd.socket"))
+            .await;
 
         Ok(())
     }

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -269,7 +269,6 @@ pub(crate) async fn retry_bootout(domain: &str, service_name: &str) -> Result<()
 /// ```
 #[tracing::instrument]
 pub(crate) async fn remove_socket_path(path: &Path) {
-    // WIP: this soft fails
     if let Err(err) = fs::remove_file(path).await {
         tracing::warn!(?err, ?path, "Could not clean up unused socket");
     }

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -263,7 +263,7 @@ pub(crate) async fn retry_bootout(domain: &str, service_name: &str) -> Result<()
 /// sometimes fail to remove sockets when `launchctl bootstrap` is invoked,
 /// leaving only these slightly cryptic errors:
 ///
-/// ```
+/// ```text
 /// 2025-04-12 14:22:58.165233 (system/systems.determinate.nix-daemon - determinate-nixd.socket) <Error>: Failed to unlinkat() old socket path: path=/var/run/determinate-nixd.socket, error=Invalid argument (22)
 /// 2025-04-12 14:22:58.165279 (system/systems.determinate.nix-daemon - nix-daemon.socket) <Error>: Failed to unlinkat() old socket path: path=/var/run/nix-daemon.socket, error=Invalid argument (22)
 /// ```

--- a/src/self_test.rs
+++ b/src/self_test.rs
@@ -115,6 +115,7 @@ impl Shell {
         );
         let output = command
             .stdin(std::process::Stdio::null())
+            .env("NIX_REMOTE", "daemon")
             .output()
             .await
             .map_err(|error| SelfTestError::Command {


### PR DESCRIPTION
##### Description

This PR addresses a fairly obscure issue on Macs with `launchd`. During an uninstall-reinstall operation, `launchd bootstrap` sometimes fails to unlink sockets declared in the service's plist file. This symptom manifests in `nix build` failing to connect to the build socket, and `launchd` leaving these log entries:

```
2025-04-12 15:02:31.041843 (system) <Notice>: Bootstrap by launchctl[43364] for /Library/LaunchDaemons/systems.determinate.nix-daemon.plist succeeded (0: )
2025-04-12 15:02:31.041864 (system/systems.determinate.nix-daemon - determinate-nixd.socket) <Error>: Failed to unlinkat() old socket path: path=/var/run/determinate-nixd.socket, error=Invalid argument (22)
2025-04-12 15:02:31.041912 (system/systems.determinate.nix-daemon - nix-daemon.socket) <Error>: Failed to unlinkat() old socket path: path=/var/run/nix-daemon.socket, error=Invalid argument (22)
```

Some in situ testing has revealed that the best way to handle this is to just remove the socket files during uninstallation, forcing `launchd` to regenerate the sockets.

In order to better surface this issue during our tests, this PR also forces the installer's self tests to use the Nix daemon, even if running as root.

##### Checklist

- [X] Formatted with `cargo fmt`
- [X] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
