### PR TITLE
Run the container / vm tests twice if they fail, with a timeout of 10…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,8 +598,8 @@ jobs:
       matrix:
         command:
           - nix flake check -L
-          - nix build -L --tarball-ttl 0 --keep-going .#hydraJobs.container-test.all.x86_64-linux.all
-          - nix build -L --tarball-ttl 0 --keep-going .#hydraJobs.vm-test.all.x86_64-linux.all
+          - nix build -L --tarball-ttl 0 --timeout 600 --keep-going .#hydraJobs.container-test.all.x86_64-linux.all
+          - nix build -L --tarball-ttl 0 --timeout 600 --keep-going .#hydraJobs.vm-test.all.x86_64-linux.all
     permissions:
       id-token: "write"
       contents: "read"
@@ -624,7 +624,12 @@ jobs:
           log-directives: nix_installer=debug
           logger: pretty
       - uses: DeterminateSystems/flakehub-cache-action@main
-      - run: ${{ matrix.command }}
+      - run: |
+          if ! (${{ matrix.command }}); then
+            echo "failed, retrying once ..."
+            printf "\n\n\n\n\n\n\n\n"
+            (${{ matrix.command }})
+          fi
 
   run-x86_64-linux-release-checks:
     name: Run x86_64 Linux release checks


### PR DESCRIPTION
…min each

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
