### PR TITLE
SelfTest: tell the user when running the self tests

### DIFF
--- a/src/self_test.rs
+++ b/src/self_test.rs
@@ -74,9 +74,12 @@ impl Shell {
         }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn self_test(&self) -> Result<(), SelfTestError> {
         let executable = self.executable();
+
+        tracing::info!("Running self test for shell {executable}");
+
         let mut command = match &self {
             // On Mac, `bash -ic nix` won't work, but `bash -lc nix` will.
             Shell::Sh | Shell::Bash => {
@@ -146,9 +149,11 @@ impl Shell {
     }
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 pub async fn self_test() -> Result<(), Vec<SelfTestError>> {
     let shells = Shell::discover();
+
+    tracing::debug!(?shells, "Discovered shells to self test");
 
     let mut failures = vec![];
 


### PR DESCRIPTION
Otherwise, if something happens to the self test, users may think the previous output is what is hanging (usually "INFO Step: Remove directory `/nix/temp-install-dir`") instead of the self test.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging for the self-test functionality to provide clearer troubleshooting information during shell discovery and test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->