### PR TITLE
Prevent daemon from being used before its available

### DIFF
--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -76,6 +76,7 @@ impl Action for SetupDefaultProfile {
             "HOME",
             dirs::home_dir().ok_or_else(|| Self::error(SetupDefaultProfileError::NoRootHome))?,
         );
+        load_db_command.env_remove("NIX_REMOTE");
         tracing::trace!(
             "Executing `{:?}` with stdin from `{}`",
             load_db_command.as_std(),

--- a/src/profile/nixenv/mod.rs
+++ b/src/profile/nixenv/mod.rs
@@ -318,6 +318,7 @@ impl NixCommandExt for tokio::process::Command {
         Ok(self
             .args(["--option", "substitute", "false"])
             .args(["--option", "post-build-hook", ""])
+            .env_remove("NIX_REMOTE")
             .env("HOME", dirs::home_dir().ok_or(super::Error::NoRootHome)?)
             .env(
                 "NIX_SSL_CERT_FILE",

--- a/src/profile/nixprofile/mod.rs
+++ b/src/profile/nixprofile/mod.rs
@@ -336,6 +336,7 @@ impl NixCommandExt for tokio::process::Command {
         Ok(self
             .args(["--option", "substitute", "false"])
             .args(["--option", "post-build-hook", ""])
+            .env_remove("NIX_REMOTE")
             .env("HOME", dirs::home_dir().ok_or(super::Error::NoRootHome)?)
             .env(
                 "NIX_SSL_CERT_FILE",


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

`NIX_REMOTE=daemon` can force nix builds to use the daemon, even when the user is root.
For magic-nix-cache, we need to use the daemon for things to upload.

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an unintended environment variable from being passed into Nix subprocesses, avoiding conflicts during package installation, removal, profile updates, and other Nix operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->