### PR TITLE
Provide GitHub Actions pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,16 @@
 version: 2
+
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "monthly"
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "monthly"
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: DeterminateSystems/*
+    commit-message:
+      prefix: ci

--- a/.github/workflows/build-aarch64-darwin.yml
+++ b/.github/workflows/build-aarch64-darwin.yml
@@ -8,10 +8,12 @@ jobs:
     name: Build aarch64 Darwin (static)
     runs-on: namespace-profile-mac-m2-12c28g
     permissions:
-      id-token: "write"
-      contents: "read"
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
@@ -20,7 +22,7 @@ jobs:
           nix build .#packages.aarch64-darwin.nix-installer-static -L
           cp result/bin/nix-installer ./nix-installer-aarch64-darwin
       - name: Create GitHub artifacts from build outputs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: nix-installer-aarch64-darwin
           name: nix-installer-aarch64-darwin

--- a/.github/workflows/build-aarch64-linux.yml
+++ b/.github/workflows/build-aarch64-linux.yml
@@ -11,7 +11,9 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
@@ -20,7 +22,7 @@ jobs:
           nix build .#packages.aarch64-linux.nix-installer-static -L
           cp result/bin/nix-installer ./nix-installer-aarch64-linux
       - name: Create GitHub artifacts from build outputs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: nix-installer-aarch64-linux
           name: nix-installer-aarch64-linux

--- a/.github/workflows/build-x86_64-linux.yml
+++ b/.github/workflows/build-x86_64-linux.yml
@@ -8,10 +8,12 @@ jobs:
     name: Build x86_64 Linux (static)
     runs-on: UbuntuLatest32Cores128G
     permissions:
-      id-token: "write"
-      contents: "read"
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@main
       - uses: DeterminateSystems/flakehub-cache-action@main
@@ -20,7 +22,7 @@ jobs:
           nix build .#packages.x86_64-linux.nix-installer-static -L
           cp result/bin/nix-installer ./nix-installer-x86_64-linux
       - name: Create GitHub artifacts from build outputs
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           path: nix-installer-x86_64-linux
           name: nix-installer-x86_64-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,20 @@ on:
   push:
     branches: [main]
 
-permissions:
-  id-token: "write"
-  contents: "read"
-
 jobs:
   build-x86_64-linux:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-x86_64-linux.yml
 
   build-aarch64-linux:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-aarch64-linux.yml
 
   build-aarch64-darwin:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-aarch64-darwin.yml
 
   lints:
@@ -27,7 +29,9 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Check Nixpkgs input
         uses: DeterminateSystems/flake-checker-action@main
         with:
@@ -60,9 +64,11 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Restore Github cache artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-x86_64-linux
       - name: Move & set executable
@@ -177,9 +183,11 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Restore Github cache artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-x86_64-linux
       - name: Move & set executable
@@ -300,9 +308,11 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Restore Github cache artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-aarch64-linux
       - name: Move & set executable
@@ -417,9 +427,11 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Restore Github cache artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-aarch64-darwin
       - name: Move & set executable
@@ -512,9 +524,11 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Restore Github cache artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-x86_64-linux
       - name: Move & set executable
@@ -542,6 +556,8 @@ jobs:
   run-x86_64-linux-release-checks:
     name: Run x86_64 Linux release checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [run-x86_64-linux-release-check-matrix]
     if: (startsWith(github.ref, 'release-') || startsWith(github.head_ref, 'release-')) && always()
     steps:

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -7,16 +7,18 @@ on:
       # otherwise creating the directory and uploading to s3 will fail
       - "main"
 
-permissions:
-  id-token: "write"
-  contents: "read"
-
 jobs:
   build-x86_64-linux:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-x86_64-linux.yml
   build-aarch64-linux:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-aarch64-linux.yml
   build-aarch64-darwin:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-aarch64-darwin.yml
 
   release:
@@ -29,20 +31,22 @@ jobs:
       - build-aarch64-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Create artifacts directory
         run: mkdir -p ./artifacts
 
       - name: Fetch x86_64-linux binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-aarch64-linux
       - name: Fetch aarch64-darwin binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-aarch64-darwin
       - name: Move binaries into upload staging dir
@@ -52,25 +56,26 @@ jobs:
           mv nix-installer-aarch64-darwin artifacts/
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_S3_UPLOAD_ROLE }}
           aws-region: us-east-2
       - name: Publish Release (Branch)
         env:
           AWS_BUCKET: ${{ secrets.AWS_S3_UPLOAD_BUCKET }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          BRANCH="branch_${{ github.ref_name }}"
-          GIT_ISH="$GITHUB_SHA"
-          ./upload_s3.sh "$BRANCH" "$GIT_ISH" "https://install.determinate.systems/nix/rev/$GIT_ISH"
+          BRANCH="branch_${REF_NAME}"
+          GIT_ISH="${GITHUB_SHA}"
+          ./upload_s3.sh "${BRANCH}" "${GIT_ISH}" "https://install.determinate.systems/nix/rev/${GIT_ISH}"
       - name: Install Instructions (Branch)
         run: |
           cat <<EOF
           This commit can be installed by running the following command:
 
-          curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/rev/$GITHUB_SHA | sh -s -- install
+          curl --proto '=https' --tlsv1.2 -sSf -L "https://install.determinate.systems/nix/rev/${GITHUB_SHA}" | sh -s -- install
 
           The latest commit from this branch can be installed by running the following command:
 
-          curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/branch/${{ github.ref_name }} | sh -s -- install
+          curl --proto '=https' --tlsv1.2 -sSf -L "https://install.determinate.systems/nix/branch/${REF_NAME}" | sh -s -- install
           EOF

--- a/.github/workflows/release-prs.yml
+++ b/.github/workflows/release-prs.yml
@@ -8,12 +8,10 @@ on:
       - synchronize
       - labeled
 
-permissions:
-  id-token: "write"
-  contents: "read"
-
 jobs:
   build-x86_64-linux:
+    permissions:
+      contents: read
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
     if: |
@@ -25,6 +23,8 @@ jobs:
       )
     uses: ./.github/workflows/build-x86_64-linux.yml
   build-aarch64-linux:
+    permissions:
+      contents: read
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
     if: |
@@ -36,6 +36,8 @@ jobs:
       )
     uses: ./.github/workflows/build-aarch64-linux.yml
   build-aarch64-darwin:
+    permissions:
+      contents: read
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
     if: |
@@ -48,6 +50,8 @@ jobs:
     uses: ./.github/workflows/build-aarch64-darwin.yml
 
   release:
+    permissions:
+      contents: read
     # Only intra-repo PRs are allowed to have PR artifacts uploaded
     # We only want to trigger once the upload once in the case the upload label is added, not when any label is added
     if: |
@@ -64,20 +68,22 @@ jobs:
       - build-aarch64-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Create artifacts directory
         run: mkdir -p ./artifacts
 
       - name: Fetch x86_64-linux binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-aarch64-linux
       - name: Fetch aarch64-darwin binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-aarch64-darwin
       - name: Move binaries into upload staging dir
@@ -87,7 +93,7 @@ jobs:
           mv nix-installer-aarch64-darwin artifacts/
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_S3_UPLOAD_ROLE }}
           aws-region: us-east-2

--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -5,41 +5,48 @@ on:
     types:
       - published
 
-permissions:
-  contents: write # In order to upload artifacts to GitHub releases
-  id-token: write # In order to request a JWT for AWS auth
-
 jobs:
   build-x86_64-linux:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-x86_64-linux.yml
   build-aarch64-linux:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-aarch64-linux.yml
   build-aarch64-darwin:
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-aarch64-darwin.yml
 
   release:
     environment: production
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     needs:
       - build-x86_64-linux
       - build-aarch64-linux
       - build-aarch64-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Create artifacts directory
         run: mkdir -p ./artifacts
 
       - name: Fetch x86_64-linux binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-x86_64-linux
       - name: Fetch aarch64-linux binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-aarch64-linux
       - name: Fetch aarch64-darwin binary artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nix-installer-aarch64-darwin
       - name: Move binaries into upload staging dir
@@ -49,7 +56,7 @@ jobs:
           mv nix-installer-aarch64-darwin artifacts/
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           role-to-assume: ${{ secrets.AWS_S3_UPLOAD_ROLE }}
           aws-region: us-east-2
@@ -59,13 +66,26 @@ jobs:
         run: |
           ./upload_s3.sh "$GITHUB_REF_NAME" "$GITHUB_SHA" "https://install.determinate.systems/nix/tag/$GITHUB_REF_NAME"
       - name: Publish Release to GitHub (Tag)
-        uses: softprops/action-gh-release@v1
-        with:
-          fail_on_unmatched_files: true
-          draft: true
-          files: |
-            artifacts/**
-            nix-installer.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          shopt -s globstar nullglob
+          files=()
+          for f in artifacts/**; do
+            [ -f "$f" ] && files+=("$f")
+          done
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No files matched 'artifacts/**'"
+            exit 1
+          fi
+          if [ ! -f nix-installer.sh ]; then
+            echo "::error::nix-installer.sh not found"
+            exit 1
+          fi
+          gh release create "${REF_NAME}" --draft \
+            "${files[@]}" nix-installer.sh
+
       - name: Install Instructions (Tag)
         run: |
           cat <<EOF

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -14,8 +14,10 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/determinate-nix-action@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/determinate-nix-action@4eea0b33e3d1f02ecfe37cf16e7204c424009606 # v3.21.0
       - uses: DeterminateSystems/update-flake-lock@main
         with:
           pr-title: "Update Nix flake inputs" # Title of PR to be created

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: zizmor
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          config: .github/zizmor.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        DeterminateSystems/*: ref-pin


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)

##### Validating with `install.determinate.systems`

If a maintainer has added the `upload to s3` label to this PR, it will become available for installation via `install.determinate.systems`:

```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix/pr/$PR_NUMBER | sh -s -- install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Strengthened CI/CD security by pinning GitHub Actions to specific versions and implementing job-level permission scoping
  * Updated dependency management to check for updates weekly with automated grouping of similar changes
  * Integrated new automated security scanning into the build and release workflows
  * Enhanced credential handling practices across deployment pipelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->