### PR TITLE
Explicitly create `/nix` folder on installation

### DIFF
--- a/src/action/common/create_nix_tree.rs
+++ b/src/action/common/create_nix_tree.rs
@@ -8,6 +8,7 @@ use crate::action::{
 };
 
 const PATHS: &[&str] = &[
+    "/nix",
     "/nix/var",
     "/nix/var/log",
     "/nix/var/log/nix",


### PR DESCRIPTION
Hey everyone,
while using this installer, when using the uninstaller it won't delete the `/nix` folder. This is a nuisance on e.g. Fedora Atomic images, where you'd have to go through extra steps to delete `/`. Checking that the installer will only revert the items it did while installing, I think that explicitly adding `/nix` to `PATHS` would solve the issue. Thanks! Please feel free to close if it's not relevant.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
