### PR TITLE
Clarify which installer is being downloaded

### DIFF
--- a/nix-installer.sh
+++ b/nix-installer.sh
@@ -89,7 +89,7 @@ main() {
         need_tty=no
     fi
 
-    say 'downloading Determinate Nix Installer'
+    say 'downloading the Determinate Nix Installer'
 
     ensure mkdir -p "$_dir"
     ensure downloader "$_url" "$_file" "$_arch"


### PR DESCRIPTION
The current "downloading installer" message could afford to be more informative. Specifying _which_ installer is at issue provides better context for the following messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified installer download message — now reads “downloading the Determinate Nix Installer” to more accurately convey which installer is being retrieved and improve log clarity during setup.
  * No functional or behavioral changes; wording-only update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->