### PR TITLE
Add init_settings to Install and Ostree planners for enhanced configu…

### DIFF
--- a/src/cli/subcommand/install/mod.rs
+++ b/src/cli/subcommand/install/mod.rs
@@ -56,6 +56,9 @@ pub struct Install {
     #[clap(flatten)]
     pub settings: CommonSettings,
 
+    #[clap(flatten)]
+    pub init_settings: crate::settings::InitSettings,
+
     /// Provide an explanation of the changes the installation process will make to your system
     #[clap(
         long,
@@ -87,6 +90,7 @@ impl CommandExecute for Install {
             planner: maybe_planner,
             settings,
             explain,
+            init_settings,
         } = self;
 
         ensure_root()?;
@@ -127,7 +131,7 @@ impl CommandExecute for Install {
         } else {
             let mut planner = match maybe_planner {
                 Some(planner) => planner,
-                None => BuiltinPlanner::from_common_settings(settings.clone())
+                None => BuiltinPlanner::from_settings(settings.clone(), init_settings.clone())
                     .await
                     .map_err(|e| eyre::eyre!(e))?,
             };

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -215,12 +215,16 @@ impl BuiltinPlanner {
         Ok(Self::Linux(linux::Linux::default().await?))
     }
 
-    pub async fn from_common_settings(settings: CommonSettings) -> Result<Self, PlannerError> {
+
+    pub async fn from_settings(settings: CommonSettings, init_settings: crate::settings::InitSettings) -> Result<Self, PlannerError> {
         let mut built = Self::default().await?;
         match &mut built {
             BuiltinPlanner::Linux(inner) => inner.settings = settings,
             BuiltinPlanner::SteamDeck(inner) => inner.settings = settings,
-            BuiltinPlanner::Ostree(inner) => inner.settings = settings,
+            BuiltinPlanner::Ostree(inner) => {
+                inner.settings = settings;
+                inner.init_settings = init_settings;
+            },
             BuiltinPlanner::Macos(inner) => inner.settings = settings,
         }
         Ok(built)


### PR DESCRIPTION
…ration

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```
