### PR TITLE
Remove OSTree Support Claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Determinate Nix installer has numerous advantages over these options:
 - It enables you to perform a best-effort reversion in the facing of a failed install
 - It improves installation performance by maximizing parallel operations
 - It supports an expanded test suite including "curing" cases (compatibility with Nix already on the system)
-- It supports SELinux and OSTree-based distributions without asking users to make compromises
+- It supports SELinux distributions without asking users to make compromises
 - It operates as a single, static binary with external dependencies such as [OpenSSL], only calling existing system tools (like `useradd`) when necessary
 - As a macOS remote build target, it ensures that Nix is present on the `PATH`
 


### PR DESCRIPTION
Installer does not currently work on [most OSTree distributions](https://github.com/DeterminateSystems/nix-installer/issues/1682) with [known workarounds breaking](https://github.com/DeterminateSystems/nix-installer/issues/1596#issuecomment-3746102740).  It seems that upstream work needs to be done [1](https://github.com/coreos/rpm-ostree/issues/5554), [2](https://github.com/DeterminateSystems/nix-installer/issues/1445).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified feature description in README for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->