### PR TITLE
fix: prevent duplicate /nix entries in fstab

### DIFF
--- a/src/action/macos/create_fstab_entry.rs
+++ b/src/action/macos/create_fstab_entry.rs
@@ -146,7 +146,7 @@ impl Action for CreateFstabEntry {
                 }
             })
             .filter_map(|line| {
-                if line.split(&[' ', '\t']).nth(1) == Some("/nix") {
+                if line.split_ascii_whitespace().nth(1) == Some("/nix") {
                     // Delete the mount line for /nix
                     None
                 } else {


### PR DESCRIPTION
Filter out all existing /nix mount point entries and prelude comments, then always append exactly one new fstab entry to ensure at most one /nix entry in the output.

Forward-ported from https://github.com/NixOS/nix-installer/pull/55

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Always ensures exactly one /nix filesystem entry in system config, removing duplicate or outdated entries.
  * Improves cleanup of old /nix lines and treats a missing config file as empty.
  * Writes updates atomically and preserves trailing newline to avoid partial or malformed configs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->