### PR TITLE
Add install.determinate.systems to the extra-trusted-substituters list for anonymous upgrades

### DIFF
--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -136,12 +136,18 @@ impl PlaceNixConfiguration {
 
         // base, unintrusive Determinate Nix options
         {
-            // Add FlakeHub cache to the list of possible substituters, but disabled by default.
-            // This allows a user to turn on FlakeHub Cache by adding it to the `extra-substituters`
-            // list without being a trusted user.
+            // Add FlakeHub Cache and install.determinate.systems to the list of possible substituters, but disabled by default.
+            // Users are then able to substitute from these caches by adding them to `extra-substituters` list without being a trusted user.
+            //
+            // * Adds cache.flakehub.com
+            //   This means FlakeHub Cache users don't need to reconfigure Nix as a trusted user.
+            //
+            // * Adds install.determinate.systems
+            //   install.determinate.systems serves a binary cache of FlakeHub Cache-signed artifacts.
+            //   The cache only contains a few projects, intended to support anonymous user upgrades.
             settings.insert(
                 "extra-trusted-substituters".to_string(),
-                "https://cache.flakehub.com".to_string(),
+                "https://cache.flakehub.com https://install.determinate.systems".to_string(),
             );
 
             // Add FlakeHub's cache signing keys to the allowed list, but unused unless a user

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -1062,7 +1062,7 @@
                     "extra-experimental-features": "nix-command flakes",
                     "auto-optimise-store": "true",
                     "always-allow-substitutes": "true",
-                    "extra-trusted-substituters": "https://cache.flakehub.com",
+                    "extra-trusted-substituters": "https://cache.flakehub.com https://install.determinate.systems",
                     "extra-trusted-public-keys": "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM= cache.flakehub.com-4:Asi8qIv291s0aYLyH6IOnr5Kf6+OF14WVjkE6t3xMio= cache.flakehub.com-5:zB96CRlL7tiPtzA9/WKyPkp3A2vqxqgdgyTVNGShPDU= cache.flakehub.com-6:W4EGFwAGgBj3he7c5fNh9NkOXw0PUVaxygCVKeuvaqU= cache.flakehub.com-7:mvxJ2DZVHn/kRxlIaxYNMuDG1OvMckZu32um1TadOR8= cache.flakehub.com-8:moO+OVS0mnTjBTcOUh2kYLQEd59ExzyoW1QgQ8XAARQ= cache.flakehub.com-9:wChaSeTI6TeCuV/Sg2513ZIM9i0qJaYsF+lZCXg0J6o= cache.flakehub.com-10:2GqeNlIp6AKp4EF2MVbE1kBOp9iBSyo0UPR9KoR0o1Y=",
                     "bash-prompt-prefix": "(nix:$name)\\040",
                     "max-jobs": "auto",

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -1087,7 +1087,7 @@
                     "extra-experimental-features": "nix-command flakes",
                     "auto-optimise-store": "true",
                     "always-allow-substitutes": "true",
-                    "extra-trusted-substituters": "https://cache.flakehub.com",
+                    "extra-trusted-substituters": "https://cache.flakehub.com https://install.determinate.systems",
                     "extra-trusted-public-keys": "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM= cache.flakehub.com-4:Asi8qIv291s0aYLyH6IOnr5Kf6+OF14WVjkE6t3xMio= cache.flakehub.com-5:zB96CRlL7tiPtzA9/WKyPkp3A2vqxqgdgyTVNGShPDU= cache.flakehub.com-6:W4EGFwAGgBj3he7c5fNh9NkOXw0PUVaxygCVKeuvaqU= cache.flakehub.com-7:mvxJ2DZVHn/kRxlIaxYNMuDG1OvMckZu32um1TadOR8= cache.flakehub.com-8:moO+OVS0mnTjBTcOUh2kYLQEd59ExzyoW1QgQ8XAARQ= cache.flakehub.com-9:wChaSeTI6TeCuV/Sg2513ZIM9i0qJaYsF+lZCXg0J6o= cache.flakehub.com-10:2GqeNlIp6AKp4EF2MVbE1kBOp9iBSyo0UPR9KoR0o1Y=",
                     "bash-prompt-prefix": "(nix:$name)\\040",
                     "max-jobs": "auto",

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -1147,7 +1147,7 @@
                   "settings": {
                     "extra-experimental-features": "nix-command flakes",
                     "always-allow-substitutes": "true",
-                    "extra-trusted-substituters": "https://cache.flakehub.com",
+                    "extra-trusted-substituters": "https://cache.flakehub.com https://install.determinate.systems",
                     "extra-trusted-public-keys": "cache.flakehub.com-3:hJuILl5sVK4iKm86JzgdXW12Y2Hwd5G07qKtHTOcDCM= cache.flakehub.com-4:Asi8qIv291s0aYLyH6IOnr5Kf6+OF14WVjkE6t3xMio= cache.flakehub.com-5:zB96CRlL7tiPtzA9/WKyPkp3A2vqxqgdgyTVNGShPDU= cache.flakehub.com-6:W4EGFwAGgBj3he7c5fNh9NkOXw0PUVaxygCVKeuvaqU= cache.flakehub.com-7:mvxJ2DZVHn/kRxlIaxYNMuDG1OvMckZu32um1TadOR8= cache.flakehub.com-8:moO+OVS0mnTjBTcOUh2kYLQEd59ExzyoW1QgQ8XAARQ= cache.flakehub.com-9:wChaSeTI6TeCuV/Sg2513ZIM9i0qJaYsF+lZCXg0J6o= cache.flakehub.com-10:2GqeNlIp6AKp4EF2MVbE1kBOp9iBSyo0UPR9KoR0o1Y=",
                     "bash-prompt-prefix": "(nix:$name)\\040",
                     "max-jobs": "auto",


### PR DESCRIPTION


##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
