### PR TITLE
Remove flake-compat input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -82,20 +82,6 @@
       }
     },
     "flake-compat": {
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "revCount": 69,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.0.0.tar.gz"
-      }
-    },
-    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1733328505,
@@ -165,7 +151,7 @@
     },
     "nix": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs",
@@ -251,7 +237,6 @@
       "inputs": {
         "crane": "crane",
         "determinate": "determinate",
-        "flake-compat": "flake-compat",
         "nix": "nix",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.nix.follows = "nix";
     };
-
-    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.0.0.tar.gz";
   };
 
   outputs =


### PR DESCRIPTION
We have neither a `default.nix` nor a `shell.nix` so this input is currently unused.
