### PR TITLE
Ditch unnecessary concurrency groups

### DIFF
--- a/.github/workflows/propose-release.yml
+++ b/.github/workflows/propose-release.yml
@@ -14,10 +14,6 @@ on:
         type: string
         required: true
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
-
 jobs:
   propose-release:
     uses: DeterminateSystems/propose-release/.github/workflows/workflow.yml@main

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -1,8 +1,5 @@
 name: Release Branch
 
-concurrency:
-  group: release
-
 on:
   push:
     branches:

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -1,8 +1,5 @@
 name: Release PR
 
-concurrency:
-  group: release
-
 on:
   pull_request:
     types:

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -1,8 +1,5 @@
 name: Release Tags
 
-concurrency:
-  group: release
-
 on:
   release:
     types:


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
