### PR TITLE
Use safe expansion for SSH_CONNECTION and SHLVL variable

### DIFF
--- a/src/action/macos/configure_remote_building.rs
+++ b/src/action/macos/configure_remote_building.rs
@@ -23,7 +23,7 @@ impl ConfigureRemoteBuilding {
             r#"
 # Set up Nix only on SSH connections
 # See: https://github.com/DeterminateSystems/nix-installer/pull/714
-if [ -e '{PROFILE_NIX_FILE_SHELL}' ] && [ -n "${{SSH_CONNECTION}}" ] && [ "${{SHLVL}}" -eq 1 ]; then
+if [ -e '{PROFILE_NIX_FILE_SHELL}' ] && [ -n "${{SSH_CONNECTION:-}}" ] && [ "${{SHLVL:-0}}" -eq 1 ]; then
     . '{PROFILE_NIX_FILE_SHELL}'
 fi
 # End Nix

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -1188,7 +1188,7 @@
             "user": null,
             "group": null,
             "mode": 420,
-            "buf": "\n# Set up Nix only on SSH connections\n# See: https://github.com/DeterminateSystems/nix-installer/pull/714\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ] && [ -n \"${SSH_CONNECTION}\" ] && [ \"${SHLVL}\" -eq 1 ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n",
+            "buf": "\n# Set up Nix only on SSH connections\n# See: https://github.com/DeterminateSystems/nix-installer/pull/714\nif [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ] && [ -n \"${SSH_CONNECTION:-}\" ] && [ \"${SHLVL:-0}\" -eq 1 ]; then\n    . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'\nfi\n# End Nix\n",
             "position": "Beginning"
           },
           "state": "Completed"


### PR DESCRIPTION
##### Description

Resolves https://github.com/DeterminateSystems/nix-installer/issues/1722

Replaced direct variable expansion with ${VAR:-} to avoid “parameter not set” errors when running the [Mac App Store command-line interface](https://formulae.brew.sh/formula/mas).

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [x] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS remote-building setup now robustly handles unset SSH/session variables in non-interactive SSH sessions. This prevents errors when those variables are absent and ensures the Nix profile sourcing behavior remains consistent across different shell environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->