### PR TITLE
.github: switch from actions/cache to actions/{download,upload}-artifact

### DIFF
--- a/.github/workflows/build-aarch64-darwin.yml
+++ b/.github/workflows/build-aarch64-darwin.yml
@@ -2,11 +2,6 @@ name: Build aarch64 Darwin
 
 on:
   workflow_call:
-    inputs:
-      cache-key:
-        type: string
-        required: false
-        default: aarch64-darwin-artifacts-${{ github.sha }}
 
 jobs:
   build-aarch64-darwin:
@@ -25,8 +20,8 @@ jobs:
         run: |
           nix build .#packages.aarch64-darwin.nix-installer-static -L
           cp result/bin/nix-installer .
-      - name: Create GitHub cache from build artifacts
-        uses: actions/cache/save@v4
+      - name: Create GitHub artifacts from build outputs
+        uses: actions/upload-artifact@v4
         with:
           path: nix-installer
-          key: ${{ inputs.cache-key }}
+          name: nix-installer-aarch64-darwin

--- a/.github/workflows/build-aarch64-darwin.yml
+++ b/.github/workflows/build-aarch64-darwin.yml
@@ -7,7 +7,6 @@ jobs:
   build-aarch64-darwin:
     name: Build aarch64 Darwin (static)
     runs-on: namespace-profile-mac-m2-12c28g
-    concurrency: ${{ inputs.cache-key }}
     permissions:
       id-token: "write"
       contents: "read"

--- a/.github/workflows/build-aarch64-darwin.yml
+++ b/.github/workflows/build-aarch64-darwin.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Build the installer
         run: |
           nix build .#packages.aarch64-darwin.nix-installer-static -L
-          cp result/bin/nix-installer .
+          cp result/bin/nix-installer ./nix-installer-aarch64-darwin
       - name: Create GitHub artifacts from build outputs
         uses: actions/upload-artifact@v4
         with:
-          path: nix-installer
+          path: nix-installer-aarch64-darwin
           name: nix-installer-aarch64-darwin

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -2,11 +2,6 @@ name: Build aarch64 Linux (static)
 
 on:
   workflow_call:
-    inputs:
-      cache-key:
-        type: string
-        required: false
-        default: aarch64-linux-artifacts-${{ github.sha }}
 
 jobs:
   build-aarch64-linux:
@@ -25,8 +20,8 @@ jobs:
         run: |
           nix build .#packages.aarch64-linux.nix-installer-static -L
           cp result/bin/nix-installer .
-      - name: Create GitHub cache from build artifacts
-        uses: actions/cache/save@v4
+      - name: Create GitHub artifacts from build outputs
+        uses: actions/upload-artifact@v4
         with:
           path: nix-installer
-          key: ${{ inputs.cache-key }}
+          name: nix-installer-aarch64-linux

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Build the installer
         run: |
           nix build .#packages.aarch64-linux.nix-installer-static -L
-          cp result/bin/nix-installer .
+          cp result/bin/nix-installer ./nix-installer-aarch64-linux
       - name: Create GitHub artifacts from build outputs
         uses: actions/upload-artifact@v4
         with:
-          path: nix-installer
+          path: nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -7,7 +7,6 @@ jobs:
   build-aarch64-linux:
     name: Build aarch64 Linux (static)
     runs-on: UbuntuLatest32Cores128GArm
-    concurrency: ${{ inputs.cache-key }}
     permissions:
       id-token: "write"
       contents: "read"

--- a/.github/workflows/build-x86_64-darwin.yml
+++ b/.github/workflows/build-x86_64-darwin.yml
@@ -7,7 +7,6 @@ jobs:
   build-x86_64-darwin:
     name: Build x86_64 Darwin (static)
     runs-on: namespace-profile-mac-m2-12c28g
-    concurrency: ${{ inputs.cache-key }}
     permissions:
       id-token: "write"
       contents: "read"

--- a/.github/workflows/build-x86_64-darwin.yml
+++ b/.github/workflows/build-x86_64-darwin.yml
@@ -2,11 +2,6 @@ name: Build x86_64 Darwin
 
 on:
   workflow_call:
-    inputs:
-      cache-key:
-        type: string
-        required: false
-        default: x86_64-darwin-artifacts-${{ github.sha }}
 
 jobs:
   build-x86_64-darwin:
@@ -25,8 +20,8 @@ jobs:
         run: |
           nix build .#packages.x86_64-darwin.nix-installer-static -L
           cp result/bin/nix-installer .
-      - name: Create GitHub cache from build artifacts
-        uses: actions/cache/save@v4
+      - name: Create GitHub artifacts from build outputs
+        uses: actions/upload-artifact@v4
         with:
           path: nix-installer
-          key: ${{ inputs.cache-key }}
+          name: nix-installer-x86_64-darwin

--- a/.github/workflows/build-x86_64-darwin.yml
+++ b/.github/workflows/build-x86_64-darwin.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Build the installer
         run: |
           nix build .#packages.x86_64-darwin.nix-installer-static -L
-          cp result/bin/nix-installer .
+          cp result/bin/nix-installer ./nix-installer-x86_64-darwin
       - name: Create GitHub artifacts from build outputs
         uses: actions/upload-artifact@v4
         with:
-          path: nix-installer
+          path: nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin

--- a/.github/workflows/build-x86_64-linux.yml
+++ b/.github/workflows/build-x86_64-linux.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Build the installer
         run: |
           nix build .#packages.x86_64-linux.nix-installer-static -L
-          cp result/bin/nix-installer .
+          cp result/bin/nix-installer ./nix-installer-x86_64-linux
       - name: Create GitHub artifacts from build outputs
         uses: actions/upload-artifact@v4
         with:
-          path: nix-installer
+          path: nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux

--- a/.github/workflows/build-x86_64-linux.yml
+++ b/.github/workflows/build-x86_64-linux.yml
@@ -7,7 +7,6 @@ jobs:
   build-x86_64-linux:
     name: Build x86_64 Linux (static)
     runs-on: UbuntuLatest32Cores128G
-    concurrency: ${{ inputs.cache-key }}
     permissions:
       id-token: "write"
       contents: "read"

--- a/.github/workflows/build-x86_64-linux.yml
+++ b/.github/workflows/build-x86_64-linux.yml
@@ -2,11 +2,6 @@ name: Build x86_64 Linux (static)
 
 on:
   workflow_call:
-    inputs:
-      cache-key:
-        type: string
-        required: false
-        default: x86_64-linux-artifacts-${{ github.sha }}
 
 jobs:
   build-x86_64-linux:
@@ -25,8 +20,8 @@ jobs:
         run: |
           nix build .#packages.x86_64-linux.nix-installer-static -L
           cp result/bin/nix-installer .
-      - name: Create GitHub cache from build artifacts
-        uses: actions/cache/save@v4
+      - name: Create GitHub artifacts from build outputs
+        uses: actions/upload-artifact@v4
         with:
           path: nix-installer
-          key: ${{ inputs.cache-key }}
+          name: nix-installer-x86_64-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer install-root/nix-installer-x86_64-linux
+          mv ./nix-installer/nix-installer install-root/nix-installer-x86_64-linux
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
           file install-root/nix-installer-x86_64-linux
           ls -al install-root/nix-installer-x86_64-linux
@@ -193,7 +193,7 @@ jobs:
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer install-root/nix-installer-x86_64-linux
+          mv ./nix-installer/nix-installer install-root/nix-installer-x86_64-linux
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
           file install-root/nix-installer-x86_64-linux
           ls -al install-root/nix-installer-x86_64-linux
@@ -319,7 +319,7 @@ jobs:
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer install-root/nix-installer-x86_64-darwin
+          mv ./nix-installer/nix-installer install-root/nix-installer-x86_64-darwin
           chmod +x install-root/nix-installer-x86_64-darwin install-root/nix-installer.sh
           file install-root/nix-installer-x86_64-darwin
           ls -al install-root/nix-installer-x86_64-darwin
@@ -411,7 +411,7 @@ jobs:
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer install-root/nix-installer-aarch64-linux
+          mv ./nix-installer/nix-installer install-root/nix-installer-aarch64-linux
           chmod +x install-root/nix-installer-aarch64-linux install-root/nix-installer.sh
           file install-root/nix-installer-aarch64-linux
           ls -al install-root/nix-installer-aarch64-linux
@@ -531,7 +531,7 @@ jobs:
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer install-root/nix-installer-aarch64-darwin
+          mv ./nix-installer/nix-installer install-root/nix-installer-aarch64-darwin
           chmod +x install-root/nix-installer-aarch64-darwin install-root/nix-installer.sh
           file install-root/nix-installer-aarch64-darwin
           ls -al install-root/nix-installer-aarch64-darwin
@@ -629,7 +629,7 @@ jobs:
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer install-root/nix-installer-x86_64-linux
+          mv ./nix-installer/nix-installer install-root/nix-installer-x86_64-linux
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
           file install-root/nix-installer-x86_64-linux
           ls -al install-root/nix-installer-x86_64-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,13 @@ jobs:
       - name: Restore Github cache artifacts
         uses: actions/download-artifact@v4
         with:
-          path: nix-installer
           name: nix-installer-x86_64-linux
       - name: Move & set executable
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer/nix-installer install-root/nix-installer-x86_64-linux
+          mv ./nix-installer-x86_64-linux install-root/
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
-          file install-root/nix-installer-x86_64-linux
-          ls -al install-root/nix-installer-x86_64-linux
       - run: sudo apt install fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -187,16 +184,13 @@ jobs:
       - name: Restore Github cache artifacts
         uses: actions/download-artifact@v4
         with:
-          path: nix-installer
           name: nix-installer-x86_64-linux
       - name: Move & set executable
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer/nix-installer install-root/nix-installer-x86_64-linux
+          mv ./nix-installer-x86_64-linux install-root/
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
-          file install-root/nix-installer-x86_64-linux
-          ls -al install-root/nix-installer-x86_64-linux
       - run: sudo apt install fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -313,16 +307,13 @@ jobs:
       - name: Restore Github cache artifacts
         uses: actions/download-artifact@v4
         with:
-          path: nix-installer
           name: nix-installer-x86_64-darwin
       - name: Move & set executable
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer/nix-installer install-root/nix-installer-x86_64-darwin
+          mv ./nix-installer-x86_64-darwin install-root/
           chmod +x install-root/nix-installer-x86_64-darwin install-root/nix-installer.sh
-          file install-root/nix-installer-x86_64-darwin
-          ls -al install-root/nix-installer-x86_64-darwin
       - run: brew install fish coreutils
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -405,16 +396,13 @@ jobs:
       - name: Restore Github cache artifacts
         uses: actions/download-artifact@v4
         with:
-          path: nix-installer
           name: nix-installer-aarch64-linux
       - name: Move & set executable
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer/nix-installer install-root/nix-installer-aarch64-linux
+          mv ./nix-installer-aarch64-linux install-root/
           chmod +x install-root/nix-installer-aarch64-linux install-root/nix-installer.sh
-          file install-root/nix-installer-aarch64-linux
-          ls -al install-root/nix-installer-aarch64-linux
       - run: sudo apt install -y fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -525,16 +513,13 @@ jobs:
       - name: Restore Github cache artifacts
         uses: actions/download-artifact@v4
         with:
-          path: nix-installer
           name: nix-installer-aarch64-darwin
       - name: Move & set executable
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer/nix-installer install-root/nix-installer-aarch64-darwin
+          mv ./nix-installer-aarch64-darwin install-root/
           chmod +x install-root/nix-installer-aarch64-darwin install-root/nix-installer.sh
-          file install-root/nix-installer-aarch64-darwin
-          ls -al install-root/nix-installer-aarch64-darwin
       - run: brew install fish coreutils
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -623,16 +608,13 @@ jobs:
       - name: Restore Github cache artifacts
         uses: actions/download-artifact@v4
         with:
-          path: nix-installer
           name: nix-installer-x86_64-linux
       - name: Move & set executable
         run: |
           mkdir install-root
           cp nix-installer.sh install-root/nix-installer.sh
-          mv ./nix-installer/nix-installer install-root/nix-installer-x86_64-linux
+          mv ./nix-installer-x86_64-linux install-root/
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
-          file install-root/nix-installer-x86_64-linux
-          ls -al install-root/nix-installer-x86_64-linux
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Restore Github cache artifacts
-        uses: actions/cache/restore@v4
+        uses: actions/download-artifact@v4
         with:
           path: nix-installer
-          key: x86_64-linux-artifacts-${{ github.sha }}
+          name: nix-installer-x86_64-linux
       - name: Move & set executable
         run: |
           mkdir install-root
@@ -183,10 +183,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Restore Github cache artifacts
-        uses: actions/cache/restore@v4
+        uses: actions/download-artifact@v4
         with:
           path: nix-installer
-          key: x86_64-linux-artifacts-${{ github.sha }}
+          name: nix-installer-x86_64-linux
       - name: Move & set executable
         run: |
           mkdir install-root
@@ -307,10 +307,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Restore Github cache artifacts
-        uses: actions/cache/restore@v4
+        uses: actions/download-artifact@v4
         with:
           path: nix-installer
-          key: x86_64-darwin-artifacts-${{ github.sha }}
+          name: nix-installer-x86_64-darwin
       - name: Move & set executable
         run: |
           mkdir install-root
@@ -397,10 +397,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Restore Github cache artifacts
-        uses: actions/cache/restore@v4
+        uses: actions/download-artifact@v4
         with:
           path: nix-installer
-          key: aarch64-linux-artifacts-${{ github.sha }}
+          name: nix-installer-aarch64-linux
       - name: Move & set executable
         run: |
           mkdir install-root
@@ -515,10 +515,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Restore Github cache artifacts
-        uses: actions/cache/restore@v4
+        uses: actions/download-artifact@v4
         with:
           path: nix-installer
-          key: aarch64-darwin-artifacts-${{ github.sha }}
+          name: nix-installer-aarch64-darwin
       - name: Move & set executable
         run: |
           mkdir install-root
@@ -611,10 +611,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Restore Github cache artifacts
-        uses: actions/cache/restore@v4
+        uses: actions/download-artifact@v4
         with:
           path: nix-installer
-          key: x86_64-linux-artifacts-${{ github.sha }}
+          name: nix-installer-x86_64-linux
       - name: Move & set executable
         run: |
           mkdir install-root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-x86_64-linux
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
+          file install-root/nix-installer-x86_64-linux
+          ls -al install-root/nix-installer-x86_64-linux
       - run: sudo apt install fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -193,6 +195,8 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-x86_64-linux
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
+          file install-root/nix-installer-x86_64-linux
+          ls -al install-root/nix-installer-x86_64-linux
       - run: sudo apt install fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -317,6 +321,8 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-x86_64-darwin
           chmod +x install-root/nix-installer-x86_64-darwin install-root/nix-installer.sh
+          file install-root/nix-installer-x86_64-darwin
+          ls -al install-root/nix-installer-x86_64-darwin
       - run: brew install fish coreutils
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -407,6 +413,8 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-aarch64-linux
           chmod +x install-root/nix-installer-aarch64-linux install-root/nix-installer.sh
+          file install-root/nix-installer-aarch64-linux
+          ls -al install-root/nix-installer-aarch64-linux
       - run: sudo apt install -y fish zsh
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -525,6 +533,8 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-aarch64-darwin
           chmod +x install-root/nix-installer-aarch64-darwin install-root/nix-installer.sh
+          file install-root/nix-installer-aarch64-darwin
+          ls -al install-root/nix-installer-aarch64-darwin
       - run: brew install fish coreutils
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
@@ -621,6 +631,8 @@ jobs:
           cp nix-installer.sh install-root/nix-installer.sh
           mv ./nix-installer install-root/nix-installer-x86_64-linux
           chmod +x install-root/nix-installer-x86_64-linux install-root/nix-installer.sh
+          file install-root/nix-installer-x86_64-linux
+          ls -al install-root/nix-installer-x86_64-linux
       - name: Initial install
         uses: DeterminateSystems/nix-installer-action@main
         with:

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -41,14 +41,17 @@ jobs:
 
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -17,20 +17,12 @@ permissions:
 jobs:
   build-x86_64-linux:
     uses: ./.github/workflows/build-x86_64-linux.yml
-    with:
-      cache-key: release-x86_64-linux-artifacts-${{ github.sha }}
   build-aarch64-linux:
     uses: ./.github/workflows/build-aarch64-linux.yml
-    with:
-      cache-key: release-aarch64-linux-artifacts-${{ github.sha }}
   build-x86_64-darwin:
     uses: ./.github/workflows/build-x86_64-darwin.yml
-    with:
-      cache-key: release-x86_64-darwin-artifacts-${{ github.sha }}
   build-aarch64-darwin:
     uses: ./.github/workflows/build-aarch64-darwin.yml
-    with:
-      cache-key: release-aarch64-darwin-artifacts-${{ github.sha }}
 
   release:
     runs-on: ubuntu-latest
@@ -47,37 +39,23 @@ jobs:
       - name: Create artifacts directory
         run: mkdir -p ./artifacts
 
-      - name: Fetch cached x86_64-linux binary
-        uses: actions/cache/restore@v4
+      - name: Fetch x86_64-linux binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-x86_64-linux
+      - name: Fetch aarch64-linux binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-aarch64-linux
+      - name: Fetch x86_64-darwin binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-x86_64-darwin
+      - name: Fetch aarch64-darwin binary artifact
+        uses: actions/download-artifact@v4
         with:
-          path: nix-installer
-          key: release-x86_64-linux-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-x86_64-linux
-
-      - name: Fetch cached aarch64-linux binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-aarch64-linux-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-aarch64-linux
-
-      - name: Fetch cached x86_64-darwin binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-x86_64-darwin-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-x86_64-darwin
-
-      - name: Fetch cached aarch64-darwin binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-aarch64-darwin-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-aarch64-darwin
+          path: ./artifacts/nix-installer
+          name: nix-installer-aarch64-darwin
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -41,20 +41,20 @@ jobs:
 
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-aarch64-darwin
           name: nix-installer-aarch64-darwin
 
       - name: Configure AWS Credentials

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -42,23 +42,25 @@ jobs:
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-aarch64-darwin
           name: nix-installer-aarch64-darwin
+      - name: Move binaries into upload staging dir
+        run: |
+          mv nix-installer-x86_64-linux artifacts/
+          mv nix-installer-aarch64-linux artifacts/
+          mv nix-installer-x86_64-darwin artifacts/
+          mv nix-installer-aarch64-darwin artifacts/
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -27,8 +27,6 @@ jobs:
         || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'upload to s3'))
       )
     uses: ./.github/workflows/build-x86_64-linux.yml
-    with:
-      cache-key: release-x86_64-linux-artifacts-${{ github.sha }}
   build-aarch64-linux:
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
@@ -40,8 +38,6 @@ jobs:
         || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'upload to s3'))
       )
     uses: ./.github/workflows/build-aarch64-linux.yml
-    with:
-      cache-key: release-aarch64-linux-artifacts-${{ github.sha }}
   build-x86_64-darwin:
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
@@ -53,8 +49,6 @@ jobs:
         || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'upload to s3'))
       )
     uses: ./.github/workflows/build-x86_64-darwin.yml
-    with:
-      cache-key: release-x86_64-darwin-artifacts-${{ github.sha }}
   build-aarch64-darwin:
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
@@ -66,8 +60,6 @@ jobs:
         || (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'upload to s3'))
       )
     uses: ./.github/workflows/build-aarch64-darwin.yml
-    with:
-      cache-key: release-aarch64-darwin-artifacts-${{ github.sha }}
 
   release:
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
@@ -91,37 +83,23 @@ jobs:
       - name: Create artifacts directory
         run: mkdir -p ./artifacts
 
-      - name: Fetch cached x86_64-linux binary
-        uses: actions/cache/restore@v4
+      - name: Fetch x86_64-linux binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-x86_64-linux
+      - name: Fetch aarch64-linux binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-aarch64-linux
+      - name: Fetch x86_64-darwin binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-x86_64-darwin
+      - name: Fetch aarch64-darwin binary artifact
+        uses: actions/download-artifact@v4
         with:
-          path: nix-installer
-          key: release-x86_64-linux-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-x86_64-linux
-
-      - name: Fetch cached aarch64-linux binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-aarch64-linux-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-aarch64-linux
-
-      - name: Fetch cached x86_64-darwin binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-x86_64-darwin-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-x86_64-darwin
-
-      - name: Fetch cached aarch64-darwin binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-aarch64-darwin-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-aarch64-darwin
+          path: ./artifacts/nix-installer
+          name: nix-installer-aarch64-darwin
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -85,14 +85,17 @@ jobs:
 
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -85,20 +85,20 @@ jobs:
 
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-aarch64-darwin
           name: nix-installer-aarch64-darwin
 
       - name: Configure AWS Credentials

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -86,23 +86,25 @@ jobs:
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-aarch64-darwin
           name: nix-installer-aarch64-darwin
+      - name: Move binaries into upload staging dir
+        run: |
+          mv nix-installer-x86_64-linux artifacts/
+          mv nix-installer-aarch64-linux artifacts/
+          mv nix-installer-x86_64-darwin artifacts/
+          mv nix-installer-aarch64-darwin artifacts/
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -38,20 +38,20 @@ jobs:
 
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer
+          path: ./artifacts/nix-installer-aarch64-darwin
           name: nix-installer-aarch64-darwin
 
       - name: Configure AWS Credentials

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -39,23 +39,25 @@ jobs:
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact
         uses: actions/download-artifact@v4
         with:
-          path: ./artifacts/nix-installer-aarch64-darwin
           name: nix-installer-aarch64-darwin
+      - name: Move binaries into upload staging dir
+        run: |
+          mv nix-installer-x86_64-linux artifacts/
+          mv nix-installer-aarch64-linux artifacts/
+          mv nix-installer-x86_64-darwin artifacts/
+          mv nix-installer-aarch64-darwin artifacts/
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -38,14 +38,17 @@ jobs:
 
       - name: Fetch x86_64-linux binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux
       - name: Fetch x86_64-darwin binary artifact
         uses: actions/download-artifact@v4
+        with:
           path: ./artifacts/nix-installer-x86_64-darwin
           name: nix-installer-x86_64-darwin
       - name: Fetch aarch64-darwin binary artifact

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -15,20 +15,12 @@ permissions:
 jobs:
   build-x86_64-linux:
     uses: ./.github/workflows/build-x86_64-linux.yml
-    with:
-      cache-key: release-x86_64-linux-artifacts-${{ github.sha }}
   build-aarch64-linux:
     uses: ./.github/workflows/build-aarch64-linux.yml
-    with:
-      cache-key: release-aarch64-linux-artifacts-${{ github.sha }}
   build-x86_64-darwin:
     uses: ./.github/workflows/build-x86_64-darwin.yml
-    with:
-      cache-key: release-x86_64-darwin-artifacts-${{ github.sha }}
   build-aarch64-darwin:
     uses: ./.github/workflows/build-aarch64-darwin.yml
-    with:
-      cache-key: release-aarch64-darwin-artifacts-${{ github.sha }}
 
   release:
     environment: production
@@ -44,37 +36,23 @@ jobs:
       - name: Create artifacts directory
         run: mkdir -p ./artifacts
 
-      - name: Fetch cached x86_64-linux binary
-        uses: actions/cache/restore@v4
+      - name: Fetch x86_64-linux binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-x86_64-linux
+      - name: Fetch aarch64-linux binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-aarch64-linux
+      - name: Fetch x86_64-darwin binary artifact
+        uses: actions/download-artifact@v4
+          path: ./artifacts/nix-installer
+          name: nix-installer-x86_64-darwin
+      - name: Fetch aarch64-darwin binary artifact
+        uses: actions/download-artifact@v4
         with:
-          path: nix-installer
-          key: release-x86_64-linux-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-x86_64-linux
-
-      - name: Fetch cached aarch64-linux binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-aarch64-linux-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-aarch64-linux
-
-      - name: Fetch cached x86_64-darwin binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-x86_64-darwin-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-x86_64-darwin
-
-      - name: Fetch cached aarch64-darwin binary
-        uses: actions/cache/restore@v4
-        with:
-          path: nix-installer
-          key: release-aarch64-darwin-artifacts-${{ github.sha }}
-      - name: Move artifact to artifacts directory
-        run: mv ./nix-installer ./artifacts/nix-installer-aarch64-darwin
+          path: ./artifacts/nix-installer
+          name: nix-installer-aarch64-darwin
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
