### PR TITLE
Avoid zsh taking over /dev/tty in self-test

### DIFF
--- a/src/self_test.rs
+++ b/src/self_test.rs
@@ -105,7 +105,7 @@ impl Shell {
             .as_millis();
 
         command.arg(format!(
-            r#"nix build --option substitute false --option post-build-hook '' --no-link --expr 'derivation {{ name = "self-test-{executable}-{timestamp_millis}"; system = "{SYSTEM}"; builder = "/bin/sh"; args = ["-c" "echo hello > \$out"]; }}'"#
+            r#"exec nix build --option substitute false --option post-build-hook '' --no-link --expr 'derivation {{ name = "self-test-{executable}-{timestamp_millis}"; system = "{SYSTEM}"; builder = "/bin/sh"; args = ["-c" "echo hello > \$out"]; }}'"#
         ));
         let command_str = format!("{:?}", command.as_std());
 


### PR DESCRIPTION
##### Description

fix https://github.com/DeterminateSystems/nix-installer/issues/813

After running nix-installer self-test in a script on Darwin, if I then attempt to read from /dev/tty in the same script, it gets suspended by SIGTTIN. This seems to be a result of running zsh -ic which appears to take over /dev/tty via tcsetpgrp when doing job control stuff[1]. I can replicate the issue by running sh -c 'zsh -ic /usr/bin/true && read'. I haven't traced the exact codepaths, but the job control stuff only seems to kick in when zsh spawns and waits on a subprocess, so by execing the command, we seem to avoid the problem. This also avoids keeping the shell around longer than necessary so this seems like a win-win.

[1] https://github.com/zsh-users/zsh/blob/87c055fb4d076c0d9bfffbef16ac8dd9348903df/Src/utils.c#L4779-L4781

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
