### PR TITLE
Update installation command for Determinate Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ By default, it installs Determinate Nix, which enables [flakes] and offers a var
 This one-liner installs Determinate Nix on just about any supported system:
 
 ```shell
-curl -fsSL https://install.determinate.systems/nix | sh -s -- install --prefer-upstream-nix
+curl -fsSL https://install.determinate.systems/nix | sh -s -- install
 ```
 
 > [!TIP]


### PR DESCRIPTION
Removed the '--prefer-upstream-nix' option from the installation command.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation command in README for a simplified setup process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->