### PR TITLE
docs: Passing `--prefer-upstream-nix` to `install` for upstream Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ curl -fsSL https://install.determinate.systems/nix | sh -s -- install --determin
 If you'd prefer upstream Nix:
 
 ```shell
-curl -fsSL https://install.determinate.systems/nix | sh -s -- install
+curl -fsSL https://install.determinate.systems/nix | sh -s -- install --prefer-upstream-nix
 ```
 
 > [!TIP]


### PR DESCRIPTION
The command example in the README file to install upstream Nix is not up to date, because the default distribution when `--prefer-upstream-nix` is not passed to `install` is `Distribution::DeterminateNix`.

https://github.com/DeterminateSystems/nix-installer/blob/91e0774401ea84ab8e0dcfdcfbc750ff7036435e/src/settings.rs#L324-L334

**Future Changes?**

Given that `Distribution::DeterminateNix` is the default distribution and the installer only supports two distributions for the time being, the logic to determine which distribution to install could be simplified a bit by removing the `--determinate` flag.


```rs
if self.prefer_upstream {
  Distribution::Nix
} else {
  Distribution::DeterminateNix
}
```

Additionally, a more general flag like `--distribution <determinate|upstream>` could be used instead of `--determinate` and `--prefer-upstream-nix` to allow for greater flexibility in the future. This could be addressed in a separate PR if the proposed changes make sense, as the primary goal of this one was to update the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example command in README with the `--prefer-upstream-nix` flag option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->