### PR TITLE
Pass --speed-limit and --speed-time when passing --retry

### DIFF
--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -280,7 +280,7 @@ downloader() {
     if [ "$1" = --check ]; then
         need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
-        check_curl_for_retry_support
+        check_curl_for_retry_and_speed_limit_support
         _retry="$RETVAL"
         get_ciphersuites_for_curl
         _ciphersuites="$RETVAL"
@@ -402,15 +402,24 @@ check_help_for() {
 }
 
 # Check if curl supports the --retry flag, then pass it to the curl invocation.
-check_curl_for_retry_support() {
+# Note that --speed-limit and --speed-time were in the very first commit of curl.
+# So this should be pretty much ubiquitously safe.
+check_curl_for_retry_and_speed_limit_support() {
   local _retry_supported=""
-  # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
-  if check_help_for "notspecified" "curl" "--retry"; then
-    _retry_supported="--retry 3"
-  fi
 
+  # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
+  if check_help_for "notspecified" "curl" "--retry" \
+      && check_help_for "notspecified" "curl" "--speed-limit" \
+      && check_help_for "notspecified" "curl" "--speed-time"; then
+
+    # 250000 is approximately 20% of the bandwidth of typical DSL
+    # these limits mean users below these limits will see failures.
+    # I don't believe we have any users like this, and if we do -- please open a ticket.
+    _retry_supported="--retry 3 --speed-limit 250000 --speed-time 15"
+  fi
   RETVAL="$_retry_supported"
 }
+
 
 # Return cipher suite string specified by user, otherwise return strong TLS 1.2-1.3 cipher suites
 # if support by local tools is detected. Detection currently supports these curl backends:


### PR DESCRIPTION
Some users report that the interior curl request stalls ~forever. This patch sets a low speed-limit of 20% of modern DSL throughput. If a user's download rate is just below the limit, it will take approximately five minutes to download.

When the speed limit trips, it will retry up to three times.

Hopefully this doesn't impact users, but if you are impacted, please open a ticket.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [x] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
