### PR TITLE
Update Nix formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         run: nix develop --command check-clippy
       - name: Check Spelling
         run: nix develop --command check-spelling
-      - name: Check nixpkgs-fmt formatting
-        run: nix develop --command check-nixpkgs-fmt
+      - name: Check Nix formatting
+        run: nix develop --command check-nixfmt
       - name: Check EditorConfig conformance
         run: nix develop --command check-editorconfig
       - name: Shell check for nix-installer.sh

--- a/nix/check.nix
+++ b/nix/check.nix
@@ -6,57 +6,96 @@ in
 {
 
   # Format
-  check-rustfmt = (writeShellApplication {
-    name = "check-rustfmt";
-    runtimeInputs = with pkgs; [ cargo rustfmt ];
-    text = "cargo fmt --check";
-  });
+  check-rustfmt = (
+    writeShellApplication {
+      name = "check-rustfmt";
+      runtimeInputs = with pkgs; [
+        cargo
+        rustfmt
+      ];
+      text = "cargo fmt --check";
+    }
+  );
 
   # Spelling
-  check-spelling = (writeShellApplication {
-    name = "check-spelling";
-    runtimeInputs = with pkgs; [ git codespell ];
-    text = ''
-      codespell \
-        --ignore-words-list="ba,sur,crate,pullrequest,pullrequests,ser,distroname" \
-        --skip="./target,.git,./src/action/linux/selinux,*.lock" \
-        .
-    '';
-  });
+  check-spelling = (
+    writeShellApplication {
+      name = "check-spelling";
+      runtimeInputs = with pkgs; [
+        git
+        codespell
+      ];
+      text = ''
+        codespell \
+          --ignore-words-list="ba,sur,crate,pullrequest,pullrequests,ser,distroname" \
+          --skip="./target,.git,./src/action/linux/selinux,*.lock" \
+          .
+      '';
+    }
+  );
 
-  # NixFormatting
-  check-nixpkgs-fmt = (writeShellApplication {
-    name = "check-nixpkgs-fmt";
-    runtimeInputs = with pkgs; [ git nixpkgs-fmt findutils ];
-    text = ''
-      nixpkgs-fmt --check .
-    '';
-  });
+  # Check Nix formatting
+  check-nixfmt = (
+    writeShellApplication {
+      name = "check-nixfmt";
+      runtimeInputs = with pkgs; [
+        git
+        nixfmt
+      ];
+      text = ''
+        git ls-files '*.nix' | xargs nixfmt --check
+      '';
+    }
+  );
+
+  # Format Nix
+  format-nix = (
+    writeShellApplication {
+      name = "format-nix";
+      runtimeInputs = with pkgs; [
+        git
+        nixfmt
+      ];
+      text = ''
+        git ls-files '*.nix' | xargs nix fmt
+      '';
+    }
+  );
 
   # EditorConfig
-  check-editorconfig = (writeShellApplication {
-    name = "check-editorconfig";
-    runtimeInputs = with pkgs; [ editorconfig-checker ];
-    text = ''
-      editorconfig-checker
-    '';
-  });
+  check-editorconfig = (
+    writeShellApplication {
+      name = "check-editorconfig";
+      runtimeInputs = with pkgs; [ editorconfig-checker ];
+      text = ''
+        editorconfig-checker
+      '';
+    }
+  );
 
   # Semver
-  check-semver = (writeShellApplication {
-    name = "check-semver";
-    runtimeInputs = with pkgs; [ cargo-semver-checks ];
-    text = ''
-      cargo-semver-checks semver-checks check-release
-    '';
-  });
+  check-semver = (
+    writeShellApplication {
+      name = "check-semver";
+      runtimeInputs = with pkgs; [ cargo-semver-checks ];
+      text = ''
+        cargo-semver-checks semver-checks check-release
+      '';
+    }
+  );
   # Clippy
-  check-clippy = (writeShellApplication {
-    name = "check-clippy";
-    runtimeInputs = with pkgs; [ cargo clippy rustc ];
-    text = ''
-      cargo clippy
-    '';
-  });
+  check-clippy = (
+    writeShellApplication {
+      name = "check-clippy";
+      runtimeInputs = with pkgs; [
+        cargo
+        clippy
+        rustc
+      ];
+      text = ''
+        cargo clippy
+      '';
+    }
+  );
 
 }

--- a/nix/tests/container-test/default.nix
+++ b/nix/tests/container-test/default.nix
@@ -36,33 +36,45 @@ let
     };
   };
 
-  makeTest = containerTool: imageName:
-    let image = images.${imageName}; in
-    with (forSystem image.system ({ system, pkgs, lib, ... }: pkgs));
-    testers.nixosTest
+  makeTest =
+    containerTool: imageName:
+    let
+      image = images.${imageName};
+    in
+    with (forSystem image.system (
       {
-        name = "container-test-${imageName}";
-        nodes = {
-          machine =
-            { config, pkgs, ... }: {
-              virtualisation.${containerTool}.enable = true;
-              virtualisation.diskSize = 4 * 1024;
-            };
-        };
-        testScript = ''
-          machine.start()
-          machine.copy_from_host("${image.tarball}", "/image")
-          machine.succeed("mkdir -p /test")
-          machine.copy_from_host("${image.tester}", "/test/Dockerfile")
-          machine.copy_from_host("${nix-installer-static}", "/test/nix-installer")
-          machine.copy_from_host("${binaryTarball.${system}}", "/test/binary-tarball")
-          machine.succeed("${containerTool} import /image default")
-          machine.succeed("${containerTool} build -t test /test")
-        '';
+        system,
+        pkgs,
+        lib,
+        ...
+      }:
+      pkgs
+    ));
+    testers.nixosTest {
+      name = "container-test-${imageName}";
+      nodes = {
+        machine =
+          { config, pkgs, ... }:
+          {
+            virtualisation.${containerTool}.enable = true;
+            virtualisation.diskSize = 4 * 1024;
+          };
       };
+      testScript = ''
+        machine.start()
+        machine.copy_from_host("${image.tarball}", "/image")
+        machine.succeed("mkdir -p /test")
+        machine.copy_from_host("${image.tester}", "/test/Dockerfile")
+        machine.copy_from_host("${nix-installer-static}", "/test/nix-installer")
+        machine.copy_from_host("${binaryTarball.${system}}", "/test/binary-tarball")
+        machine.succeed("${containerTool} import /image default")
+        machine.succeed("${containerTool} build -t test /test")
+      '';
+    };
 
-  container-tests = builtins.mapAttrs
-    (imageName: image: (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); {
+  container-tests = builtins.mapAttrs (
+    imageName: image:
+    (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); {
       ${image.system} = rec {
         docker = makeTest "docker" imageName;
         podman = makeTest "podman" imageName;
@@ -74,27 +86,36 @@ let
           ];
         };
       };
-    }))
-    images;
+    })
+  ) images;
 
 in
-container-tests // {
+container-tests
+// {
   all."x86_64-linux" = rec {
-    all = (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); pkgs.releaseTools.aggregate {
-      name = "all";
-      constituents = [
-        docker
-        podman
-      ];
-    });
-    docker = (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); pkgs.releaseTools.aggregate {
-      name = "all";
-      constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".docker) container-tests;
-    });
-    podman = (with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs)); pkgs.releaseTools.aggregate {
-      name = "all";
-      constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".podman) container-tests;
-    });
+    all = (
+      with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs));
+      pkgs.releaseTools.aggregate {
+        name = "all";
+        constituents = [
+          docker
+          podman
+        ];
+      }
+    );
+    docker = (
+      with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs));
+      pkgs.releaseTools.aggregate {
+        name = "all";
+        constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".docker) container-tests;
+      }
+    );
+    podman = (
+      with (forSystem "x86_64-linux" ({ system, pkgs, ... }: pkgs));
+      pkgs.releaseTools.aggregate {
+        name = "all";
+        constituents = pkgs.lib.mapAttrsToList (name: value: value."x86_64-linux".podman) container-tests;
+      }
+    );
   };
 }
-


### PR DESCRIPTION
This updates the installer repo to use the official Nix formatter rather than nixpkgs-fmt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated Nix formatting checks from nixpkgs-fmt to nixfmt across the CI pipeline and build infrastructure.
  * Added a new `format-nix` tool for Nix code formatting.
  * Refactored internal build configuration and test harness structure for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->