### PR TITLE
Run daemon at startup

### DIFF
--- a/src/action/common/configure_determinate_nixd_init_service/mod.rs
+++ b/src/action/common/configure_determinate_nixd_init_service/mod.rs
@@ -206,7 +206,7 @@ enum SocketFamily {
 
 fn generate_plist() -> DeterminateNixDaemonPlist {
     DeterminateNixDaemonPlist {
-        run_at_load: false,
+        run_at_load: true,
         label: "systems.determinate.nix-daemon".into(),
         program_arguments: vec!["/usr/local/bin/determinate-nixd".into(), "daemon".into()],
         standard_error_path: "/var/log/determinate-nix-daemon.log".into(),

--- a/src/action/common/configure_init_service.rs
+++ b/src/action/common/configure_init_service.rs
@@ -181,6 +181,12 @@ impl Action for ConfigureInitService {
         let mut vec = Vec::new();
         match self.init {
             InitSystem::Systemd => {
+                let service_dest = self
+                    .service_dest
+                    .as_ref()
+                    .expect("service_dest should be defined for systemd")
+                    .display();
+
                 let mut explanation = vec![
                     "Run `systemd-tmpfiles --create --prefix=/nix/var/nix`".to_string(),
                     match self
@@ -188,21 +194,10 @@ impl Action for ConfigureInitService {
                         .as_ref()
                         .expect("service_src should be defined or systemd")
                     {
-                        UnitSrc::Path(src) => format!(
-                            "Symlink `{0}` to `{1}`",
-                            src.display(),
-                            self.service_dest
-                                .as_ref()
-                                .expect("service_dest should be defined for systemd")
-                                .display()
-                        ),
-                        UnitSrc::Literal(_) => format!(
-                            "Create `{0}`",
-                            self.service_dest
-                                .as_ref()
-                                .expect("service_dest should be defined for systemd")
-                                .display()
-                        ),
+                        UnitSrc::Path(src) => {
+                            format!("Symlink `{0}` to `{1}`", src.display(), service_dest,)
+                        },
+                        UnitSrc::Literal(_) => format!("Create `{0}`", service_dest,),
                     },
                 ];
 
@@ -227,6 +222,13 @@ impl Action for ConfigureInitService {
                         explanation.push(format!("Run `systemctl enable --now {}`", name));
                     }
                 }
+
+                explanation.push(format!(
+                    "Run `systemctl enable {}{}`",
+                    if self.start_daemon { "--now " } else { "" },
+                    service_dest
+                ));
+
                 vec.push(ActionDescription::new(self.tracing_synopsis(), explanation))
             },
             InitSystem::Launchd => {
@@ -478,6 +480,10 @@ impl Action for ConfigureInitService {
                         },
                     }
                 }
+
+                enable(service_dest.display().to_string().as_ref(), *start_daemon)
+                    .await
+                    .map_err(Self::error)?;
             },
             InitSystem::None => {
                 // Nothing here, no init system


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon service now set to start automatically when the system loads.
  * Initialization now enables the main service unit during setup so the service can be activated immediately (includes conditional --now behavior respecting the "start daemon" setting).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->