### PR TITLE
fixup: don't escape newlines in hardcoded "Install Determinate Nix?" prompt

### DIFF
--- a/src/cli/subcommand/install/determinate.rs
+++ b/src/cli/subcommand/install/determinate.rs
@@ -9,8 +9,8 @@ use crate::planner::BuiltinPlanner;
 const PRE_PKG_SUGGEST: &str = "For a more robust Nix installation, use the Determinate package for macOS: https://dtr.mn/determinate-nix";
 
 const INSTALL_DETERMINATE_NIX_PROMPT: &str = "\
-Install Determinate Nix?\
-\
+Install Determinate Nix?
+
 Selecting 'no' will install Nix from NixOS.org, without automated garbage collection and enterprise certificate support.\
 ";
 


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
