### PR TITLE
Enable auto-optimise-store on macOS

### DIFF
--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -127,8 +127,10 @@ impl PlaceNixConfiguration {
             experimental_features.join(" "),
         );
 
+        // Previously disabled on macOS due to:
         // https://github.com/DeterminateSystems/nix-installer/issues/449#issuecomment-1551782281
-        #[cfg(not(target_os = "macos"))]
+        // But was fixed:
+        // https://github.com/NixOS/nix/pull/14676
         settings.insert("auto-optimise-store".to_string(), "true".to_string());
 
         // https://github.com/NixOS/nix/pull/8047


### PR DESCRIPTION
The issue that caused us to disable it was fixed in November: https://github.com/NixOS/nix/pull/14676

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-optimise-store setting to now apply consistently across all platforms, including macOS, which was previously excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->