### PR TITLE
fix: allow --force to recreate nixbld group with different GID

### DIFF
--- a/src/action/base/create_group.rs
+++ b/src/action/base/create_group.rs
@@ -16,14 +16,16 @@ Create an operating system level user group
 pub struct CreateGroup {
     name: String,
     gid: u32,
+    force: bool,
 }
 
 impl CreateGroup {
     #[tracing::instrument(level = "debug", skip_all)]
-    pub fn plan(name: String, gid: u32) -> Result<StatefulAction<Self>, ActionError> {
+    pub fn plan(name: String, gid: u32, force: bool) -> Result<StatefulAction<Self>, ActionError> {
         let this = Self {
             name: name.clone(),
             gid,
+            force,
         };
 
         match OperatingSystem::host() {
@@ -38,12 +40,23 @@ impl CreateGroup {
             },
         }
 
-        // Ensure group does not exists
+        // Ensure group does not exist
         if let Some(group) = Group::from_name(name.as_str())
             .map_err(|e| ActionErrorKind::GettingGroupId(name.clone(), e))
             .map_err(Self::error)?
         {
             if group.gid.as_raw() != gid {
+                if force {
+                    tracing::warn!(
+                        "Group `{}` exists with GID {}, but GID {} was requested. \
+                         Will delete and recreate the group.",
+                        name,
+                        group.gid.as_raw(),
+                        gid
+                    );
+                    // Return uncompleted so the group gets deleted and recreated during execute
+                    return Ok(StatefulAction::uncompleted(this));
+                }
                 return Err(Self::error(ActionErrorKind::GroupGidMismatch(
                     name.clone(),
                     group.gid.as_raw(),
@@ -68,7 +81,11 @@ impl Action for CreateGroup {
         format!("Create group `{}` (GID {})", self.name, self.gid)
     }
     fn execute_description(&self) -> Vec<ActionDescription> {
-        let Self { name: _, gid: _ } = &self;
+        let Self {
+            name: _,
+            gid: _,
+            force: _,
+        } = &self;
         vec![ActionDescription::new(
             self.tracing_synopsis(),
             vec![format!(
@@ -88,7 +105,61 @@ impl Action for CreateGroup {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(&mut self) -> Result<(), ActionError> {
-        let Self { name, gid } = self;
+        let Self { name, gid, force } = self;
+
+        // If force is set, try to delete existing group first
+        if *force {
+            if Group::from_name(name.as_str())
+                .map_err(|e| ActionErrorKind::GettingGroupId(name.clone(), e))
+                .map_err(Self::error)?
+                .is_some()
+            {
+                tracing::debug!(
+                    "Force mode: deleting existing group `{}` before recreating",
+                    name
+                );
+                use OperatingSystem;
+                match OperatingSystem::host() {
+                    OperatingSystem::MacOSX {
+                        major: _,
+                        minor: _,
+                        patch: _,
+                    }
+                    | OperatingSystem::Darwin => {
+                        execute_command(
+                            Command::new("/usr/bin/dscl")
+                                .args([".", "-delete", &format!("/Groups/{name}")])
+                                .stdin(std::process::Stdio::null()),
+                        )
+                        .await
+                        .map_err(Self::error)?;
+                    },
+                    _ => {
+                        if which::which("groupdel").is_ok() {
+                            execute_command(
+                                Command::new("groupdel")
+                                    .process_group(0)
+                                    .arg(&**name)
+                                    .stdin(std::process::Stdio::null()),
+                            )
+                            .await
+                            .map_err(Self::error)?;
+                        } else if which::which("delgroup").is_ok() {
+                            execute_command(
+                                Command::new("delgroup")
+                                    .process_group(0)
+                                    .arg(&**name)
+                                    .stdin(std::process::Stdio::null()),
+                            )
+                            .await
+                            .map_err(Self::error)?;
+                        } else {
+                            return Err(Self::error(ActionErrorKind::MissingGroupDeletionCommand));
+                        }
+                    },
+                };
+            }
+        }
 
         use OperatingSystem;
         match OperatingSystem::host() {
@@ -144,7 +215,11 @@ impl Action for CreateGroup {
     }
 
     fn revert_description(&self) -> Vec<ActionDescription> {
-        let Self { name, gid } = &self;
+        let Self {
+            name,
+            gid,
+            force: _,
+        } = &self;
         vec![ActionDescription::new(
             format!("Delete group `{name}` (GID {gid})"),
             vec![format!(
@@ -155,7 +230,11 @@ impl Action for CreateGroup {
 
     #[tracing::instrument(level = "debug", skip_all)]
     async fn revert(&mut self) -> Result<(), ActionError> {
-        let Self { name, gid: _ } = self;
+        let Self {
+            name,
+            gid: _,
+            force: _,
+        } = self;
 
         use OperatingSystem;
         match OperatingSystem::host() {

--- a/src/action/common/create_users_and_groups.rs
+++ b/src/action/common/create_users_and_groups.rs
@@ -26,6 +26,7 @@ impl CreateUsersAndGroups {
         let create_group = CreateGroup::plan(
             settings.nix_build_group_name.clone(),
             settings.nix_build_group_id,
+            settings.force,
         )?;
         let mut create_users = Vec::with_capacity(settings.nix_build_user_count as usize);
         let mut add_users_to_groups = Vec::with_capacity(settings.nix_build_user_count as usize);


### PR DESCRIPTION
## Problem

When the `nixbld` group already exists with a different GID than expected (e.g., from an old Nix installation or a different installer), the Determinate Nix Installer fails with:

```
Error:
   0: Planner error
   1: Error executing action
   2: Action `create_group` errored
   3: Group `nixbld` existed but had a different gid (960) than planned (30000)
```

This is a common issue when:
- Nix was previously installed with an older version that used different GIDs (e.g., GID 960 or 3000)
- The system already has a `nixbld` group from a manual installation

This issue affects both Linux (default GID: 30000) and macOS (default GID: 350).

## Solution

This PR adds force mode support to the `CreateGroup` action:

- **With `--force`**: When a GID mismatch is detected, the existing group is deleted and recreated with the correct GID
- **Without `--force`**: Behavior remains unchanged (error on mismatch), maintaining backward compatibility

### Changes

- `src/action/base/create_group.rs`: Added `force` field to `CreateGroup` struct, updated `plan()` to accept force parameter, and modified `execute()` to handle group deletion in force mode
- `src/action/common/create_users_and_groups.rs`: Pass `settings.force` to `CreateGroup::plan()`

## Usage

After this fix, users can resolve the GID mismatch by using the `--force` flag:

```bash
curl --proto "=https" --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --force
```

Or via environment variable:

```bash
NIX_INSTALLER_FORCE=true curl --proto "=https" --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
```

## Related Issues

- Closes #404
- Closes #1382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a force option for group creation.
  * When enabled, existing groups with a different GID can be replaced automatically before recreation.
  * Force behavior is now applied consistently when creating users and groups together.

* **Bug Fixes**
  * Preserved the existing error behavior for GID mismatches when force mode is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->