### PR TITLE
Fix build failure when default features disabled

### DIFF
--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -158,16 +158,16 @@ dyn_clone::clone_trait_object!(Planner);
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "cli", derive(clap::Subcommand))]
 pub enum BuiltinPlanner {
-    #[cfg_attr(not(target_os = "linux"), clap(hide = true))]
+    #[cfg_attr(all(feature = "cli", not(target_os = "linux")), clap(hide = true))]
     /// A planner for traditional, mutable Linux systems like Debian, RHEL, or Arch
     Linux(linux::Linux),
-    #[cfg_attr(not(target_os = "linux"), clap(hide = true))]
+    #[cfg_attr(all(feature = "cli", not(target_os = "linux")), clap(hide = true))]
     /// A planner for the Valve Steam Deck running SteamOS
     SteamDeck(steam_deck::SteamDeck),
-    #[cfg_attr(not(target_os = "linux"), clap(hide = true))]
+    #[cfg_attr(all(feature = "cli", not(target_os = "linux")), clap(hide = true))]
     /// A planner suitable for immutable systems using ostree, such as Fedora Silverblue
     Ostree(ostree::Ostree),
-    #[cfg_attr(not(target_os = "macos"), clap(hide = true))]
+    #[cfg_attr(all(feature = "cli", not(target_os = "macos")), clap(hide = true))]
     /// A planner for MacOS (Darwin) systems
     Macos(macos::Macos),
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -140,9 +140,9 @@ pub struct CommonSettings {
     )]
     pub nix_package_url: Option<UrlOrPath>,
 
-    #[clap(from_global)]
+    #[cfg_attr(all(feature = "cli"), clap(from_global))]
     pub proxy: Option<Url>,
-    #[clap(from_global)]
+    #[cfg_attr(all(feature = "cli"), clap(from_global))]
     pub ssl_cert_file: Option<PathBuf>,
 
     /// Extra configuration lines for `/etc/nix.conf`


### PR DESCRIPTION
##### Description

I want to leverage nix-installer as a rust library. I tried building the library without any features enabled and got compilation errors due due to usage of `clap` without the `cli` feature enabled (which I presume brings in clap).

This PR simply adds some checks to ensure the `cli` feature is enabled before calling anything from `clap`. Only two files needed to be modified before the code compiled without any features enabled.

Example error
```
error: cannot find attribute `clap` in this scope
   --> /Users/<username>/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/nix-installer-0.23.0/src/planner/mod.rs:180:42
    |
180 |     #[cfg_attr(not(target_os = "linux"), clap(hide = true))]
```


##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
