### PR TITLE
encrypt_apfs_volume: skip force-unmount when already mounted at /nix

### DIFF
--- a/src/action/macos/encrypt_apfs_volume.rs
+++ b/src/action/macos/encrypt_apfs_volume.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     distribution::Distribution,
     execute_command,
-    os::darwin::DiskUtilApfsListOutput,
+    os::darwin::{DiskUtilApfsListOutput, DiskUtilInfoOutput},
 };
 use rand::Rng;
 use std::{
@@ -289,15 +289,48 @@ impl Action for EncryptApfsVolume {
             }
         }
 
-        execute_command(
-            Command::new("/usr/sbin/diskutil")
-                .process_group(0)
-                .arg("unmount")
-                .arg("force")
-                .arg(&self.name),
-        )
-        .await
-        .map_err(Self::error)?;
+        // If the volume is already mounted at /nix on the disk we expect, skip the
+        // trailing force-unmount: the volume mount LaunchDaemon bootstrapped a few
+        // steps later (`systems.determinate.nix-store` for Determinate, or
+        // `org.nixos.darwin-store` for upstream Nix) treats its mount step as a
+        // no-op against an already-correctly-mounted volume, so the unmount serves
+        // no purpose in that case.
+        //
+        // Force-unmounting a `/nix` volume that is currently serving live
+        // `/nix/store` mmaps to user processes severs those mappings; macOS then
+        // delivers SIGBUS to every process the next time it touches a page from
+        // the now-detached volume — terminals, editors, GUI apps whose code or
+        // libs are paged from `/nix/store` all die mid-install. Remounting the
+        // same APFS volume afterwards does not restore the severed mappings.
+        //
+        // Mirrors the existing `UnmountApfsVolume::plan_skip_if_already_mounted_to_nix`
+        // pattern used for the other unmount in this install path.
+        let already_mounted_at_nix = match DiskUtilInfoOutput::for_volume_name(&self.name).await {
+            Ok(info) => {
+                Path::new(&info.parent_whole_disk) == self.disk
+                    && info.mount_point.as_deref() == Some(Path::new("/nix"))
+            },
+            Err(_) => false,
+        };
+
+        if already_mounted_at_nix {
+            tracing::debug!(
+                volume = %self.name,
+                disk = %self.disk.display(),
+                "Volume is already mounted at /nix on the expected disk; skipping \
+                 force-unmount to avoid SIGBUS on processes with /nix/store mmaps"
+            );
+        } else {
+            execute_command(
+                Command::new("/usr/sbin/diskutil")
+                    .process_group(0)
+                    .arg("unmount")
+                    .arg("force")
+                    .arg(&self.name),
+            )
+            .await
+            .map_err(Self::error)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
##### Description

When `EncryptApfsVolume::execute` runs on a host where `/nix` is already
correctly mounted, the trailing unconditional
`/usr/sbin/diskutil unmount force <name>` severs every active mmap from
`/nix/store`. macOS doesn't proactively kill processes whose mappings live
on the now-detached volume — instead the kernel breaks the backing and
delivers `SIGBUS` to each process the next time it touches a page in the
severed mapping. In practice every process whose code or libs live in
`/nix/store` (terminals, editors, GUI apps, …) dies mid-install. This
PR gates that unmount on a `DiskUtilInfoOutput::for_volume_name(...)`
check that mirrors the existing
[`UnmountApfsVolume::plan_skip_if_already_mounted_to_nix`](https://github.com/DeterminateSystems/nix-installer/blob/v3.19.0/src/action/macos/unmount_apfs_volume.rs)
idiom — when the volume is already mounted at `/nix` on the expected
disk, skip the unmount.

Reproduces with both `installer -pkg Determinate.pkg -tgt /` and direct
`nix-installer install --determinate` on a host with vanilla nix already
present at `/nix` (the bug lives in the open-source `nix-installer`; the
`.pkg` is a wrapper around it).

Real-world incident: I hit this manually on my own laptop while testing
a Determinate Nix upgrade — `ghostty`, `tmux` (and every shell inside
it), and `logseq` all crashed simultaneously the moment the installer
hit the encrypt-volume step.

#### Probe survival, with and without this patch

Validated end-to-end against `main` at v3.19.0 inside a `tart` VM. Four
probe processes were spawned before the install, each chosen to isolate
which relationship to `/nix/store` matters:

| Probe | Executable | `/nix/store` relationship | Without patch | With patch |
|---|---|---|---|---|
| 1 | `coreutils sleep` | mmap'd; idle (no page touches) | alive | alive |
| 2 | `bash` from `/nix/store` in a write loop | mmap'd; active text pages | **SIGBUS (138)** | alive |
| 3 | `python3Minimal` from `/nix/store` in a write loop | mmap'd; many `.so` pages | **SIGBUS (138)** | alive |
| 4 | system `/bin/bash` with cwd inside `/nix/store` | only cwd entry | alive (control) | alive (control) |

#### `fs_usage -w -f filesys` during the install window

Without the patch:

```
... 21:03:52.052337  unmount  <FORCE>            /nix                          0.113107  diskarbitrationd.10393
... 21:03:52.767647  mount    <FLGS=0x18100008>  /nix    /dev/disk3s7          0.000538  mount_apfs.10520
```

(The unmount carries `<FORCE>` — the macOS-specific path that bypasses
the "resource busy" check that would normally protect mmap'd files.
Proximate caller is `diskarbitrationd`, requested via XPC by
`nix-installer`.)

With the patch: zero `unmount` or `mount` opcodes against `/nix` during
the install window, and `/nix` stays mounted at the same `dev_t`
throughout. The same install was also exercised through the production
`.pkg` path (a re-flattened upstream `Determinate.pkg` with the patched
`nix-installer` binary swapped into `Scripts/`), with the same outcome.

#### Notes on the patch

- The skip predicate is `parent_whole_disk == self.disk &&
  mount_point == Some("/nix")`. This is intentionally identical to the
  shape of `UnmountApfsVolume::plan_skip_if_already_mounted_to_nix`,
  which is already used to skip a different unmount of the same volume
  earlier in the install path — both sites should trip on the same
  precondition.
- One known edge case (preserved for symmetry, out of scope for this
  PR): the `parent_whole_disk == self.disk` comparison is sensitive to
  whether the user supplied `--root-disk` with or without a `/dev/`
  prefix. The existing `plan_skip_if_already_mounted_to_nix` has the
  same behavior, so this PR doesn't make things worse — but tightening
  both sites to canonicalize the disk path before comparing is a
  reasonable follow-up.
- `tracing::debug!` is emitted when the skip path fires, so a verbose
  install log will record that the unmount was deliberately skipped
  (as opposed to silently elided).

##### Checklist

- [x] Formatted with `cargo fmt`
- [x] Built with `nix build`
- [x] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (validated via a macOS-specific `tart`-VM end-to-end harness that is not appropriate for inclusion in-tree — depends on `tart`, `sshpass`, and live network resources)
- [x] Added or updated relevant documentation (inline rationale in the patch)
- [ ] Linked to related issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced disk operation handling with intelligent state verification, avoiding redundant operations and improving system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->