### PR TITLE
Pin back plist to 1.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,9 +1513,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.4"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+checksum = "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed"
 dependencies = [
  "base64",
  "indexmap 2.10.0",
@@ -1565,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.0"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tracing-error = { version = "0.2.0", default-features = false, optional = true, 
 tracing-subscriber = { version = "0.3.15", default-features = false, features = [ "std", "registry", "fmt", "json", "ansi", "env-filter" ], optional = true }
 url = { version = "2.3.1", default-features = false, features = ["serde"] }
 xz2 = { version = "0.1.7", default-features = false, features = ["static", "tokio"] }
-plist = { version = "1.7.0", default-features = false, features = [ "serde" ]}
+plist = { version = "=1.7.2", default-features = false, features = [ "serde" ]}
 dirs = { version = "5.0.0", default-features = false }
 typetag = { version = "0.2.17", default-features = false }
 dyn-clone = { version = "1.0.9", default-features = false }


### PR DESCRIPTION
The update to 1.7.4 broke some parsing of profiles, which we'll dig in to separately.

The error:

    WARN Skipping SystemUIServer checks: failed to load profile data: Parse(Error { inner: ErrorImpl { kind: UnexpectedXmlCharactersExpectedElement, file_position: Some(FilePosition(657677)) } })
    WARN install: Skipping SystemUIServer checks: failed to load profile data: Parse(Error { inner: ErrorImpl { kind: UnexpectedXmlCharactersExpectedElement, file_position: Some(FilePosition(657677)) } })

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
